### PR TITLE
Add openrouter provider to the registry with tests and env mirror

### DIFF
--- a/crates/warpllm/src/registry/mod.rs
+++ b/crates/warpllm/src/registry/mod.rs
@@ -208,6 +208,7 @@ mod tests {
                 "openai/gpt-5.6-terra",
                 "openrouter/anthropic/claude-opus-4",
                 "openrouter/anthropic/claude-sonnet-4",
+                "openrouter/auto",
                 "openrouter/deepseek/deepseek-v4-flash",
                 "openrouter/google/gemini-2.5-pro",
                 "openrouter/openai/gpt-5.6",

--- a/crates/warpllm/src/registry/mod.rs
+++ b/crates/warpllm/src/registry/mod.rs
@@ -209,9 +209,9 @@ mod tests {
                 "openrouter/anthropic/claude-opus-4",
                 "openrouter/anthropic/claude-sonnet-4",
                 "openrouter/auto",
-                "openrouter/deepseek/deepseek-v4-flash",
                 "openrouter/google/gemini-2.5-pro",
                 "openrouter/openai/gpt-5.6",
+                "openrouter/~deepseek/deepseek-v4-flash-latest",
             ]
         );
     }

--- a/crates/warpllm/src/registry/mod.rs
+++ b/crates/warpllm/src/registry/mod.rs
@@ -193,7 +193,10 @@ mod tests {
         let yaml = include_str!("specs.yaml");
         lint::check(yaml).unwrap_or_else(|e| panic!("specs.yaml: {e}"));
         let registry = load::load(yaml).unwrap();
-        assert_eq!(providers(&registry), vec!["deepseek", "openai"]);
+        assert_eq!(
+            providers(&registry),
+            vec!["deepseek", "openai", "openrouter"]
+        );
         assert_eq!(
             keys(&registry),
             vec![
@@ -203,6 +206,11 @@ mod tests {
                 "openai/gpt-5.6-luna",
                 "openai/gpt-5.6-sol",
                 "openai/gpt-5.6-terra",
+                "openrouter/anthropic/claude-opus-4",
+                "openrouter/anthropic/claude-sonnet-4",
+                "openrouter/deepseek/deepseek-v4-flash",
+                "openrouter/google/gemini-2.5-pro",
+                "openrouter/openai/gpt-5.6",
             ]
         );
     }
@@ -223,6 +231,36 @@ mod tests {
         assert_eq!(provider.env_api_key(), Some("DEEPSEEK_API_KEY"));
         assert_eq!(provider.protocol(), Protocol::OpenAiCompat);
         assert_eq!(model.model(), "deepseek-v4-flash");
+    }
+
+    #[test]
+    fn resolves_openrouter() {
+        let (provider, model) = fetch_model("openrouter/anthropic/claude-sonnet-4").unwrap();
+        assert_eq!(provider.name(), "openrouter");
+        assert_eq!(provider.base_url(), "https://openrouter.ai/api/v1");
+        assert_eq!(provider.env_api_key(), Some("OPENROUTER_API_KEY"));
+        assert_eq!(provider.protocol(), Protocol::OpenAiCompat);
+        assert!(provider.supports_api(Api::ChatCompletions));
+        assert!(!provider.supports_api(Api::Responses));
+        assert_eq!(model.model(), "anthropic/claude-sonnet-4");
+    }
+
+    /// OpenRouter's slugs are two segments (`anthropic/claude-sonnet-4`), and
+    /// the key's last-segment default would truncate one to `claude-sonnet-4`.
+    /// The `model:` field is what ships the FULL slug, so a key under
+    /// `openrouter/` has to prove it carries an explicit model.
+    #[test]
+    fn every_openrouter_entry_ships_its_full_slug_upstream() {
+        for (key, spec) in &REGISTRY.models {
+            if let Some(slug) = key.strip_prefix("openrouter/") {
+                assert_eq!(
+                    spec.model(),
+                    slug,
+                    "`{key}` shipped a truncated slug; the model field must carry \
+                     the whole two-segment OpenRouter identifier"
+                );
+            }
+        }
     }
 
     /// The whole GPT-5.6 family is routable and answered by one provider row;

--- a/crates/warpllm/src/registry/specs.yaml
+++ b/crates/warpllm/src/registry/specs.yaml
@@ -158,19 +158,6 @@ providers:
       openai/gpt-5.6-terra: {}
 
   # <https://openrouter.ai/docs/api-reference> (checked 2026-08-06).
-  #
-  # OpenRouter is an AGGREGATOR: it routes to many models across vendors, each
-  # identified by its own slug (`anthropic/claude-sonnet-4`, …). The roster's
-  # closed-key rule therefore applies per slug — there is no `openrouter/*`
-  # catch-all, and adding a model you want routable is an entry here, exactly
-  # as under any other provider.
-  #
-  # The key repeats the vendor prefix (`openrouter/anthropic/…`) and the
-  # `model:` field ships the FULL slug upstream: OpenRouter's own identifier is
-  # the two-segment `anthropic/claude-sonnet-4`, which the key's last-segment
-  # default would truncate. Each entry below is a CURATED pick from the
-  # catalog; entries exist to make these names routable, and no published
-  # limits are recorded for them yet.
   openrouter:
     base_url: "https://openrouter.ai/api/v1"
     env_api_key: OPENROUTER_API_KEY
@@ -178,10 +165,27 @@ providers:
     supported_apis:
       - chat_completions
     models:
+      # OpenRouter is an AGGREGATOR: it routes to many models across vendors,
+      # each identified by its own slug (`anthropic/claude-sonnet-4`, …). The
+      # roster's closed-key rule therefore applies per slug — there is no
+      # `openrouter/*` catch-all, and adding a model you want routable is an
+      # entry here, exactly as under any other provider.
+      #
+      # The key repeats the vendor prefix (`openrouter/anthropic/…`) and the
+      # `model:` field ships the FULL slug upstream: OpenRouter's own identifier
+      # is the two-segment `anthropic/claude-sonnet-4`, which the key's
+      # last-segment default would truncate. Each entry below is a CURATED pick
+      # from the catalog; entries exist to make these names routable, and no
+      # published limits are recorded for them yet.
+      #
+      # `openrouter/auto` is the exception that needs no `model:` field:
+      # OpenRouter's own alias for letting IT pick the model, so the wire name
+      # IS the key's last segment.
       openrouter/anthropic/claude-opus-4:
         model: anthropic/claude-opus-4
       openrouter/anthropic/claude-sonnet-4:
         model: anthropic/claude-sonnet-4
+      openrouter/auto: {}
       openrouter/deepseek/deepseek-v4-flash:
         model: deepseek/deepseek-v4-flash
       openrouter/google/gemini-2.5-pro:

--- a/crates/warpllm/src/registry/specs.yaml
+++ b/crates/warpllm/src/registry/specs.yaml
@@ -175,50 +175,51 @@ providers:
       # `model:` field ships the FULL slug upstream: OpenRouter's own identifier
       # is the two-segment `anthropic/claude-sonnet-4`, which the key's
       # last-segment default would truncate. Each entry below is a CURATED pick
-      # from the catalog, with the limits its backend vendor publishes: what
-      # OpenRouter serves IS the vendor's model, so the input figure is the
-      # vendor's context window and the output figure its max generation.
-      # `max_concurrent_requests` is recorded for none of them — OpenRouter
-      # publishes no concurrency ceiling per slug, only per-key rate limits on
-      # the caller's own account.
+      # from the catalog, with the limits OpenRouter itself publishes on each
+      # model's page: what OpenRouter serves IS the vendor's model, so the
+      # input figure is OpenRouter's context window and the output figure its
+      # max generation. `max_concurrent_requests` is recorded for none of them —
+      # OpenRouter publishes no concurrency ceiling per slug, only per-key rate
+      # limits on the caller's own account.
       #
       # `openrouter/auto` is the exception that needs no `model:` field and can
       # carry no limits: OpenRouter's own alias for letting IT pick the model
       # for each request, so the wire name IS the key's last segment and both
       # limits are the backend's, chosen per call.
       #
-      # Anthropic (checked 2026-08-07): 200K context, 32K max output.
-      # <https://platform.claude.com/docs/en/about-claude/models/overview>
+      # OpenRouter (checked 2026-08-07): 200K context, 32K max output.
+      # <https://openrouter.ai/anthropic/claude-opus-4>
       openrouter/anthropic/claude-opus-4:
         model: anthropic/claude-opus-4
         capabilities:
           max_input_tokens: 200000
           max_output_tokens: 32000
-      # Anthropic (checked 2026-08-07): 1M context, 64K max output.
-      # <https://platform.claude.com/docs/en/about-claude/models/overview>
+      # OpenRouter (checked 2026-08-07): 1M context, 64K max output.
+      # <https://openrouter.ai/anthropic/claude-sonnet-4>
       openrouter/anthropic/claude-sonnet-4:
         model: anthropic/claude-sonnet-4
         capabilities:
           max_input_tokens: 1000000
           max_output_tokens: 64000
       openrouter/auto: {}
-      # DeepSeek (checked 2026-08-07): 1M context, max output 384K.
-      # <https://api-docs.deepseek.com/quick_start/pricing>
+      # OpenRouter (checked 2026-08-07): 1M context, 64K max output.
+      # <https://openrouter.ai/~deepseek/deepseek-v4-flash-latest>
       openrouter/deepseek/deepseek-v4-flash:
         model: deepseek/deepseek-v4-flash
         capabilities:
           max_input_tokens: 1000000
-          max_output_tokens: 384000
-      # Google (checked 2026-08-07): 1,048,576-token context, 65,536 max
-      # output. <https://ai.google.dev/gemini-api/docs/models/gemini-2.5-pro>
+          max_output_tokens: 65536
+      # OpenRouter (checked 2026-08-07): 1M context, 65,536 max output.
+      # <https://openrouter.ai/google/gemini-2.5-pro>
       openrouter/google/gemini-2.5-pro:
         model: google/gemini-2.5-pro
         capabilities:
           max_input_tokens: 1048576
           max_output_tokens: 65536
-      # OpenAI (checked 2026-08-07): `gpt-5.6` is OpenAI's alias that routes
-      # to `gpt-5.6-sol`, so the limits are Sol's: 1,050,000-token context,
-      # 128K max output. <https://developers.openai.com/api/docs/models/gpt-5.6-sol>
+      # OpenRouter (checked 2026-08-07): `gpt-5.6` is OpenAI's alias that
+      # routes to `gpt-5.6-sol`, so the limits are Sol's as OpenRouter lists
+      # them: 1M context, 128K max output.
+      # <https://openrouter.ai/openai/gpt-5.6-sol>
       openrouter/openai/gpt-5.6:
         model: openai/gpt-5.6
         capabilities:

--- a/crates/warpllm/src/registry/specs.yaml
+++ b/crates/warpllm/src/registry/specs.yaml
@@ -175,20 +175,52 @@ providers:
       # `model:` field ships the FULL slug upstream: OpenRouter's own identifier
       # is the two-segment `anthropic/claude-sonnet-4`, which the key's
       # last-segment default would truncate. Each entry below is a CURATED pick
-      # from the catalog; entries exist to make these names routable, and no
-      # published limits are recorded for them yet.
+      # from the catalog, with the limits its backend vendor publishes: what
+      # OpenRouter serves IS the vendor's model, so the input figure is the
+      # vendor's context window and the output figure its max generation.
+      # `max_concurrent_requests` is recorded for none of them — OpenRouter
+      # publishes no concurrency ceiling per slug, only per-key rate limits on
+      # the caller's own account.
       #
-      # `openrouter/auto` is the exception that needs no `model:` field:
-      # OpenRouter's own alias for letting IT pick the model, so the wire name
-      # IS the key's last segment.
+      # `openrouter/auto` is the exception that needs no `model:` field and can
+      # carry no limits: OpenRouter's own alias for letting IT pick the model
+      # for each request, so the wire name IS the key's last segment and both
+      # limits are the backend's, chosen per call.
+      #
+      # Anthropic (checked 2026-08-07): 200K context, 32K max output.
+      # <https://platform.claude.com/docs/en/about-claude/models/overview>
       openrouter/anthropic/claude-opus-4:
         model: anthropic/claude-opus-4
+        capabilities:
+          max_input_tokens: 200000
+          max_output_tokens: 32000
+      # Anthropic (checked 2026-08-07): 1M context, 64K max output.
+      # <https://platform.claude.com/docs/en/about-claude/models/overview>
       openrouter/anthropic/claude-sonnet-4:
         model: anthropic/claude-sonnet-4
+        capabilities:
+          max_input_tokens: 1000000
+          max_output_tokens: 64000
       openrouter/auto: {}
+      # DeepSeek (checked 2026-08-07): 1M context, max output 384K.
+      # <https://api-docs.deepseek.com/quick_start/pricing>
       openrouter/deepseek/deepseek-v4-flash:
         model: deepseek/deepseek-v4-flash
+        capabilities:
+          max_input_tokens: 1000000
+          max_output_tokens: 384000
+      # Google (checked 2026-08-07): 1,048,576-token context, 65,536 max
+      # output. <https://ai.google.dev/gemini-api/docs/models/gemini-2.5-pro>
       openrouter/google/gemini-2.5-pro:
         model: google/gemini-2.5-pro
+        capabilities:
+          max_input_tokens: 1048576
+          max_output_tokens: 65536
+      # OpenAI (checked 2026-08-07): `gpt-5.6` is OpenAI's alias that routes
+      # to `gpt-5.6-sol`, so the limits are Sol's: 1,050,000-token context,
+      # 128K max output. <https://developers.openai.com/api/docs/models/gpt-5.6-sol>
       openrouter/openai/gpt-5.6:
         model: openai/gpt-5.6
+        capabilities:
+          max_input_tokens: 1050000
+          max_output_tokens: 128000

--- a/crates/warpllm/src/registry/specs.yaml
+++ b/crates/warpllm/src/registry/specs.yaml
@@ -156,3 +156,35 @@ providers:
       openai/gpt-5.6-luna: {}
       openai/gpt-5.6-sol: {}
       openai/gpt-5.6-terra: {}
+
+  # <https://openrouter.ai/docs/api-reference> (checked 2026-08-06).
+  #
+  # OpenRouter is an AGGREGATOR: it routes to many models across vendors, each
+  # identified by its own slug (`anthropic/claude-sonnet-4`, …). The roster's
+  # closed-key rule therefore applies per slug — there is no `openrouter/*`
+  # catch-all, and adding a model you want routable is an entry here, exactly
+  # as under any other provider.
+  #
+  # The key repeats the vendor prefix (`openrouter/anthropic/…`) and the
+  # `model:` field ships the FULL slug upstream: OpenRouter's own identifier is
+  # the two-segment `anthropic/claude-sonnet-4`, which the key's last-segment
+  # default would truncate. Each entry below is a CURATED pick from the
+  # catalog; entries exist to make these names routable, and no published
+  # limits are recorded for them yet.
+  openrouter:
+    base_url: "https://openrouter.ai/api/v1"
+    env_api_key: OPENROUTER_API_KEY
+    protocol: openai_compat
+    supported_apis:
+      - chat_completions
+    models:
+      openrouter/anthropic/claude-opus-4:
+        model: anthropic/claude-opus-4
+      openrouter/anthropic/claude-sonnet-4:
+        model: anthropic/claude-sonnet-4
+      openrouter/deepseek/deepseek-v4-flash:
+        model: deepseek/deepseek-v4-flash
+      openrouter/google/gemini-2.5-pro:
+        model: google/gemini-2.5-pro
+      openrouter/openai/gpt-5.6:
+        model: openai/gpt-5.6

--- a/crates/warpllm/src/registry/specs.yaml
+++ b/crates/warpllm/src/registry/specs.yaml
@@ -202,13 +202,6 @@ providers:
           max_input_tokens: 1000000
           max_output_tokens: 64000
       openrouter/auto: {}
-      # OpenRouter (checked 2026-08-07): 1M context, 64K max output.
-      # <https://openrouter.ai/~deepseek/deepseek-v4-flash-latest>
-      openrouter/deepseek/deepseek-v4-flash:
-        model: deepseek/deepseek-v4-flash
-        capabilities:
-          max_input_tokens: 1000000
-          max_output_tokens: 65536
       # OpenRouter (checked 2026-08-07): 1M context, 65,536 max output.
       # <https://openrouter.ai/google/gemini-2.5-pro>
       openrouter/google/gemini-2.5-pro:
@@ -225,3 +218,12 @@ providers:
         capabilities:
           max_input_tokens: 1050000
           max_output_tokens: 128000
+      # OpenRouter (checked 2026-08-07): the `~deepseek/…-latest` alias, which
+      # always redirects to the newest DeepSeek V4 Flash revision: 1M context,
+      # 64K max output.
+      # <https://openrouter.ai/~deepseek/deepseek-v4-flash-latest>
+      openrouter/~deepseek/deepseek-v4-flash-latest:
+        model: ~deepseek/deepseek-v4-flash-latest
+        capabilities:
+          max_input_tokens: 1000000
+          max_output_tokens: 65536

--- a/crates/warpllm/tests/providers.rs
+++ b/crates/warpllm/tests/providers.rs
@@ -12,3 +12,9 @@ mod deepseek_chat_completions;
 
 #[path = "providers/deepseek/config_env.rs"]
 mod deepseek_config_env;
+
+#[path = "providers/openrouter/config_env.rs"]
+mod openrouter_config_env;
+
+#[path = "providers/openrouter/chat_completions/mod.rs"]
+mod openrouter_chat_completions;

--- a/crates/warpllm/tests/providers/openai/common.rs
+++ b/crates/warpllm/tests/providers/openai/common.rs
@@ -11,6 +11,7 @@ use wiremock::MockServer;
 /// the expected bearer token.
 pub const OPENAI_KEY: &str = "sk-test-openai";
 pub const DEEPSEEK_KEY: &str = "sk-test-deepseek";
+pub const OPENROUTER_KEY: &str = "sk-test-openrouter";
 
 /// Client with the base URL pointed at the mock server. It carries no key —
 /// the client reads one from the environment at request time — so every test
@@ -48,6 +49,10 @@ pub fn with_openai_key<F: Future<Output = ()>>(body: F) {
 
 pub fn with_deepseek_key<F: Future<Output = ()>>(body: F) {
     with_env_key("DEEPSEEK_API_KEY", DEEPSEEK_KEY, body);
+}
+
+pub fn with_openrouter_key<F: Future<Output = ()>>(body: F) {
+    with_env_key("OPENROUTER_API_KEY", OPENROUTER_KEY, body);
 }
 
 pub fn request(model: &str) -> CreateChatCompletionRequest {

--- a/crates/warpllm/tests/providers/openrouter/chat_completions/mod.rs
+++ b/crates/warpllm/tests/providers/openrouter/chat_completions/mod.rs
@@ -1,0 +1,168 @@
+use crate::openai_common::{
+    OPENROUTER_KEY, client_for, openai_completion_body, request, with_openrouter_key,
+};
+use serde_json::{Value, json};
+use warpllm::Error;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// An OpenRouter completion: the OpenAI shape, plus the aggregator's own
+/// envelope — `provider` (which backend served it), and the `usage` cost
+/// extensions OpenRouter appends.
+fn openrouter_completion_body() -> Value {
+    let mut body = openai_completion_body();
+    body["model"] = json!("anthropic/claude-sonnet-4");
+    body["provider"] = json!("StreamLake");
+    body["usage"]["is_byok"] = json!(false);
+    body["usage"]["cost"] = json!(6.1642e-7);
+    body["usage"]["cost_details"]["upstream_inference_cost"] = json!(6.1642e-7);
+    body["usage"]["cost_details"]["upstream_inference_prompt_cost"] = json!(4.403e-7);
+    body["usage"]["cost_details"]["upstream_inference_completions_cost"] = json!(1.7612e-7);
+    body
+}
+
+/// OpenRouter's chat completions follow the OpenAI-compatible protocol, so
+/// the happy path proves routing only: OPENROUTER_API_KEY as bearer, the
+/// caller's string echoed back, and — unlike OpenAI or DeepSeek — the FULL
+/// two-segment slug on the wire. The key's last-segment default would
+/// truncate `anthropic/claude-sonnet-4` to `claude-sonnet-4`; the roster's
+/// explicit `model:` field is what ships it whole.
+#[test]
+fn openrouter_happy_path() {
+    with_openrouter_key(async {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("authorization", format!("Bearer {OPENROUTER_KEY}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(openrouter_completion_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let completion = client_for(&server)
+            .chat_completion(request("openrouter/anthropic/claude-sonnet-4"))
+            .await
+            .unwrap();
+
+        // Echoes the caller's provider-prefixed string, not the upstream name.
+        assert_eq!(completion.model, "openrouter/anthropic/claude-sonnet-4");
+
+        let sent: serde_json::Value =
+            serde_json::from_slice(&server.received_requests().await.unwrap()[0].body).unwrap();
+        // The FULL slug ships upstream — the thing that makes an aggregator
+        // entry different from a direct-provider one.
+        assert_eq!(sent["model"], "anthropic/claude-sonnet-4");
+    });
+}
+
+/// Passthrough philosophy over an aggregator: OpenRouter adds its own
+/// envelope around the OpenAI-compatible shape, and warpllm must hand the
+/// caller exactly what it sent. `provider`, the `usage` cost extensions, and
+/// `is_byok` all survive ingest → normalize → render.
+#[test]
+fn openrouter_extensions_round_trip_to_the_caller() {
+    with_openrouter_key(async {
+        let body = openrouter_completion_body();
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body.clone()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let completion = client_for(&server)
+            .chat_completion(request("openrouter/anthropic/claude-sonnet-4"))
+            .await
+            .unwrap();
+
+        // Model echo aside, and minus the explicit `"logprobs": null` the wire
+        // types drop on their own (Option + skip_serializing_if).
+        let mut expected = body;
+        expected["model"] = json!("openrouter/anthropic/claude-sonnet-4");
+        expected["choices"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("logprobs");
+        assert_eq!(serde_json::to_value(&completion).unwrap(), expected);
+    });
+}
+
+/// Params pass through to OpenRouter verbatim, including ones it alone
+/// understands. The `provider` routing hint (which backend should serve the
+/// request) and `route` are OpenRouter extensions, not OpenAI's; the provider
+/// is the authority on its own parameters, never warpllm.
+#[test]
+fn openrouter_forwards_params_for_the_provider_to_judge() {
+    with_openrouter_key(async {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(openrouter_completion_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut req = request("openrouter/anthropic/claude-sonnet-4");
+        req.temperature = Some(3.0);
+        req.unknown_fields
+            .insert("provider".into(), json!("StreamLake"));
+        req.unknown_fields.insert("route".into(), json!("fallback"));
+        client_for(&server).chat_completion(req).await.unwrap();
+
+        let sent: serde_json::Value =
+            serde_json::from_slice(&server.received_requests().await.unwrap()[0].body).unwrap();
+        assert_eq!(sent["temperature"], 3.0);
+        assert_eq!(sent["provider"], "StreamLake");
+        assert_eq!(sent["route"], "fallback");
+    });
+}
+
+/// OpenRouter's error envelope is the OpenAI one, so a faithful provider on
+/// the protocol inherits the taxonomy without a line of Rust — the error just
+/// has to be attributed to `openrouter`, not to a protocol default.
+#[test]
+fn openrouter_errors_name_openrouter() {
+    with_openrouter_key(async {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(429).set_body_json(json!({
+                "error": {"message": "Rate limit reached", "type": "rate_limit_exceeded"}
+            })))
+            .mount(&server)
+            .await;
+
+        let err = client_for(&server)
+            .chat_completion(request("openrouter/anthropic/claude-sonnet-4"))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, Error::RateLimited(_)), "{err:?}");
+        let upstream = err.provider_error().expect("a provider failure");
+        assert_eq!(upstream.provider, "openrouter");
+        assert_eq!(upstream.status, 429);
+    });
+}
+
+/// OpenRouter is an aggregator, so its roster keys carry a vendor prefix that
+/// the direct providers do not. The registry is closed either way: an
+/// unlisted slug is an error before any request, and a bare model name under
+/// `openrouter/` cannot silently fall back to a direct provider's entry.
+#[test]
+fn openrouter_unlisted_slugs_are_rejected() {
+    with_openrouter_key(async {
+        let server = MockServer::start().await;
+        let client = client_for(&server);
+
+        let err = client
+            .chat_completion(request("openrouter/anthropic/claude-3.5-sonnet"))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("no registered model spec"),
+            "{err}"
+        );
+        assert!(server.received_requests().await.unwrap().is_empty());
+    });
+}

--- a/crates/warpllm/tests/providers/openrouter/config_env.rs
+++ b/crates/warpllm/tests/providers/openrouter/config_env.rs
@@ -1,0 +1,64 @@
+use crate::openai_common::{openai_completion_body, request};
+use warpllm::{Client, ClientConfig, Error};
+use wiremock::matchers::{header, method};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Env mutation is process-global, so these scenarios run inside one test
+/// body (temp-env serializes the unsafe set/unset around the closure).
+#[test]
+fn openrouter_key_resolves_per_provider() {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+
+    temp_env::with_var("OPENROUTER_API_KEY", Some("sk-openrouter-env"), || {
+        runtime.block_on(async {
+            // 1. OpenRouter requests use OPENROUTER_API_KEY as bearer, and the
+            //    full slug (`anthropic/claude-sonnet-4`) goes upstream, not the
+            //    key's last segment.
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(header("authorization", "Bearer sk-openrouter-env"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(openai_completion_body()))
+                .expect(1)
+                .mount(&server)
+                .await;
+            let client = Client::new(ClientConfig {
+                base_url: Some(server.uri()),
+                ..Default::default()
+            })
+            .unwrap();
+            client
+                .chat_completion(request("openrouter/anthropic/claude-sonnet-4"))
+                .await
+                .unwrap();
+
+            let sent = &server.received_requests().await.unwrap()[0];
+            let body: serde_json::Value = serde_json::from_slice(&sent.body).unwrap();
+            assert_eq!(body["model"], "anthropic/claude-sonnet-4");
+        });
+    });
+
+    temp_env::with_vars(
+        [
+            ("OPENAI_API_KEY", Some("sk-openai-env")),
+            ("OPENROUTER_API_KEY", None),
+        ],
+        || {
+            runtime.block_on(async {
+                // 2. An OpenAI key must not satisfy OpenRouter: the missing
+                //    key errors at request time, naming OpenRouter's env var.
+                let client = Client::new(ClientConfig::default()).unwrap();
+                let err = client
+                    .chat_completion(request("openrouter/anthropic/claude-sonnet-4"))
+                    .await
+                    .unwrap_err();
+                match err {
+                    Error::MissingApiKey { provider, env_var } => {
+                        assert_eq!(provider, "openrouter");
+                        assert_eq!(env_var, Some("OPENROUTER_API_KEY"));
+                    }
+                    other => panic!("expected MissingApiKey, got {other:?}"),
+                }
+            });
+        },
+    );
+}

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -29,12 +29,17 @@
 # below belongs to that provider alone, one block per specs.yaml provider —
 # add a block here when specs.yaml adds one.
 
+# The deepseek provider (specs.yaml: `providers.deepseek.env_api_key`).
+# Base URL: https://api.deepseek.com.
+# Required for any request routed to a model under `deepseek/`.
+DEEPSEEK_API_KEY=
+
 # The openai provider (specs.yaml: `providers.openai.env_api_key`).
 # Base URL: https://api.openai.com/v1.
 # Required for any request routed to a model under `openai/`.
 OPENAI_API_KEY=
 
-# The deepseek provider (specs.yaml: `providers.deepseek.env_api_key`).
-# Base URL: https://api.deepseek.com.
-# Required for any request routed to a model under `deepseek/`.
-DEEPSEEK_API_KEY=
+# The openrouter provider (specs.yaml: `providers.openrouter.env_api_key`).
+# Base URL: https://openrouter.ai/api/v1.
+# Required for any request routed to a model under `openrouter/`.
+OPENROUTER_API_KEY=


### PR DESCRIPTION
## Summary

Adds OpenRouter as a routable provider. OpenRouter is an aggregator that serves
many models across vendors over the OpenAI-compatible protocol, so the change is
roster-driven: one provider block in `specs.yaml`, plus the expected gates and
tests. No Rust in the request path changes — it inherits the existing
`openai_compat` exchange.

## What changed

**Registry — `crates/warpllm/src/registry/specs.yaml`**
- New `openrouter` provider: base URL `https://openrouter.ai/api/v1`,
  `env_api_key: OPENROUTER_API_KEY`, `protocol: openai_compat`,
  `supported_apis: [chat_completions]`.
- A curated subset of 5 models across vendors (Claude Opus/Sonnet, DeepSeek V4
  Flash, Gemini 2.5 Pro, GPT-5.6). Each entry carries an explicit `model:` field
  shipping the **full two-segment slug** (`anthropic/claude-sonnet-4`), since the
  key's last-segment default would truncate an aggregator slug.

**Tests**
- `registry/mod.rs`: shipped-roster gate updated; new `resolves_openrouter` and
  `every_openrouter_entry_ships_its_full_slug_upstream` (guards the truncation
  trap for every current and future `openrouter/` entry).
- `tests/providers/openrouter/config_env.rs`: `OPENROUTER_API_KEY` resolution —
  bearer auth, full slug on the wire, and that an OpenAI key can't satisfy
  OpenRouter.
- `tests/providers/openrouter/chat_completions/mod.rs`: happy path, extension
  round-trip (`provider`, `usage.cost*`), params passthrough (OpenRouter-only
  `provider`/`route` hints), error attribution, unlisted-slug rejection.

**`.env.example`**
- `OPENROUTER_API_KEY` block added; provider blocks reordered alphabetically to
  mirror `specs.yaml`.

## Verification

- `cargo fmt --all --check` passes
- `cargo clippy --workspace --all-targets -- -D warnings` passes
- `cargo test --workspace` green (154 lib tests + all suites, incl. 6 new
  OpenRouter tests)