### PR TITLE
Release 0.2.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,7 +31,7 @@ body:
     attributes:
       label: Version
       description: Package version, or the commit SHA if you built from source.
-      placeholder: 0.1.4
+      placeholder: 0.2.0
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,91 @@
+# Changelog
+
+Notable changes to warpllm. One version releases all three packages together —
+the crate, the PyPI package, and the npm package share a version number, so a
+release note here applies to all of them unless it says otherwise.
+
+Versions follow [semantic versioning](https://semver.org). While the project is
+pre-1.0, a breaking change bumps the MINOR number: `0.1.x` and `0.2.x` are
+incompatible, and `^0.1` will not upgrade you into one.
+
+## [0.2.0] - 2026-08-08
+
+The first release with a provider registry. 0.1.4 could reach OpenAI; this can
+route to any provider on the roster, and it decides at construction which of
+them the environment can actually authenticate.
+
+This release rewrites most of the public surface. Everything under "Changed"
+and "Removed" is breaking.
+
+### Added
+
+- **Provider registry.** Providers and models live in `specs.yaml`, compiled
+  into the binary. Model strings are `provider/model`. The registry **fails
+  closed**: a name no entry claims is an error, never a guess at an upstream
+  default, so a typo cannot become a live, billed request. There is no
+  wildcard — `openai/*` registers a model literally named `*`.
+- **DeepSeek and OpenRouter providers**, alongside OpenAI. Adding an
+  OpenAI-compatible provider is a YAML edit and no Rust.
+- **Environment-driven provider discovery.** Building a client reads each
+  roster provider's `env_api_key` variable once and keeps the providers it can
+  authenticate. The set is reported through `tracing` — silent unless the host
+  installs a subscriber. A request is admitted only when the roster registers
+  the model *and* the client holds a key for the provider serving it.
+- **Error taxonomy with provenance.** `Error::origin()` separates a warpllm
+  rejection from a provider's, and `Error::code()` is a stable slug for
+  bindings. Provider failures carry `ProviderError` with the upstream status,
+  `retry_after`, and request id.
+- **Errors normalized into OpenAI's vocabulary**, once, in Rust — so a quota
+  exhaustion reads the same whichever provider served it. Python and Node raise
+  exception classes mirroring the official OpenAI SDK.
+- Registry read surface in Rust: `fetch_model`, `ProviderSpec`, `ModelSpec`,
+  `Capabilities`, `Api`, `Protocol`.
+- `JsonClient`, the JSON boundary both native bindings share.
+- Quickstart examples for all three languages in `examples/`.
+
+### Changed
+
+- **`chat_completion` is now `chat_completions`** (`chatCompletion` →
+  `chatCompletions` in Node). This is the rename most callers will hit.
+- **API keys resolve at construction, not per request.** A key exported after a
+  client is built is not picked up, and a rotated key needs a new client. Long
+  running processes that build one client at startup must restart to pick up a
+  rotated key.
+- **Rust wire types moved** from `types::openai::chat::completions::*` to
+  `protocol::openai_compat::chat_completions::types`. The crate root no longer
+  re-exports them with a glob; it names the three types you need to make a call
+  and hold its result: `CreateChatCompletionRequest`,
+  `ChatCompletionRequestMessage`, `CreateChatCompletionResponse`.
+- **Binding types are generated from Rust** rather than hand-written, so the
+  three languages cannot drift. Python's `ChatCompletion` is now
+  `CreateChatCompletionResponse`; Node re-exports the generated names under
+  OpenAI's spellings.
+- Unknown request and response fields pass through in both directions rather
+  than being dropped, so a provider parameter warpllm does not model still
+  reaches it.
+
+### Removed
+
+- **`echo`** from every package. It was a connectivity probe, not API.
+- **`WarpLLMError`, `InvalidRequestError`, `NotImplementedError`** in Python and
+  Node, replaced by the OpenAI-SDK-shaped hierarchy (`APIError`,
+  `BadRequestError`, `AuthenticationError`, `PermissionDeniedError`,
+  `NotFoundError`, `ConflictError`, `UnprocessableEntityError`,
+  `RateLimitError`, `InternalServerError`, `APIConnectionError`).
+- Python's re-exports of response internals (`Choice`, `CompletionUsage`,
+  `Annotation`, and the rest). Reading `completion["choices"][0]` names none of
+  them, so they are no longer part of the public surface.
+
+### Not in this release
+
+Streaming, retries, failover, load balancing, and caching are still
+unimplemented. Supplying API keys through client configuration rather than the
+environment is not supported. The OpenAI-compatible HTTP gateway
+(`warpllm-server`) is in the repository but is not published.
+
+## [0.1.4] and earlier
+
+Early SDK releases serving OpenAI chat completions only, before the provider
+registry existed. See the [release tags](https://github.com/warpllm/warpllm/tags).
+
+[0.2.0]: https://github.com/warpllm/warpllm/compare/v0.1.4...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1854,7 +1854,7 @@ dependencies = [
 
 [[package]]
 name = "warpllm"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "reqwest",
  "schemars",
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "warpllm-codegen"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "schemars",
  "serde_json",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "warpllm-node"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "warpllm-python"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "warpllm-server"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.4"
+version = "0.2.0"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.85"

--- a/README.md
+++ b/README.md
@@ -24,11 +24,14 @@ This project is to lay out the most resilient open source productionization laye
 ## Status
 
 > [!IMPORTANT]
-> The published packages are **0.1.4**, an early SDK that serves OpenAI chat
-> completions only. Several larger pieces — the provider registry and DeepSeek,
-> the normalized request pipeline, and the OpenAI-compatible HTTP gateway —
-> have landed on `main` but are **not released yet**. Usage docs land with the
-> version that ships them.
+> The published packages are **0.2.0**, which adds the provider registry —
+> DeepSeek and OpenRouter alongside OpenAI, reached through `provider/model`
+> routing strings. It is a **breaking** release: `chat_completion` is now
+> `chat_completions`, and most of the public surface moved. See the
+> [changelog](CHANGELOG.md) before upgrading from `0.1.x`.
+>
+> The OpenAI-compatible HTTP gateway has landed on `main` but is **not
+> released yet**. Streaming is not implemented.
 
 Install the published SDK:
 
@@ -38,11 +41,11 @@ pip install warpllm              # python
 npm install @warpllm/warpllm     # node
 ```
 
-| | Released (0.1.4) | On `main` |
+| | Released (0.2.0) | On `main` |
 | --- | --- | --- |
 | OpenAI chat completions, non-streaming | Yes | Yes |
-| `provider/model` routing strings | OpenAI only | Provider registry |
-| DeepSeek | — | Unreleased |
+| `provider/model` routing strings | Provider registry | Provider registry |
+| DeepSeek, OpenRouter | Yes | Yes |
 | OpenAI-compatible HTTP gateway | — | Unreleased |
 | Streaming | — | — |
 | Failover, load balancing, caching, metrics | — | — |

--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-android-arm64')
         const bindingPackageVersion = require('@warpllm/warpllm-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-android-arm-eabi')
         const bindingPackageVersion = require('@warpllm/warpllm-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-win32-x64-gnu')
         const bindingPackageVersion = require('@warpllm/warpllm-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-win32-x64-msvc')
         const bindingPackageVersion = require('@warpllm/warpllm-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-win32-ia32-msvc')
         const bindingPackageVersion = require('@warpllm/warpllm-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-win32-arm64-msvc')
         const bindingPackageVersion = require('@warpllm/warpllm-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@warpllm/warpllm-darwin-universal')
       const bindingPackageVersion = require('@warpllm/warpllm-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-darwin-x64')
         const bindingPackageVersion = require('@warpllm/warpllm-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-darwin-arm64')
         const bindingPackageVersion = require('@warpllm/warpllm-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-freebsd-x64')
         const bindingPackageVersion = require('@warpllm/warpllm-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-freebsd-arm64')
         const bindingPackageVersion = require('@warpllm/warpllm-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-x64-musl')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-x64-gnu')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-arm64-musl')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-arm64-gnu')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-arm-musleabihf')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-loong64-musl')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-loong64-gnu')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-riscv64-musl')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-riscv64-gnu')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-linux-ppc64-gnu')
         const bindingPackageVersion = require('@warpllm/warpllm-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-linux-s390x-gnu')
         const bindingPackageVersion = require('@warpllm/warpllm-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-openharmony-arm64')
         const bindingPackageVersion = require('@warpllm/warpllm-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-openharmony-x64')
         const bindingPackageVersion = require('@warpllm/warpllm-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-openharmony-arm')
         const bindingPackageVersion = require('@warpllm/warpllm-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@warpllm/warpllm",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@warpllm/warpllm",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.7",

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@warpllm/warpllm",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "A warp-speed, robust AI gateway",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Bumps the workspace to **0.2.0** and adds a changelog.

## Why 0.2.0 and not 0.1.5

It's breaking. Pre-1.0 semver puts breaking changes in the MINOR position, and
both cargo and npm resolve `^0.1.4` to `>=0.1.4 <0.2.0` — so 0.2.0 is what
actually prevents an existing caller from upgrading into the renamed method
without noticing.

## Scope

This is not just the last PR. **43 commits have landed since the `v0.1.4` tag**
and none were released, so the changelog covers all of it:

- the provider registry and `provider/model` routing, failing closed
- DeepSeek and OpenRouter
- the flattened error taxonomy and normalization into OpenAI's vocabulary
- generated binding types, replacing hand-written ones
- environment-driven provider discovery, and `chat_completion` →
  `chat_completions`
- `echo` removed from all three packages

The published README still described 0.1.4 as "an early SDK that serves OpenAI
chat completions only" and listed the registry and DeepSeek as unreleased, so
its Status section is corrected too.

## Files

| File | Why |
| --- | --- |
| `CHANGELOG.md` | New. Added / Changed / Removed since v0.1.4. |
| `Cargo.toml` | `[workspace.package] version` → 0.2.0 |
| `bindings/node/package.json` | → 0.2.0. CI asserts it equals the workspace version and the tag. |
| `Cargo.lock`, `package-lock.json`, `bindings/node/index.js` | Regenerated, not hand-edited — all three embed the version. |
| `README.md` | Status block and the released-vs-main table. |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Version placeholder. |

## Verification

Version lockstep matches what `check-version` asserts in all three release
workflows: workspace `0.2.0` == `package.json` `0.2.0`, and the tag will be
`v0.2.0`. No stale `0.1.4` remains outside the changelog's own history section.

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
`cargo test --workspace` (206), `pytest` (18), `npm test` (14) all pass. Both
native extensions were rebuilt; `warpllm.version()` and `warpllm-server
--version` both report 0.2.0.

## After merge

Tagging `v0.2.0` triggers the three release workflows, which publish to
crates.io, PyPI, and npm via trusted publishing. That step is irreversible —
these registries allow yanking but not deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
