### PR TITLE
Move supported_apis onto the model and drop protocol: from the roster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,25 @@ and "Removed" is breaking.
   closed**: a name no entry claims is an error, never a guess at an upstream
   default, so a typo cannot become a live, billed request. There is no
   wildcard — `openai/*` registers a model literally named `*`.
+- **Every model declares the API surfaces it serves**, and inherits nothing
+  from its provider:
+
+  ```yaml
+  openai/gpt-5.6:
+    supported_apis:
+      - {api: openai_compat_chat_completions}
+  ```
+
+  A provider is a host, not a capability — one host commonly serves chat
+  completions, embeddings, and moderation from disjoint sets of models — so
+  there is nothing at that level to route on. A request for a surface the model
+  does not list is refused before the network, rather than discovered as a 404
+  upstream. A surface name carries the protocol it is spoken in, which is what
+  lets a model one day list `anthropic_messages` beside the entry above.
+- **Provider entries are transport only**: `base_url`, `env_api_key`, `models`.
+  There is no `protocol:` field — the surfaces a model lists already say which
+  wire format is in play, so one host may serve models over different
+  protocols.
 - **DeepSeek and OpenRouter providers**, alongside OpenAI. Adding an
   OpenAI-compatible provider is a YAML edit and no Rust.
 - **Environment-driven provider discovery.** Building a client reads each
@@ -39,7 +58,8 @@ and "Removed" is breaking.
   exhaustion reads the same whichever provider served it. Python and Node raise
   exception classes mirroring the official OpenAI SDK.
 - Registry read surface in Rust: `fetch_model`, `ProviderSpec`, `ModelSpec`,
-  `Capabilities`, `Api`, `Protocol`.
+  `Capabilities`, `SupportedApi`, `Api`. Every field is private and there is no
+  public constructor, so a spec is read-only outside the crate.
 - `JsonClient`, the JSON boundary both native bindings share.
 - Quickstart examples for all three languages in `examples/`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,10 +77,10 @@ crates/warpllm/          The SDK. Everything below is a module of this crate.
                          and receives, per wire format (not per provider).
   gateway/               warpllm's own request/response types, and the
                          conversions between them and the wire shapes.
-  types.rs               The vocabulary both layers share: `Protocol` (which
-                         wire format) and `Api` (which surface).
-  client.rs              Routes a request: look up the model, pick the
-                         protocol, send it, convert the response back.
+  types.rs               `Api`: which surface a model serves, named so that it
+                         also says which wire format that surface is spoken in.
+  client.rs              Routes a request: look up the model, check it serves
+                         the surface, send it, convert the response back.
 crates/warpllm-server/   The OpenAI-compatible HTTP gateway (unreleased),
                          an axum server wrapping the SDK.
 bindings/python/         PyO3 + maturin. Rust glue in src/, the importable
@@ -103,13 +103,16 @@ The three ideas worth knowing before you read the code:
   in [`specs.yaml`](crates/warpllm/src/registry/specs.yaml) explains the
   provider/model split and the rules the lint enforces — read it before adding
   either.
-* **`Protocol` has one variant per wire format, not per provider.** Providers
-  that speak the same protocol share it, and a provider that diverges states
-  only its delta, under that protocol's `provider_overrides/` module. A
-  provider that matches its protocol implements nothing and inherits it whole
-  — which is why
-  adding an OpenAI-compatible provider is usually a registry edit and no new
-  Rust. A backend whose wire SHAPE differs is a new protocol, not an override.
+* **A surface names its own protocol, and the model names the surface.** An
+  `Api` is spelled `<protocol>_<endpoint>` — `openai_compat_chat_completions` —
+  so a model's `supported_apis` is the only place the roster records a wire
+  format. A provider entry is transport alone, which is what lets one host
+  serve models over different protocols. Providers on the same protocol share
+  its module, and one that diverges states only its delta under that protocol's
+  `provider_overrides/`; a provider that matches it implements nothing and
+  inherits it whole, which is why adding an OpenAI-compatible provider is
+  usually a registry edit and no new Rust. A backend whose wire SHAPE differs
+  is a new protocol, not an override.
 * **The bindings hold no wire shapes of their own.** The non-published
   `warpllm-codegen` workspace tool emits their generated request, response, and
   error types from Rust. Small handwritten facade files decide which names are

--- a/crates/warpllm/src/client.rs
+++ b/crates/warpllm/src/client.rs
@@ -10,7 +10,7 @@ use crate::protocol::openai_compat::chat_completions::types::{
     CreateChatCompletionRequest, CreateChatCompletionResponse,
 };
 use crate::registry::{ModelSpec, ProviderSpec, fetch_model};
-use crate::types::{Api, Protocol};
+use crate::types::Api;
 
 pub struct Client {
     http: reqwest::Client,
@@ -59,7 +59,7 @@ impl Client {
         let (provider, model) = fetch_model(&requested_model)?;
         Self::validate_api(
             model,
-            Api::OpenAiChatCompletions,
+            Api::OpenAiCompatChatCompletions,
             provider,
             &requested_model,
         )?;
@@ -73,20 +73,18 @@ impl Client {
         // warpllm's routing alias differs from the provider's own name.
         let normalized =
             openai_compat::api::chat_completions::ingest_request(request, model.model());
-        // One arm per protocol, each `&ChatRequest -> ChatResponse`. Adding a
-        // protocol is a line here plus its own `exchange`.
-        let response = match provider.protocol() {
-            Protocol::OpenAiCompat => {
-                openai_compat::api::chat_completions::exchange(
-                    &normalized,
-                    &self.http,
-                    provider.name(),
-                    self.base_url(provider),
-                    api_key,
-                )
-                .await?
-            }
-        };
+        // No dispatch to do: the surface above names its own protocol, so
+        // asking for `openai_compat_chat_completions` IS the choice of module.
+        // A second protocol arrives as a second entrypoint, not as an arm here
+        // — this one takes an OpenAI-shaped request by signature.
+        let response = openai_compat::api::chat_completions::exchange(
+            &normalized,
+            &self.http,
+            provider.name(),
+            self.base_url(provider),
+            api_key,
+        )
+        .await?;
         let mut completion =
             openai_compat::api::chat_completions::render_response(&response, provider.name());
         // Echo the caller's provider-prefixed string, not the upstream echo.
@@ -185,7 +183,6 @@ mod tests {
             name: "demo".into(),
             base_url: base_url.into(),
             env_api_key: env_api_key.map(str::to_string),
-            protocol: Protocol::OpenAiCompat,
         }))
     }
 
@@ -208,9 +205,9 @@ mod tests {
     fn a_model_that_does_not_serve_the_api_is_refused() {
         let err = Client::validate_api(
             demo_model(vec![SupportedApi {
-                api: Api::OpenAiResponses,
+                api: Api::OpenAiCompatResponses,
             }]),
-            Api::OpenAiChatCompletions,
+            Api::OpenAiCompatChatCompletions,
             demo_provider("https://api.demo.test", Some("DEMO_API_KEY")),
             "demo/embed",
         )
@@ -220,7 +217,7 @@ mod tests {
         // The roster's spelling, not the variant's — this is the string a
         // reader greps `specs.yaml` for.
         assert!(
-            message.contains("does not serve openai_chat_completions"),
+            message.contains("does not serve openai_compat_chat_completions"),
             "{message}"
         );
 
@@ -238,13 +235,13 @@ mod tests {
         Client::validate_api(
             demo_model(vec![
                 SupportedApi {
-                    api: Api::OpenAiChatCompletions,
+                    api: Api::OpenAiCompatChatCompletions,
                 },
                 SupportedApi {
-                    api: Api::OpenAiResponses,
+                    api: Api::OpenAiCompatResponses,
                 },
             ]),
-            Api::OpenAiChatCompletions,
+            Api::OpenAiCompatChatCompletions,
             demo_provider("https://api.demo.test", Some("DEMO_API_KEY")),
             "demo/chat",
         )
@@ -257,12 +254,15 @@ mod tests {
     #[test]
     fn the_answer_depends_on_which_api_is_asked_about() {
         let model = demo_model(vec![SupportedApi {
-            api: Api::OpenAiResponses,
+            api: Api::OpenAiCompatResponses,
         }]);
         let provider = demo_provider("https://api.demo.test", Some("DEMO_API_KEY"));
 
-        Client::validate_api(model, Api::OpenAiResponses, provider, "demo/x").unwrap();
-        for refused in [Api::OpenAiChatCompletions, Api::OpenAiChatCompletionsStream] {
+        Client::validate_api(model, Api::OpenAiCompatResponses, provider, "demo/x").unwrap();
+        for refused in [
+            Api::OpenAiCompatChatCompletions,
+            Api::OpenAiCompatChatCompletionsStream,
+        ] {
             let message = Client::validate_api(model, refused, provider, "demo/x")
                 .unwrap_err()
                 .to_string();
@@ -282,16 +282,16 @@ mod tests {
     fn chat_completions_does_not_imply_its_streaming_surface() {
         let err = Client::validate_api(
             demo_model(vec![SupportedApi {
-                api: Api::OpenAiChatCompletions,
+                api: Api::OpenAiCompatChatCompletions,
             }]),
-            Api::OpenAiChatCompletionsStream,
+            Api::OpenAiCompatChatCompletionsStream,
             demo_provider("https://api.demo.test", Some("DEMO_API_KEY")),
             "demo/chat",
         )
         .unwrap_err()
         .to_string();
         assert!(
-            err.contains("does not serve openai_chat_completions_stream"),
+            err.contains("does not serve openai_compat_chat_completions_stream"),
             "{err}"
         );
     }
@@ -362,7 +362,7 @@ mod tests {
             provider: "demo".into(),
             model: "demo-chat-20240101".into(),
             supported_apis: vec![SupportedApi {
-                api: Api::OpenAiChatCompletions,
+                api: Api::OpenAiCompatChatCompletions,
             }],
             capabilities: Capabilities::blank(),
         }));

--- a/crates/warpllm/src/client.rs
+++ b/crates/warpllm/src/client.rs
@@ -9,7 +9,7 @@ use crate::gateway::openai_compat;
 use crate::protocol::openai_compat::chat_completions::types::{
     CreateChatCompletionRequest, CreateChatCompletionResponse,
 };
-use crate::registry::{ProviderSpec, fetch_model};
+use crate::registry::{ModelSpec, ProviderSpec, fetch_model};
 use crate::types::{Api, Protocol};
 
 pub struct Client {
@@ -57,13 +57,12 @@ impl Client {
         let requested_model = request.model.clone();
         // Half one: the roster. Closed, so an unregistered name stops here.
         let (provider, model) = fetch_model(&requested_model)?;
-        if !provider.supports_api(Api::ChatCompletions) {
-            return Err(Error::InvalidInput(format!(
-                "{}: {} does not serve chat_completions",
-                provider.name(),
-                requested_model
-            )));
-        }
+        Self::validate_api(
+            model,
+            Api::OpenAiChatCompletions,
+            provider,
+            &requested_model,
+        )?;
         // Half two: this client. A registered model whose provider was not
         // authenticated at construction never reaches the network.
         let api_key = self.api_key(provider)?;
@@ -111,6 +110,42 @@ impl Client {
             })
     }
 
+    /// Whether the routed MODEL serves `api`, which is what every entrypoint
+    /// has to establish before it sends anything.
+    ///
+    /// Asking the model is the whole point, and the only place the answer
+    /// exists: a provider is a host, and one host commonly serves chat
+    /// completions, embeddings, and moderation from three disjoint sets of
+    /// models. There is nothing at the provider level to ask.
+    ///
+    /// Takes the surface rather than naming one, so the second entrypoint
+    /// reuses this rather than copying it — and so the refusal cannot claim
+    /// the wrong surface, which a hard-coded message eventually would.
+    ///
+    /// `model` and `api` are the check; `provider` and `requested` only build
+    /// the message. Split out from [`Client::chat_completions`] so the refusal
+    /// can be tested at all: every model the roster ships today serves chat
+    /// completions, so the failing branch is otherwise unreachable from the
+    /// public entrypoint until one lands that does not.
+    fn validate_api(
+        model: &'static ModelSpec,
+        api: Api,
+        provider: &'static ProviderSpec,
+        requested: &str,
+    ) -> Result<()> {
+        if model.supports_api(api) {
+            return Ok(());
+        }
+        // The roster's own spelling for the surface, and the provider because
+        // the roster is where what-is-served is recorded — between them they
+        // name the line a reader would go and fix.
+        Err(Error::InvalidInput(format!(
+            "{}: {requested} does not serve {}",
+            provider.name(),
+            api.as_str()
+        )))
+    }
+
     /// A configured `base_url` overrides the provider default (proxies,
     /// tests); otherwise each provider talks to its own API.
     fn base_url(&self, provider: &'static ProviderSpec) -> &str {
@@ -126,7 +161,7 @@ mod tests {
     use super::*;
     use crate::credentials::with_env;
     use crate::protocol::openai_compat::chat_completions::types::ChatCompletionRequestMessage;
-    use crate::registry::{Capabilities, ModelSpec};
+    use crate::registry::{Capabilities, ModelSpec, SupportedApi};
 
     /// A client built under the environment lock.
     ///
@@ -151,8 +186,114 @@ mod tests {
             base_url: base_url.into(),
             env_api_key: env_api_key.map(str::to_string),
             protocol: Protocol::OpenAiCompat,
-            supported_apis: vec![Api::ChatCompletions],
         }))
+    }
+
+    /// Leaked for the same reason as [`demo_provider`]. Takes its surfaces so
+    /// a caller can express the case the roster cannot yet: a model under a
+    /// chat-serving host that does not itself serve chat.
+    fn demo_model(supported_apis: Vec<SupportedApi>) -> &'static ModelSpec {
+        Box::leak(Box::new(ModelSpec {
+            provider: "demo".into(),
+            model: "demo-embed".into(),
+            supported_apis,
+            capabilities: Capabilities::blank(),
+        }))
+    }
+
+    /// The gate the whole model-level `supported_apis` split exists for. This
+    /// model sits under a perfectly ordinary chat-serving provider and does
+    /// not serve chat itself, which only the model's own list can say.
+    #[test]
+    fn a_model_that_does_not_serve_the_api_is_refused() {
+        let err = Client::validate_api(
+            demo_model(vec![SupportedApi {
+                api: Api::OpenAiResponses,
+            }]),
+            Api::OpenAiChatCompletions,
+            demo_provider("https://api.demo.test", Some("DEMO_API_KEY")),
+            "demo/embed",
+        )
+        .unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("demo/embed"), "{message}");
+        // The roster's spelling, not the variant's — this is the string a
+        // reader greps `specs.yaml` for.
+        assert!(
+            message.contains("does not serve openai_chat_completions"),
+            "{message}"
+        );
+
+        // A 400: the caller asked for something this model cannot do, which is
+        // theirs to fix, not the provider's to fail.
+        let wire: serde_json::Value = serde_json::from_str(&err.to_openai_json()).unwrap();
+        assert_eq!(wire["status"], 400);
+    }
+
+    /// The other side of the same gate: a model that does serve the surface
+    /// passes, so the check cannot be one that refuses everything. Listing a
+    /// second surface alongside it changes nothing — each is its own claim.
+    #[test]
+    fn a_model_that_serves_the_api_is_admitted() {
+        Client::validate_api(
+            demo_model(vec![
+                SupportedApi {
+                    api: Api::OpenAiChatCompletions,
+                },
+                SupportedApi {
+                    api: Api::OpenAiResponses,
+                },
+            ]),
+            Api::OpenAiChatCompletions,
+            demo_provider("https://api.demo.test", Some("DEMO_API_KEY")),
+            "demo/chat",
+        )
+        .unwrap();
+    }
+
+    /// The point of passing the surface in: one model, and the answer depends
+    /// on which surface is asked about. A check that ignored its argument
+    /// would pass both of the tests above and fail here.
+    #[test]
+    fn the_answer_depends_on_which_api_is_asked_about() {
+        let model = demo_model(vec![SupportedApi {
+            api: Api::OpenAiResponses,
+        }]);
+        let provider = demo_provider("https://api.demo.test", Some("DEMO_API_KEY"));
+
+        Client::validate_api(model, Api::OpenAiResponses, provider, "demo/x").unwrap();
+        for refused in [Api::OpenAiChatCompletions, Api::OpenAiChatCompletionsStream] {
+            let message = Client::validate_api(model, refused, provider, "demo/x")
+                .unwrap_err()
+                .to_string();
+            // Each refusal names the surface it was asked about, so a caller
+            // is never told the wrong thing is missing.
+            assert!(
+                message.contains(refused.as_str()),
+                "asked about `{}`: {message}",
+                refused.as_str()
+            );
+        }
+    }
+
+    /// Streaming is its own surface, so serving chat completions says nothing
+    /// about it. The roster documents that; this is where it holds.
+    #[test]
+    fn chat_completions_does_not_imply_its_streaming_surface() {
+        let err = Client::validate_api(
+            demo_model(vec![SupportedApi {
+                api: Api::OpenAiChatCompletions,
+            }]),
+            Api::OpenAiChatCompletionsStream,
+            demo_provider("https://api.demo.test", Some("DEMO_API_KEY")),
+            "demo/chat",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("does not serve openai_chat_completions_stream"),
+            "{err}"
+        );
     }
 
     /// A provider that names no environment variable has no key source at all,
@@ -220,6 +361,9 @@ mod tests {
         let aliased = Box::leak(Box::new(ModelSpec {
             provider: "demo".into(),
             model: "demo-chat-20240101".into(),
+            supported_apis: vec![SupportedApi {
+                api: Api::OpenAiChatCompletions,
+            }],
             capabilities: Capabilities::blank(),
         }));
         let client = client(ClientConfig::default());

--- a/crates/warpllm/src/gateway/openai_compat/api/chat_completions/response.rs
+++ b/crates/warpllm/src/gateway/openai_compat/api/chat_completions/response.rs
@@ -153,8 +153,8 @@ fn ingest_message(message: ChatCompletionResponseMessage) -> types::Message {
 /// the provider said; the block is what it means.
 ///
 /// `provenance` records the protocol rather than a hand-written identifier:
-/// [`Protocol::as_str`] is one drift-tested string, so it cannot disagree with
-/// the namespace the same field is filed under.
+/// [`Protocol::as_str`] is the same one string the namespace is keyed by, so
+/// the two cannot disagree about where this field came from.
 fn reasoning_block(fields: &UnknownFields) -> Option<ContentBlock> {
     let text = fields
         .get("reasoning_content")?

--- a/crates/warpllm/src/gateway/types/mod.rs
+++ b/crates/warpllm/src/gateway/types/mod.rs
@@ -70,9 +70,10 @@ impl RawJson {
 #[allow(dead_code)] // staged: read once the passthrough fast path lands
 pub(crate) struct IngestSource {
     /// The wire format this was ingested from. [`Protocol`] rather than an
-    /// enum of its own: the name that keys the `ext` bags, the name the
-    /// registry YAML uses, and the name of the format are one string, so they
-    /// are one type.
+    /// enum of its own: the name that keys the `ext` bags and the name of the
+    /// format are one string, so they are one type. The roster no longer
+    /// records a protocol at all — a surface names its own — so this is a tag
+    /// the ingesting module states about itself.
     pub protocol: Protocol,
     /// The inbound body as ingested — re-serialized from the typed wire
     /// form, NOT the original bytes: unknown-field order survives

--- a/crates/warpllm/src/lib.rs
+++ b/crates/warpllm/src/lib.rs
@@ -51,7 +51,7 @@ pub use protocol::openai_compat::error::{ErrorBody, ErrorClass, OpenAiError};
 ///
 /// Read-only by construction: every field is private and there is no public
 /// constructor, so [`fetch_model`] is the way to obtain either half.
-pub use registry::{Capabilities, ModelSpec, ProviderSpec, fetch_model};
+pub use registry::{Capabilities, ModelSpec, ProviderSpec, SupportedApi, fetch_model};
 pub use types::{Api, Protocol};
 
 /// Returns the warpllm version.

--- a/crates/warpllm/src/lib.rs
+++ b/crates/warpllm/src/lib.rs
@@ -52,7 +52,7 @@ pub use protocol::openai_compat::error::{ErrorBody, ErrorClass, OpenAiError};
 /// Read-only by construction: every field is private and there is no public
 /// constructor, so [`fetch_model`] is the way to obtain either half.
 pub use registry::{Capabilities, ModelSpec, ProviderSpec, SupportedApi, fetch_model};
-pub use types::{Api, Protocol};
+pub use types::Api;
 
 /// Returns the warpllm version.
 ///

--- a/crates/warpllm/src/protocol/mod.rs
+++ b/crates/warpllm/src/protocol/mod.rs
@@ -8,16 +8,16 @@
 //! about the wire. That makes this module a leaf: it depends on nothing but
 //! `error` and `http`, and `gateway` depends on it.
 //!
-//! The module path is [`crate::types::Api`]'s snake_case name, not the HTTP
-//! path: `Api::ChatCompletions` deserializes from `"chat_completions"` and is
-//! implemented at `openai_compat::chat_completions`. The URL an API is reached
-//! at is a transport detail and lives in that module's `transport.rs` — two
-//! protocols may serve the same API at different paths.
+//! The module path spells out [`crate::types::Api`]'s own name, not the HTTP
+//! path: `Api::OpenAiCompatChatCompletions` deserializes from
+//! `"openai_compat_chat_completions"` and is implemented at
+//! `openai_compat::chat_completions`, protocol segment and all. The URL an API
+//! is reached at is a transport detail and lives in that module's
+//! `transport.rs` — two protocols may serve the same API at different paths.
 //!
-//! The names themselves — [`crate::types::Protocol`] and `Api` — are declared
-//! in `crate::types`, above this module and `crate::gateway` both, since both
-//! layers speak them and neither owns them. What lives here are the protocols
-//! those names refer to.
+//! [`crate::types::Api`] itself is declared in `crate::types`, above this
+//! module and `crate::gateway` both, since both layers speak it and neither
+//! owns it. What lives here are the protocols its names refer to.
 //!
 //! Provider-specific logic does NOT live here either: per-model specs are
 //! contributed by `crate::registry`, and per-provider conversion deltas belong

--- a/crates/warpllm/src/protocol/openai_compat/mod.rs
+++ b/crates/warpllm/src/protocol/openai_compat/mod.rs
@@ -1,6 +1,8 @@
-//! The OpenAI-compatible protocol: every provider whose spec selects
-//! `Protocol::OpenAiCompat` is spoken through here, parameterized by the
-//! provider's name, base URL, and key.
+//! The OpenAI-compatible protocol: every model whose roster entry lists an
+//! `openai_compat_*` surface is served through here, parameterized by its
+//! provider's name, base URL, and key. A surface names the protocol it is
+//! spoken in, so listing one is what selects this module — a provider entry
+//! chooses nothing.
 //!
 //! `openai_compat` is warpllm's OpenAI-*compatible* protocol: a permissive
 //! superset (unknown-field passthrough) of the OpenAI request, which many

--- a/crates/warpllm/src/registry/lint.rs
+++ b/crates/warpllm/src/registry/lint.rs
@@ -10,7 +10,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use super::load::load;
-use super::types::{ProviderSpec, Registry};
+use super::types::{ModelSpec, ProviderSpec, Registry};
 
 /// Every policy below, first failure reported.
 pub(super) fn check(yaml: &str) -> Result<(), String> {
@@ -38,6 +38,11 @@ pub(super) fn check(yaml: &str) -> Result<(), String> {
                  last segment"
             ));
         }
+        let provider = registry
+            .providers
+            .get(&spec.provider)
+            .expect("load registers a provider for every model it holds");
+        serves(spec, provider).map_err(|e| format!("`{key}`: {e}"))?;
     }
     env_api_keys(&registry)
 }
@@ -162,17 +167,43 @@ fn routable(provider: &ProviderSpec) -> Result<(), String> {
                 .into(),
         );
     }
-    if provider.supported_apis().is_empty() {
-        return Err("supported_apis names no API, so nothing could ever route here".into());
+    Ok(())
+}
+
+/// A model's `supported_apis`: non-empty, without repeats, and every surface
+/// one its provider can actually speak.
+///
+/// The list is the model's alone — nothing is inherited — so all three of
+/// these are things only the roster's own text can get wrong.
+///
+/// The protocol check is what keeps a surface from naming a wire format its
+/// host does not speak. Each variant carries its protocol in its name, so
+/// `openai_responses` under a provider speaking something else is a roster
+/// mistake that would otherwise be found by sending the request.
+fn serves(spec: &ModelSpec, provider: &ProviderSpec) -> Result<(), String> {
+    if spec.supported_apis().is_empty() {
+        return Err(
+            "supported_apis is empty, so nothing could ever route to this model; \
+             name a surface it serves, or delete the entry"
+                .into(),
+        );
     }
-    // A provider can serve fewer APIs than its protocol defines, never one the
-    // protocol has never heard of. Naming an API that does not exist at all is
-    // caught earlier still, by `Api`'s own deserialization.
-    for api in provider.supported_apis() {
-        if !provider.protocol().apis().contains(api) {
+    // On the surface, not the whole entry: two entries naming one surface are
+    // one mistake whether or not everything else about them matches, and only
+    // the first would ever be found by `supported_api`.
+    let mut seen = HashSet::new();
+    for entry in spec.supported_apis() {
+        let api = entry.api();
+        if !seen.insert(api) {
+            return Err(format!("`{api:?}` is listed twice"));
+        }
+        if api.protocol() != provider.protocol() {
             return Err(format!(
-                "`{api:?}` is not an API of this protocol, which defines {:?}",
-                provider.protocol().apis()
+                "`{api:?}` is spoken in {:?}, but provider `{}` speaks {:?}; a \
+                 surface names its own protocol, and the two have to agree",
+                api.protocol(),
+                provider.name(),
+                provider.protocol()
             ));
         }
     }
@@ -206,14 +237,14 @@ fn env_api_keys(registry: &Registry) -> Result<(), String> {
 /// not.
 #[cfg(test)]
 mod tests {
-    use super::super::testing::{OTHER_PROVIDER, PROVIDER, clean, with};
+    use super::super::testing::{CHAT, OTHER_PROVIDER, PROVIDER, clean, model, models, with};
     use super::*;
 
     /// One provider's roster, plus a second one that shares its variable.
     fn two_providers(env_api_key: &str) -> String {
         format!(
             "{}{}",
-            with("      demo/plain: {}\n"),
+            with(&model("demo/plain")),
             OTHER_PROVIDER.replace("OTHER_API_KEY", env_api_key)
         )
     }
@@ -255,7 +286,7 @@ mod tests {
     /// would send a request-time lookup of `""`.
     #[test]
     fn an_empty_env_api_key_points_at_omitting_it() {
-        let yaml = with("      demo/plain: {}\n").replace("DEMO_API_KEY", "\"\"");
+        let yaml = with(&model("demo/plain")).replace("DEMO_API_KEY", "\"\"");
         let err = check(&yaml).unwrap_err();
         assert!(err.contains("env_api_key is empty"), "{err}");
         assert!(err.contains("omit the field entirely"), "{err}");
@@ -270,11 +301,18 @@ mod tests {
     /// contributor fix the line without opening `protocol/types.rs`.
     #[test]
     fn an_api_outside_the_vocabulary_fails_to_load() {
-        let yaml =
-            with("      demo/plain: {}\n").replace("- chat_completions", "- chat_completion");
+        let yaml = with(&model("demo/plain"))
+            .replace("api: openai_chat_completions", "api: anthropic_messages");
         let err = load(&yaml).unwrap_err();
-        assert!(err.contains("unknown variant `chat_completion`"), "{err}");
-        for known in ["chat_completions", "chat_completions_stream", "responses"] {
+        assert!(
+            err.contains("unknown variant `anthropic_messages`"),
+            "{err}"
+        );
+        for known in [
+            "openai_chat_completions",
+            "openai_chat_completions_stream",
+            "openai_responses",
+        ] {
             assert!(err.contains(known), "vocabulary missing {known}: {err}");
         }
         // `check` loads first, so it reports the same thing rather than some
@@ -290,15 +328,15 @@ mod tests {
     /// which is exactly why it must not stop the tables being built.
     #[test]
     fn out_of_order_models_are_rejected() {
-        let yaml = with("      demo/zeta: {}\n      demo/alpha: {}\n");
+        let yaml = with(&models(&["demo/zeta", "demo/alpha"]));
         assert!(load(&yaml).is_ok(), "key order cannot break loading");
         let err = check(&yaml).unwrap_err();
         // Names the map, the key to move, where to move it, and the ordering
         // it is judged against, so nobody has to work out what "unsorted"
         // meant.
         assert!(err.contains("`demo`'s models"), "{err}");
-        assert!(err.contains("`demo/alpha` (line 11)"), "{err}");
-        assert!(err.contains("move it above `demo/zeta` (line 10)"), "{err}");
+        assert!(err.contains("`demo/alpha` (line 10)"), "{err}");
+        assert!(err.contains("move it above `demo/zeta` (line 7)"), "{err}");
         assert!(err.contains("ascending BYTE order"), "{err}");
     }
 
@@ -310,8 +348,9 @@ mod tests {
     fn out_of_order_models_are_rejected_under_any_provider() {
         // `demo` above is in order; the misplaced key is in the LAST provider.
         let yaml = format!(
-            "{}{OTHER_PROVIDER}      other/alpha: {{}}\n",
-            with("      demo/plain: {}\n")
+            "{}{OTHER_PROVIDER}{}",
+            with(&model("demo/plain")),
+            model("other/alpha")
         );
         assert!(load(&yaml).is_ok(), "key order cannot break loading");
         let err = check(&yaml).unwrap_err();
@@ -323,7 +362,7 @@ mod tests {
     /// talking about.
     #[test]
     fn out_of_order_providers_are_rejected() {
-        let demo = with("      demo/plain: {}\n");
+        let demo = with(&model("demo/plain"));
         let demo = demo
             .strip_prefix("providers:\n")
             .expect("the fixture's first line");
@@ -339,9 +378,9 @@ mod tests {
     /// search gets wrong.
     #[test]
     fn the_order_error_points_at_the_right_line() {
-        let err = check(&with("      demo/model-x: {}\n      demo/model: {}\n")).unwrap_err();
-        assert!(err.contains("`demo/model` (line 11)"), "{err}");
-        assert!(err.contains("above `demo/model-x` (line 10)"), "{err}");
+        let err = check(&with(&models(&["demo/model-x", "demo/model"]))).unwrap_err();
+        assert!(err.contains("`demo/model` (line 10)"), "{err}");
+        assert!(err.contains("above `demo/model-x` (line 7)"), "{err}");
     }
 
     /// Both ways of writing "no models yet" load fine and are caught here,
@@ -356,34 +395,81 @@ mod tests {
     }
 
     /// Each of these loads into a spec that is well-formed and then cannot
-    /// serve a request: no credential, a URL that would double its slash, or
-    /// no surface at all.
+    /// serve a request: a URL that would double its slash, or a roster with
+    /// nothing in it at all.
     #[test]
     fn unroutable_providers_are_rejected() {
-        let models = "      demo/plain: {}\n";
-
-        let trailing = with(models).replace("api.demo.test/v1", "api.demo.test/v1/");
+        let trailing = with(&model("demo/plain")).replace("api.demo.test/v1", "api.demo.test/v1/");
         let err = check(&trailing).unwrap_err();
         assert!(err.contains("doubled slash"), "{err}");
 
-        // An EMPTY list is a lint failure; omitting the field entirely fails
-        // to load, since nothing else could answer it.
-        let empty = with(models).replace(
-            "    supported_apis:\n      - chat_completions\n      - responses\n",
-            "    supported_apis: []\n",
-        );
-        let err = check(&empty).unwrap_err();
-        assert!(err.contains("names no API"), "{err}");
-
         let err = check("providers: {}\n").unwrap_err();
         assert!(err.contains("names no providers"), "{err}");
+    }
+
+    /// A surface names its protocol, and a model cannot name one its host does
+    /// not speak. Unreachable while `openai_compat` is the only protocol —
+    /// every surface belongs to it — so this asserts the rule directly on
+    /// [`serves`] rather than through a roster that cannot express the
+    /// mistake yet.
+    ///
+    /// Written now rather than retrofitted the day a second protocol lands,
+    /// which is the day it starts being able to fail.
+    #[test]
+    fn a_model_naming_a_surface_its_provider_cannot_speak_is_rejected() {
+        let registry = clean(&with(&model("demo/plain")));
+        let provider = registry.providers.get("demo").unwrap();
+        let spec = registry.models.get("demo/plain").unwrap();
+        // The real pair agrees, which is the case that has to keep passing.
+        serves(spec, provider).unwrap();
+        assert_eq!(
+            spec.supported_apis()[0].api().protocol(),
+            provider.protocol(),
+            "the check has nothing to catch unless these can differ"
+        );
+    }
+
+    /// The same surface twice is one mistake, however its settings are
+    /// written. Caught on the surface's identity, not on the payload, which
+    /// today is `{}` in both copies and would compare equal either way.
+    #[test]
+    fn a_repeated_surface_is_rejected() {
+        let yaml = with(concat!(
+            "      demo/plain:\n",
+            "        supported_apis:\n",
+            "          - {api: openai_chat_completions}\n",
+            "          - {api: openai_chat_completions}\n",
+        ));
+        assert!(
+            load(&yaml).is_ok(),
+            "the roster is what is wrong, not the tables"
+        );
+        let err = check(&yaml).unwrap_err();
+        assert!(err.contains("`demo/plain`"), "{err}");
+        assert!(err.contains("listed twice"), "{err}");
+    }
+
+    /// An empty list is a model nothing can route to. It loads — the tables
+    /// are fine — and the message says what to do, since an entry that serves
+    /// nothing is either missing a line or should not be there at all.
+    #[test]
+    fn a_model_serving_no_surface_is_rejected() {
+        let yaml = with("      demo/plain:\n        supported_apis: []\n");
+        assert!(load(&yaml).is_ok(), "the roster is what is wrong");
+        let err = check(&yaml).unwrap_err();
+        assert!(err.contains("`demo/plain`"), "{err}");
+        assert!(err.contains("supported_apis is empty"), "{err}");
+        assert!(err.contains("delete the entry"), "{err}");
     }
 
     /// An empty `model` would ship `"model": ""` upstream, which no provider
     /// serves. Omitting the field is how an entry says "use my key's name".
     #[test]
     fn an_empty_model_points_at_omitting_it() {
-        let err = check(&with("      demo/plain:\n        model: \"\"\n")).unwrap_err();
+        let err = check(&with(&format!(
+            "      demo/plain:\n{CHAT}        model: \"\"\n"
+        )))
+        .unwrap_err();
         assert!(err.contains("model is empty"), "{err}");
         assert!(err.contains("omit the field"), "{err}");
     }

--- a/crates/warpllm/src/registry/lint.rs
+++ b/crates/warpllm/src/registry/lint.rs
@@ -38,11 +38,7 @@ pub(super) fn check(yaml: &str) -> Result<(), String> {
                  last segment"
             ));
         }
-        let provider = registry
-            .providers
-            .get(&spec.provider)
-            .expect("load registers a provider for every model it holds");
-        serves(spec, provider).map_err(|e| format!("`{key}`: {e}"))?;
+        serves(spec).map_err(|e| format!("`{key}`: {e}"))?;
     }
     env_api_keys(&registry)
 }
@@ -170,17 +166,17 @@ fn routable(provider: &ProviderSpec) -> Result<(), String> {
     Ok(())
 }
 
-/// A model's `supported_apis`: non-empty, without repeats, and every surface
-/// one its provider can actually speak.
+/// A model's `supported_apis`: non-empty, and without repeats.
 ///
-/// The list is the model's alone — nothing is inherited — so all three of
-/// these are things only the roster's own text can get wrong.
+/// The list is the model's alone — nothing is inherited — so both of these are
+/// things only the roster's own text can get wrong.
 ///
-/// The protocol check is what keeps a surface from naming a wire format its
-/// host does not speak. Each variant carries its protocol in its name, so
-/// `openai_responses` under a provider speaking something else is a roster
-/// mistake that would otherwise be found by sending the request.
-fn serves(spec: &ModelSpec, provider: &ProviderSpec) -> Result<(), String> {
+/// There is deliberately no cross-check against the provider. A surface names
+/// the wire format it is spoken in, and the provider records none, so there is
+/// nothing left for the two to disagree about — which is the point: one host
+/// may serve one model over one protocol and its neighbour over another, and
+/// no roster rule has to be taught the exception.
+fn serves(spec: &ModelSpec) -> Result<(), String> {
     if spec.supported_apis().is_empty() {
         return Err(
             "supported_apis is empty, so nothing could ever route to this model; \
@@ -196,15 +192,6 @@ fn serves(spec: &ModelSpec, provider: &ProviderSpec) -> Result<(), String> {
         let api = entry.api();
         if !seen.insert(api) {
             return Err(format!("`{api:?}` is listed twice"));
-        }
-        if api.protocol() != provider.protocol() {
-            return Err(format!(
-                "`{api:?}` is spoken in {:?}, but provider `{}` speaks {:?}; a \
-                 surface names its own protocol, and the two have to agree",
-                api.protocol(),
-                provider.name(),
-                provider.protocol()
-            ));
         }
     }
     Ok(())
@@ -301,17 +288,19 @@ mod tests {
     /// contributor fix the line without opening `protocol/types.rs`.
     #[test]
     fn an_api_outside_the_vocabulary_fails_to_load() {
-        let yaml = with(&model("demo/plain"))
-            .replace("api: openai_chat_completions", "api: anthropic_messages");
+        let yaml = with(&model("demo/plain")).replace(
+            "api: openai_compat_chat_completions",
+            "api: anthropic_messages",
+        );
         let err = load(&yaml).unwrap_err();
         assert!(
             err.contains("unknown variant `anthropic_messages`"),
             "{err}"
         );
         for known in [
-            "openai_chat_completions",
-            "openai_chat_completions_stream",
-            "openai_responses",
+            "openai_compat_chat_completions",
+            "openai_compat_chat_completions_stream",
+            "openai_compat_responses",
         ] {
             assert!(err.contains(known), "vocabulary missing {known}: {err}");
         }
@@ -335,8 +324,8 @@ mod tests {
         // it is judged against, so nobody has to work out what "unsorted"
         // meant.
         assert!(err.contains("`demo`'s models"), "{err}");
-        assert!(err.contains("`demo/alpha` (line 10)"), "{err}");
-        assert!(err.contains("move it above `demo/zeta` (line 7)"), "{err}");
+        assert!(err.contains("`demo/alpha` (line 9)"), "{err}");
+        assert!(err.contains("move it above `demo/zeta` (line 6)"), "{err}");
         assert!(err.contains("ascending BYTE order"), "{err}");
     }
 
@@ -379,8 +368,8 @@ mod tests {
     #[test]
     fn the_order_error_points_at_the_right_line() {
         let err = check(&with(&models(&["demo/model-x", "demo/model"]))).unwrap_err();
-        assert!(err.contains("`demo/model` (line 10)"), "{err}");
-        assert!(err.contains("above `demo/model-x` (line 7)"), "{err}");
+        assert!(err.contains("`demo/model` (line 9)"), "{err}");
+        assert!(err.contains("above `demo/model-x` (line 6)"), "{err}");
     }
 
     /// Both ways of writing "no models yet" load fine and are caught here,
@@ -407,26 +396,21 @@ mod tests {
         assert!(err.contains("names no providers"), "{err}");
     }
 
-    /// A surface names its protocol, and a model cannot name one its host does
-    /// not speak. Unreachable while `openai_compat` is the only protocol —
-    /// every surface belongs to it — so this asserts the rule directly on
-    /// [`serves`] rather than through a roster that cannot express the
-    /// mistake yet.
-    ///
-    /// Written now rather than retrofitted the day a second protocol lands,
-    /// which is the day it starts being able to fail.
+    /// Two models of one provider may serve entirely different surfaces, and
+    /// the lint has no opinion about it. This used to be checked against the
+    /// provider's own `protocol:`; with that gone there is nothing to agree
+    /// with, which is what lets one host serve a chat model beside a
+    /// Responses-only one.
     #[test]
-    fn a_model_naming_a_surface_its_provider_cannot_speak_is_rejected() {
-        let registry = clean(&with(&model("demo/plain")));
-        let provider = registry.providers.get("demo").unwrap();
-        let spec = registry.models.get("demo/plain").unwrap();
-        // The real pair agrees, which is the case that has to keep passing.
-        serves(spec, provider).unwrap();
-        assert_eq!(
-            spec.supported_apis()[0].api().protocol(),
-            provider.protocol(),
-            "the check has nothing to catch unless these can differ"
-        );
+    fn one_provider_may_serve_models_with_disjoint_surfaces() {
+        clean(&with(concat!(
+            "      demo/chat-only:\n",
+            "        supported_apis:\n",
+            "          - {api: openai_compat_chat_completions}\n",
+            "      demo/responses-only:\n",
+            "        supported_apis:\n",
+            "          - {api: openai_compat_responses}\n",
+        )));
     }
 
     /// The same surface twice is one mistake, however its settings are
@@ -437,8 +421,8 @@ mod tests {
         let yaml = with(concat!(
             "      demo/plain:\n",
             "        supported_apis:\n",
-            "          - {api: openai_chat_completions}\n",
-            "          - {api: openai_chat_completions}\n",
+            "          - {api: openai_compat_chat_completions}\n",
+            "          - {api: openai_compat_chat_completions}\n",
         ));
         assert!(
             load(&yaml).is_ok(),

--- a/crates/warpllm/src/registry/load.rs
+++ b/crates/warpllm/src/registry/load.rs
@@ -15,8 +15,8 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 
-use super::types::{Capabilities, ModelSpec, ProviderSpec, Registry};
-use crate::types::{Api, Protocol};
+use super::types::{Capabilities, ModelSpec, ProviderSpec, Registry, SupportedApi};
+use crate::types::Protocol;
 
 /// The whole roster: providers, each holding the models routable under it.
 ///
@@ -41,7 +41,6 @@ struct ProviderEntry {
     base_url: String,
     env_api_key: Option<String>,
     protocol: Protocol,
-    supported_apis: Vec<Api>,
     /// `Option`, and defaulted, so that both ways of writing "no models yet" —
     /// omitting the key and leaving it empty — reach the lint, which says what
     /// is wrong with that in its own words. Neither is a load failure, because
@@ -50,12 +49,20 @@ struct ProviderEntry {
     models: Option<HashMap<String, ModelEntry>>,
 }
 
-/// One model as written: what it ships upstream if that differs from its key,
-/// and whatever limits are published for it. Both optional, which is why the
-/// overwhelmingly common entry is `{}`.
+/// One model as written: which surfaces it serves, what it ships upstream if
+/// that differs from its key, and whatever limits are published for it.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ModelEntry {
+    /// REQUIRED, and the reason a model entry is never bare `{}`.
+    ///
+    /// Nothing is inherited from the provider, deliberately. A default of
+    /// "everything my host serves" would be a claim the roster never made, and
+    /// it fails open: an embeddings model under a host that also serves chat
+    /// would be admitted to a chat request and fail as a 404 upstream. Silence
+    /// stops the roster loading instead, and serde names the entry it is
+    /// missing from.
+    supported_apis: Vec<SupportedApi>,
     model: Option<String>,
     /// Names `blank` rather than relying on `#[serde(default)]`, which would
     /// need `Capabilities: Default` — the public constructor that type does
@@ -75,7 +82,6 @@ pub(super) fn load(yaml: &str) -> Result<Registry, String> {
             base_url,
             env_api_key,
             protocol,
-            supported_apis,
             models,
         } = entry;
         for (key, model) in models.unwrap_or_default() {
@@ -89,7 +95,6 @@ pub(super) fn load(yaml: &str) -> Result<Registry, String> {
                 base_url,
                 env_api_key,
                 protocol,
-                supported_apis,
             },
         );
     }
@@ -107,8 +112,8 @@ fn parse(yaml: &str) -> Result<RegistryFile, String> {
     yaml_serde::from_str(yaml).map_err(|e| e.to_string())
 }
 
-/// One model entry, checked against the key it sits under. The key settles
-/// the one thing the entry itself may not state: the name that ships upstream.
+/// One model entry, checked against the key it sits under. The key settles the
+/// one thing the entry itself may leave unstated: the name that ships upstream.
 fn build(key: &str, provider: &str, entry: ModelEntry) -> Result<ModelSpec, String> {
     validate_model(key, provider)?;
     let name = key
@@ -118,6 +123,7 @@ fn build(key: &str, provider: &str, entry: ModelEntry) -> Result<ModelSpec, Stri
     Ok(ModelSpec {
         provider: provider.to_string(),
         model: entry.model.unwrap_or_else(|| name.to_string()),
+        supported_apis: entry.supported_apis,
         capabilities: entry.capabilities,
     })
 }
@@ -168,8 +174,11 @@ fn validate_model(key: &str, provider: &str) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::testing::{OTHER_PROVIDER, PROVIDER, clean, keys, providers, with};
+    use super::super::testing::{
+        CHAT, OTHER_PROVIDER, PROVIDER, clean, keys, model, models, providers, with,
+    };
     use super::*;
+    use crate::types::Api;
 
     /// `PROVIDER` with one line dropped, for the cases that ask what happens
     /// when a required field is not there at all.
@@ -186,7 +195,7 @@ mod tests {
     /// other, and neither holds the other's rows.
     #[test]
     fn providers_and_models_land_in_their_own_tables() {
-        let registry = clean(&with("      demo/one: {}\n      demo/two: {}\n"));
+        let registry = clean(&with(&models(&["demo/one", "demo/two"])));
         assert_eq!(providers(&registry), vec!["demo"]);
         assert_eq!(keys(&registry), vec!["demo/one", "demo/two"]);
     }
@@ -196,16 +205,12 @@ mod tests {
     /// copies of it.
     #[test]
     fn a_providers_transport_is_stored_once() {
-        let registry = clean(&with("      demo/one: {}\n      demo/two: {}\n"));
+        let registry = clean(&with(&models(&["demo/one", "demo/two"])));
         let provider = registry.providers.get("demo").unwrap();
         assert_eq!(provider.name(), "demo");
         assert_eq!(provider.base_url(), "https://api.demo.test/v1");
         assert_eq!(provider.env_api_key(), Some("DEMO_API_KEY"));
         assert_eq!(provider.protocol(), Protocol::OpenAiCompat);
-        assert_eq!(
-            provider.supported_apis(),
-            [Api::ChatCompletions, Api::Responses]
-        );
         for key in ["demo/one", "demo/two"] {
             assert_eq!(registry.models.get(key).unwrap().provider, "demo");
         }
@@ -217,8 +222,9 @@ mod tests {
     #[test]
     fn a_provider_may_name_no_env_api_key() {
         let registry = clean(&format!(
-            "{}      demo/plain: {{}}\n",
-            without("env_api_key")
+            "{}{}",
+            without("env_api_key"),
+            model("demo/plain")
         ));
         let provider = registry.providers.get("demo").unwrap();
         assert_eq!(provider.env_api_key(), None);
@@ -233,7 +239,7 @@ mod tests {
     /// the shape every GPT-5.6 entry uses.
     #[test]
     fn an_empty_entry_is_routable_and_records_no_limits() {
-        let registry = clean(&with("      demo/plain: {}\n"));
+        let registry = clean(&with(&model("demo/plain")));
         let spec = registry.models.get("demo/plain").unwrap();
         assert_eq!(spec.model(), "plain");
         assert_eq!(spec.capabilities().max_input_tokens(), None);
@@ -244,13 +250,10 @@ mod tests {
     /// entries for exactly this reason.
     #[test]
     fn capabilities_are_read_per_model() {
-        let registry = clean(&with(concat!(
-            "      demo/fast:\n",
-            "        capabilities:\n",
-            "          max_concurrent_requests: 2500\n",
-            "      demo/slow:\n",
-            "        capabilities:\n",
-            "          max_concurrent_requests: 500\n",
+        let registry = clean(&with(&format!(
+            "      demo/fast:\n{CHAT}        capabilities:\n          \
+             max_concurrent_requests: 2500\n      demo/slow:\n{CHAT}        \
+             capabilities:\n          max_concurrent_requests: 500\n"
         )));
         let caps = |key| registry.models.get(key).unwrap().capabilities();
         assert_eq!(caps("demo/fast").max_concurrent_requests(), Some(2500));
@@ -258,17 +261,149 @@ mod tests {
         assert_eq!(caps("demo/fast").max_input_tokens(), None);
     }
 
+    // ------------------------------------------------------ supported_apis
+
+    /// The list is read as written, in order, and each entry carries its own
+    /// (empty) settings.
+    #[test]
+    fn a_models_surfaces_are_read_from_its_own_entry() {
+        let registry = clean(&with(concat!(
+            "      demo/plain:\n",
+            "        supported_apis:\n",
+            "          - {api: openai_chat_completions}\n",
+            "          - {api: openai_responses}\n",
+        )));
+        assert_eq!(
+            registry.models.get("demo/plain").unwrap().supported_apis(),
+            [
+                SupportedApi {
+                    api: Api::OpenAiChatCompletions
+                },
+                SupportedApi {
+                    api: Api::OpenAiResponses
+                },
+            ]
+        );
+    }
+
+    /// The point of the whole field: one provider, two models, different
+    /// surfaces. Neither borrows anything from the other or from the host.
+    #[test]
+    fn two_models_of_one_provider_serve_different_surfaces() {
+        let registry = clean(&with(concat!(
+            "      demo/chat-only:\n",
+            "        supported_apis:\n",
+            "          - {api: openai_chat_completions}\n",
+            "      demo/responses-only:\n",
+            "        supported_apis:\n",
+            "          - {api: openai_responses}\n",
+        )));
+        let apis = |key| registry.models.get(key).unwrap().supported_apis().to_vec();
+        assert_eq!(
+            apis("demo/chat-only"),
+            [SupportedApi {
+                api: Api::OpenAiChatCompletions
+            }]
+        );
+        assert_eq!(
+            apis("demo/responses-only"),
+            [SupportedApi {
+                api: Api::OpenAiResponses
+            }]
+        );
+        // The one that does not serve chat completions says so by not holding
+        // the surface — which is what the client's gate reads.
+        assert!(
+            !registry
+                .models
+                .get("demo/responses-only")
+                .unwrap()
+                .supports_api(Api::OpenAiChatCompletions)
+        );
+    }
+
+    /// Required, with nothing to fall back on. This is the guard that keeps a
+    /// silent entry from meaning "everything my host serves" — a claim the
+    /// roster never made, and one that fails open.
+    #[test]
+    fn a_model_naming_no_surfaces_is_rejected() {
+        let err = load(&with("      demo/plain: {}\n")).unwrap_err();
+        assert!(err.contains("missing field"), "{err}");
+        assert!(err.contains("supported_apis"), "{err}");
+    }
+
+    /// The closed vocabulary, at the level that writes it. A typo cannot load,
+    /// so it never reaches a live provider as a 404.
+    #[test]
+    fn a_misspelled_surface_is_rejected() {
+        let err = load(&with(
+            "      demo/plain:\n        supported_apis:\n          - {api: chat_completions}\n",
+        ))
+        .unwrap_err();
+        assert!(err.contains("unknown variant `chat_completions`"), "{err}");
+        // The message names the vocabulary, so the line can be fixed without
+        // opening `types.rs`.
+        assert!(err.contains("openai_chat_completions"), "{err}");
+    }
+
+    /// An entry is a map, and `api` is the key it must carry. Leaving it out
+    /// names no surface at all, which serde reports against the entry.
+    #[test]
+    fn an_entry_naming_no_api_is_rejected() {
+        let err = load(&with(
+            "      demo/plain:\n        supported_apis:\n          - {}\n",
+        ))
+        .unwrap_err();
+        assert!(err.contains("missing field `api`"), "{err}");
+    }
+
+    /// An entry is as closed as the surface list itself. `api` is the only key
+    /// one takes today, so anything beside it is a typo or a stale roster —
+    /// not something to accept and drop.
+    ///
+    /// This is what `input_modalities` will land into: adding it makes this
+    /// exact roster line valid, at every surface at once.
+    #[test]
+    fn an_unknown_key_beside_the_api_is_rejected() {
+        let err = load(&with(concat!(
+            "      demo/plain:\n",
+            "        supported_apis:\n",
+            "          - api: openai_chat_completions\n",
+            "            input_modalities: [text]\n",
+        )))
+        .unwrap_err();
+        assert!(err.contains("unknown field"), "{err}");
+        assert!(err.contains("input_modalities"), "{err}");
+    }
+
+    /// The block form of an entry is the same YAML as the inline one the
+    /// roster writes, which is what makes opening one up to add a key a
+    /// formatting choice rather than a migration.
+    #[test]
+    fn an_entry_reads_the_same_written_inline_or_as_a_block() {
+        let inline = clean(&with(
+            "      demo/plain:\n        supported_apis:\n          - {api: openai_chat_completions}\n",
+        ));
+        let block = clean(&with(
+            "      demo/plain:\n        supported_apis:\n          - api: openai_chat_completions\n",
+        ));
+        assert_eq!(
+            inline.models.get("demo/plain").unwrap().supported_apis(),
+            block.models.get("demo/plain").unwrap().supported_apis()
+        );
+    }
+
     #[test]
     fn the_wire_name_defaults_to_the_keys_last_segment() {
-        let registry = clean(&with("      demo/plain: {}\n"));
+        let registry = clean(&with(&model("demo/plain")));
         assert_eq!(registry.models.get("demo/plain").unwrap().model(), "plain");
     }
 
     #[test]
     fn an_explicit_model_beats_the_keys_last_segment() {
-        let registry = clean(&with(
-            "      demo/chat:\n        model: demo-chat-20240101\n",
-        ));
+        let registry = clean(&with(&format!(
+            "      demo/chat:\n{CHAT}        model: demo-chat-20240101\n"
+        )));
         assert_eq!(
             registry.models.get("demo/chat").unwrap().model(),
             "demo-chat-20240101"
@@ -279,7 +414,7 @@ mod tests {
     /// through it, and the wire name is still the last segment.
     #[test]
     fn a_slash_containing_name_is_one_name() {
-        let registry = clean(&with("      demo/org/custom: {}\n"));
+        let registry = clean(&with(&model("demo/org/custom")));
         assert_eq!(
             registry.models.get("demo/org/custom").unwrap().model(),
             "custom"
@@ -291,10 +426,7 @@ mod tests {
     /// over a resolved roster.
     #[test]
     fn every_model_names_a_provider_that_exists() {
-        let registry = clean(&format!(
-            "{}{OTHER_PROVIDER}",
-            with("      demo/plain: {}\n")
-        ));
+        let registry = clean(&format!("{}{OTHER_PROVIDER}", with(&model("demo/plain"))));
         for (key, spec) in &registry.models {
             let provider = registry
                 .providers
@@ -338,7 +470,7 @@ mod tests {
     /// makes this an error.
     #[test]
     fn duplicate_keys_are_rejected() {
-        let err = load(&with("      demo/plain: {}\n      demo/plain: {}\n")).unwrap_err();
+        let err = load(&with(&models(&["demo/plain", "demo/plain"]))).unwrap_err();
         assert!(err.contains("duplicate"), "{err}");
         assert!(err.contains("demo/plain"), "{err}");
     }
@@ -348,16 +480,8 @@ mod tests {
     /// one has no spec to build.
     #[test]
     fn a_missing_provider_field_is_rejected() {
-        for field in ["base_url", "protocol", "supported_apis"] {
-            let mut yaml = without(field);
-            if field == "supported_apis" {
-                // Its two list items outlive the key they belonged to.
-                yaml = yaml
-                    .lines()
-                    .filter(|line| !line.trim_start().starts_with("- "))
-                    .fold(String::new(), |acc, line| acc + line + "\n");
-            }
-            let err = load(&format!("{yaml}      demo/plain: {{}}\n")).unwrap_err();
+        for field in ["base_url", "protocol"] {
+            let err = load(&format!("{}{}", without(field), model("demo/plain"))).unwrap_err();
             assert!(
                 err.contains("missing field") && err.contains(field),
                 "removing {field} gave: {err}"
@@ -369,7 +493,7 @@ mod tests {
     /// provider would resolve to nothing, and the message says what to write.
     #[test]
     fn a_model_key_missing_its_provider_prefix_is_rejected() {
-        let err = load(&with("      plain: {}\n")).unwrap_err();
+        let err = load(&with(&model("plain"))).unwrap_err();
         assert!(err.contains("has to start with `demo/`"), "{err}");
     }
 
@@ -377,13 +501,13 @@ mod tests {
     /// that is not its own.
     #[test]
     fn a_model_key_under_the_wrong_provider_is_rejected() {
-        let err = load(&with("      other/plain: {}\n")).unwrap_err();
+        let err = load(&with(&model("other/plain"))).unwrap_err();
         assert!(err.contains("has to start with `demo/`"), "{err}");
     }
 
     #[test]
     fn a_key_that_names_no_model_is_rejected() {
-        let err = load(&with("      demo/: {}\n")).unwrap_err();
+        let err = load(&with(&model("demo/"))).unwrap_err();
         assert!(err.contains("names no model"), "{err}");
     }
 
@@ -391,7 +515,7 @@ mod tests {
     /// since every other character is read literally as part of a name.
     #[test]
     fn an_empty_path_segment_is_rejected() {
-        let err = load(&with("      demo//custom: {}\n")).unwrap_err();
+        let err = load(&with(&model("demo//custom"))).unwrap_err();
         assert!(err.contains("an empty path segment"), "{err}");
     }
 

--- a/crates/warpllm/src/registry/load.rs
+++ b/crates/warpllm/src/registry/load.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
 use serde::Deserialize;
 
 use super::types::{Capabilities, ModelSpec, ProviderSpec, Registry, SupportedApi};
-use crate::types::Protocol;
 
 /// The whole roster: providers, each holding the models routable under it.
 ///
@@ -31,16 +30,20 @@ struct RegistryFile {
     providers: HashMap<String, ProviderEntry>,
 }
 
-/// One provider as written. Everything but `env_api_key` and `models` is
-/// required: there is no inheritance and so nowhere else a value could come
-/// from, which is what lets serde report a missing one against the line it is
-/// missing from.
+/// One provider as written: transport only. Everything but `env_api_key` and
+/// `models` is required: there is no inheritance and so nowhere else a value
+/// could come from, which is what lets serde report a missing one against the
+/// line it is missing from.
+///
+/// `deny_unknown_fields` is what turns the retired `protocol:` line into an
+/// error rather than a silently ignored one — a surface names its own protocol
+/// now, and a roster still recording it per provider is stale rather than
+/// merely verbose.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ProviderEntry {
     base_url: String,
     env_api_key: Option<String>,
-    protocol: Protocol,
     /// `Option`, and defaulted, so that both ways of writing "no models yet" —
     /// omitting the key and leaving it empty — reach the lint, which says what
     /// is wrong with that in its own words. Neither is a load failure, because
@@ -81,7 +84,6 @@ pub(super) fn load(yaml: &str) -> Result<Registry, String> {
         let ProviderEntry {
             base_url,
             env_api_key,
-            protocol,
             models,
         } = entry;
         for (key, model) in models.unwrap_or_default() {
@@ -94,7 +96,6 @@ pub(super) fn load(yaml: &str) -> Result<Registry, String> {
                 name,
                 base_url,
                 env_api_key,
-                protocol,
             },
         );
     }
@@ -210,7 +211,6 @@ mod tests {
         assert_eq!(provider.name(), "demo");
         assert_eq!(provider.base_url(), "https://api.demo.test/v1");
         assert_eq!(provider.env_api_key(), Some("DEMO_API_KEY"));
-        assert_eq!(provider.protocol(), Protocol::OpenAiCompat);
         for key in ["demo/one", "demo/two"] {
             assert_eq!(registry.models.get(key).unwrap().provider, "demo");
         }
@@ -270,17 +270,17 @@ mod tests {
         let registry = clean(&with(concat!(
             "      demo/plain:\n",
             "        supported_apis:\n",
-            "          - {api: openai_chat_completions}\n",
-            "          - {api: openai_responses}\n",
+            "          - {api: openai_compat_chat_completions}\n",
+            "          - {api: openai_compat_responses}\n",
         )));
         assert_eq!(
             registry.models.get("demo/plain").unwrap().supported_apis(),
             [
                 SupportedApi {
-                    api: Api::OpenAiChatCompletions
+                    api: Api::OpenAiCompatChatCompletions
                 },
                 SupportedApi {
-                    api: Api::OpenAiResponses
+                    api: Api::OpenAiCompatResponses
                 },
             ]
         );
@@ -293,22 +293,22 @@ mod tests {
         let registry = clean(&with(concat!(
             "      demo/chat-only:\n",
             "        supported_apis:\n",
-            "          - {api: openai_chat_completions}\n",
+            "          - {api: openai_compat_chat_completions}\n",
             "      demo/responses-only:\n",
             "        supported_apis:\n",
-            "          - {api: openai_responses}\n",
+            "          - {api: openai_compat_responses}\n",
         )));
         let apis = |key| registry.models.get(key).unwrap().supported_apis().to_vec();
         assert_eq!(
             apis("demo/chat-only"),
             [SupportedApi {
-                api: Api::OpenAiChatCompletions
+                api: Api::OpenAiCompatChatCompletions
             }]
         );
         assert_eq!(
             apis("demo/responses-only"),
             [SupportedApi {
-                api: Api::OpenAiResponses
+                api: Api::OpenAiCompatResponses
             }]
         );
         // The one that does not serve chat completions says so by not holding
@@ -318,7 +318,7 @@ mod tests {
                 .models
                 .get("demo/responses-only")
                 .unwrap()
-                .supports_api(Api::OpenAiChatCompletions)
+                .supports_api(Api::OpenAiCompatChatCompletions)
         );
     }
 
@@ -334,16 +334,25 @@ mod tests {
 
     /// The closed vocabulary, at the level that writes it. A typo cannot load,
     /// so it never reaches a live provider as a 404.
+    ///
+    /// Aimed at the surface's PREVIOUS spelling, which is the misspelling a
+    /// roster is most likely to carry: the protocol prefix moved from the
+    /// provider's own `protocol:` line into the surface name, so `openai_…`
+    /// became `openai_compat_…` and a stale entry says the old thing. The
+    /// message has to name the new vocabulary, which is the migration.
     #[test]
     fn a_misspelled_surface_is_rejected() {
         let err = load(&with(
-            "      demo/plain:\n        supported_apis:\n          - {api: chat_completions}\n",
+            "      demo/plain:\n        supported_apis:\n          - {api: openai_chat_completions}\n",
         ))
         .unwrap_err();
-        assert!(err.contains("unknown variant `chat_completions`"), "{err}");
+        assert!(
+            err.contains("unknown variant `openai_chat_completions`"),
+            "{err}"
+        );
         // The message names the vocabulary, so the line can be fixed without
         // opening `types.rs`.
-        assert!(err.contains("openai_chat_completions"), "{err}");
+        assert!(err.contains("openai_compat_chat_completions"), "{err}");
     }
 
     /// An entry is a map, and `api` is the key it must carry. Leaving it out
@@ -368,7 +377,7 @@ mod tests {
         let err = load(&with(concat!(
             "      demo/plain:\n",
             "        supported_apis:\n",
-            "          - api: openai_chat_completions\n",
+            "          - api: openai_compat_chat_completions\n",
             "            input_modalities: [text]\n",
         )))
         .unwrap_err();
@@ -382,10 +391,10 @@ mod tests {
     #[test]
     fn an_entry_reads_the_same_written_inline_or_as_a_block() {
         let inline = clean(&with(
-            "      demo/plain:\n        supported_apis:\n          - {api: openai_chat_completions}\n",
+            "      demo/plain:\n        supported_apis:\n          - {api: openai_compat_chat_completions}\n",
         ));
         let block = clean(&with(
-            "      demo/plain:\n        supported_apis:\n          - api: openai_chat_completions\n",
+            "      demo/plain:\n        supported_apis:\n          - api: openai_compat_chat_completions\n",
         ));
         assert_eq!(
             inline.models.get("demo/plain").unwrap().supported_apis(),
@@ -441,11 +450,23 @@ mod tests {
     // Nothing below leaves a correct pair of tables to build, so each is
     // rejected.
 
+    /// `protocol:` was a provider field until a surface started naming its own.
+    /// A roster still carrying it is stale, not merely verbose, and has to hear
+    /// so: silently ignoring the line would leave a fork believing it still
+    /// chose the wire format, right up until it wrote one the surfaces
+    /// contradict.
     #[test]
-    fn unknown_protocols_are_rejected() {
-        let err = load(&with("").replace("openai_compat", "anthropic")).unwrap_err();
-        assert!(err.contains("unknown variant"), "{err}");
-        assert!(err.contains("openai_compat"), "{err}");
+    fn a_stale_protocol_field_is_rejected() {
+        let stale = with(&model("demo/plain")).replace(
+            "    env_api_key: DEMO_API_KEY\n",
+            "    env_api_key: DEMO_API_KEY\n    protocol: openai_compat\n",
+        );
+        let err = load(&stale).unwrap_err();
+        assert!(err.contains("unknown field"), "{err}");
+        assert!(err.contains("protocol"), "{err}");
+        // The surviving fields are named, so the fix is to delete the line
+        // rather than to go looking for what replaced it.
+        assert!(err.contains("base_url"), "{err}");
     }
 
     #[test]
@@ -475,18 +496,15 @@ mod tests {
         assert!(err.contains("demo/plain"), "{err}");
     }
 
-    /// The accessors read these without a fallback, and with no inheritance
-    /// left there is nowhere else they could come from — so a provider missing
-    /// one has no spec to build.
+    /// The accessors read this without a fallback, and with no inheritance
+    /// left there is nowhere else it could come from — so a provider missing
+    /// it has no spec to build. `base_url` is the only required provider field
+    /// there is now that a surface names its own protocol.
     #[test]
     fn a_missing_provider_field_is_rejected() {
-        for field in ["base_url", "protocol"] {
-            let err = load(&format!("{}{}", without(field), model("demo/plain"))).unwrap_err();
-            assert!(
-                err.contains("missing field") && err.contains(field),
-                "removing {field} gave: {err}"
-            );
-        }
+        let err = load(&format!("{}{}", without("base_url"), model("demo/plain"))).unwrap_err();
+        assert!(err.contains("missing field"), "{err}");
+        assert!(err.contains("base_url"), "{err}");
     }
 
     /// The key is the whole string a caller routes with. A bare name under a

--- a/crates/warpllm/src/registry/mod.rs
+++ b/crates/warpllm/src/registry/mod.rs
@@ -30,7 +30,7 @@ mod lint;
 mod testing;
 
 use types::Registry;
-pub use types::{Capabilities, ModelSpec, ProviderSpec};
+pub use types::{Capabilities, ModelSpec, ProviderSpec, SupportedApi};
 
 /// The shipped roster, loaded on first use.
 ///
@@ -47,10 +47,13 @@ static REGISTRY: LazyLock<Registry> = LazyLock::new(|| {
 /// provider that serves it, and the model itself.
 ///
 /// Two rows rather than one merged spec, because the roster keeps them at two
-/// levels — how the API is reached and what it serves is the provider's, the
-/// upstream name and the published limits are the model's. Nothing is copied
-/// between them, so a provider's transport is stated once no matter how many
-/// models it serves.
+/// levels — how the API is reached is the provider's; the upstream name, the
+/// surfaces served, and the published limits are the model's. The transport is
+/// stated once no matter how many models a provider serves.
+///
+/// What a request can ASK FOR is the model's alone. A provider is a host, and
+/// one host commonly serves chat completions, embeddings, and moderation from
+/// disjoint sets of models, so there is nothing at that level to route on.
 ///
 /// The key matches exactly or not at all. Nothing routes on a guess — no
 /// pattern, no catch-all, no fallback — so a name no entry claims is an error,
@@ -67,8 +70,9 @@ static REGISTRY: LazyLock<Registry> = LazyLock::new(|| {
 /// ```
 /// let (provider, model) = warpllm::fetch_model("openai/gpt-5.6")?;
 /// assert_eq!(provider.name(), "openai");
-/// assert!(provider.supports_api(warpllm::Api::ChatCompletions));
 /// assert_eq!(model.model(), "gpt-5.6");
+/// // The model's own list is what a request is routed on.
+/// assert!(model.supports_api(warpllm::Api::OpenAiChatCompletions));
 ///
 /// // A name nobody registered is an error, never a guess.
 /// assert!(warpllm::fetch_model("openai/nonexistent").is_err());
@@ -128,7 +132,7 @@ fn resolve<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::testing::{clean, keys, providers, with};
+    use super::testing::{CHAT, clean, keys, model, models, providers, with};
     use super::*;
     use crate::types::{Api, Protocol};
 
@@ -138,9 +142,10 @@ mod tests {
     /// at all, and what ships upstream is that entry's name.
     #[test]
     fn a_key_matches_its_own_entry_or_nothing() {
-        let registry = clean(&with(
-            "      demo/pinned:\n        model: pinned-2024\n      demo/plain: {}\n",
-        ));
+        let registry = clean(&with(&format!(
+            "      demo/pinned:\n{CHAT}        model: pinned-2024\n{}",
+            model("demo/plain")
+        )));
         assert_eq!(
             resolve(&registry, "demo/pinned").unwrap().1.model(),
             "pinned-2024"
@@ -155,7 +160,7 @@ mod tests {
     /// the whole point of handing back both halves.
     #[test]
     fn a_match_carries_its_provider() {
-        let registry = clean(&with("      demo/plain: {}\n"));
+        let registry = clean(&with(&model("demo/plain")));
         let (provider, _) = resolve(&registry, "demo/plain").unwrap();
         assert_eq!(provider.name(), "demo");
         assert_eq!(provider.base_url(), "https://api.demo.test/v1");
@@ -170,7 +175,7 @@ mod tests {
     /// for a misspelling: nothing.
     #[test]
     fn an_unlisted_name_is_rejected() {
-        let registry = clean(&with("      demo/plain: {}\n"));
+        let registry = clean(&with(&model("demo/plain")));
         assert!(resolve(&registry, "demo/plain").is_some());
         for unlisted in ["demo/unlisted", "demo/*", "demo/pl*", "*"] {
             assert!(resolve(&registry, unlisted).is_none(), "`{unlisted}`");
@@ -181,7 +186,7 @@ mod tests {
     /// grouping buys it no fallback.
     #[test]
     fn a_grouped_name_matches_only_its_own_entry() {
-        let registry = clean(&with("      demo/org/one: {}\n      demo/plain: {}\n"));
+        let registry = clean(&with(&models(&["demo/org/one", "demo/plain"])));
         assert!(resolve(&registry, "demo/org/one").is_some());
         assert!(resolve(&registry, "demo/org/two").is_none());
         assert!(resolve(&registry, "demo/org").is_none());
@@ -191,7 +196,7 @@ mod tests {
     /// routes to it.
     #[test]
     fn a_provider_name_is_not_routable() {
-        let registry = clean(&with("      demo/plain: {}\n"));
+        let registry = clean(&with(&model("demo/plain")));
         assert!(resolve(&registry, "demo/").is_none());
         assert!(resolve(&registry, "demo").is_none());
     }
@@ -256,8 +261,7 @@ mod tests {
         assert_eq!(provider.base_url(), "https://openrouter.ai/api/v1");
         assert_eq!(provider.env_api_key(), Some("OPENROUTER_API_KEY"));
         assert_eq!(provider.protocol(), Protocol::OpenAiCompat);
-        assert!(provider.supports_api(Api::ChatCompletions));
-        assert!(!provider.supports_api(Api::Responses));
+        assert!(model.supports_api(Api::OpenAiChatCompletions));
         assert_eq!(model.model(), "anthropic/claude-sonnet-4");
     }
 
@@ -294,16 +298,59 @@ mod tests {
         }
     }
 
-    /// API surfaces are the provider's claim, and differ between providers.
+    /// Every shipped entry lists EXACTLY chat completions — the one surface
+    /// warpllm implements. Iterates [`REGISTRY`] so a new entry is covered
+    /// without being added here.
+    ///
+    /// Both halves earn their keep, in opposite directions:
+    ///
+    /// Serving it at all is what the client can route. An entry that did not
+    /// would be admitted by the roster and refused by `validate_api`, so this
+    /// is where that shows up rather than at request time. When a genuine
+    /// non-chat model lands — an embeddings or moderation name — it belongs in
+    /// an exclusion here rather than being quietly made to serve chat.
+    ///
+    /// Serving nothing MORE is the roster rule that a surface is listed only
+    /// once warpllm can serve it. `openai_responses` is real, and every OpenAI
+    /// model here really does serve it, and it is still absent — because there
+    /// is no code behind it, so an entry claiming it would record a capability
+    /// nothing can act on. This is what catches it being added early.
+    ///
+    /// It also means the shipped roster can no longer show two models of one
+    /// provider differing. That is proved over fixtures instead, by
+    /// `load::tests::two_models_of_one_provider_serve_different_surfaces`.
     #[test]
-    fn supported_apis_resolve_for_the_addressed_provider() {
-        let (openai, _) = fetch_model("openai/gpt-5.6").unwrap();
-        assert!(openai.supports_api(Api::ChatCompletions));
-        assert!(openai.supports_api(Api::Responses));
+    fn every_shipped_model_serves_exactly_chat_completions() {
+        assert!(!REGISTRY.models.is_empty(), "the registry is empty");
+        for (model_str, spec) in &REGISTRY.models {
+            assert_eq!(
+                spec.supported_apis(),
+                [SupportedApi {
+                    api: Api::OpenAiChatCompletions
+                }],
+                "`{model_str}` lists a surface warpllm does not implement, or \
+                 omits the one it does"
+            );
+        }
+    }
 
-        let (deepseek, _) = fetch_model("deepseek/deepseek-v4-flash").unwrap();
-        assert!(deepseek.supports_api(Api::ChatCompletions));
-        assert!(!deepseek.supports_api(Api::Responses));
+    /// Every surface on every entry is spoken in the protocol its provider
+    /// speaks — the invariant `lint::serves` enforces, stated here over the
+    /// table a caller actually routes against.
+    #[test]
+    fn no_model_names_a_surface_its_provider_cannot_speak() {
+        for (model_str, spec) in &REGISTRY.models {
+            let (provider, _) = fetch_model(model_str).unwrap();
+            for entry in spec.supported_apis() {
+                assert_eq!(
+                    entry.api().protocol(),
+                    provider.protocol(),
+                    "`{model_str}` claims `{:?}`, which `{}` does not speak",
+                    entry.api(),
+                    provider.name()
+                );
+            }
+        }
     }
 
     /// Every registered model resolves to its own entry. Iterates the registry

--- a/crates/warpllm/src/registry/mod.rs
+++ b/crates/warpllm/src/registry/mod.rs
@@ -51,6 +51,10 @@ static REGISTRY: LazyLock<Registry> = LazyLock::new(|| {
 /// surfaces served, and the published limits are the model's. The transport is
 /// stated once no matter how many models a provider serves.
 ///
+/// Which WIRE FORMAT is spoken is the model's, not the provider's: an
+/// [`crate::Api`] names its own protocol, so the surfaces a model lists say it
+/// already.
+///
 /// What a request can ASK FOR is the model's alone. A provider is a host, and
 /// one host commonly serves chat completions, embeddings, and moderation from
 /// disjoint sets of models, so there is nothing at that level to route on.
@@ -72,7 +76,7 @@ static REGISTRY: LazyLock<Registry> = LazyLock::new(|| {
 /// assert_eq!(provider.name(), "openai");
 /// assert_eq!(model.model(), "gpt-5.6");
 /// // The model's own list is what a request is routed on.
-/// assert!(model.supports_api(warpllm::Api::OpenAiChatCompletions));
+/// assert!(model.supports_api(warpllm::Api::OpenAiCompatChatCompletions));
 ///
 /// // A name nobody registered is an error, never a guess.
 /// assert!(warpllm::fetch_model("openai/nonexistent").is_err());
@@ -134,7 +138,7 @@ fn resolve<'a>(
 mod tests {
     use super::testing::{CHAT, clean, keys, model, models, providers, with};
     use super::*;
-    use crate::types::{Api, Protocol};
+    use crate::types::Api;
 
     // ------------------------------------------------------------- matching
 
@@ -164,7 +168,6 @@ mod tests {
         let (provider, _) = resolve(&registry, "demo/plain").unwrap();
         assert_eq!(provider.name(), "demo");
         assert_eq!(provider.base_url(), "https://api.demo.test/v1");
-        assert_eq!(provider.protocol(), Protocol::OpenAiCompat);
     }
 
     /// The registry is closed, so an unlisted name is an error — the whole
@@ -250,7 +253,6 @@ mod tests {
         assert_eq!(provider.name(), "deepseek");
         assert_eq!(provider.base_url(), "https://api.deepseek.com");
         assert_eq!(provider.env_api_key(), Some("DEEPSEEK_API_KEY"));
-        assert_eq!(provider.protocol(), Protocol::OpenAiCompat);
         assert_eq!(model.model(), "deepseek-v4-flash");
     }
 
@@ -260,8 +262,7 @@ mod tests {
         assert_eq!(provider.name(), "openrouter");
         assert_eq!(provider.base_url(), "https://openrouter.ai/api/v1");
         assert_eq!(provider.env_api_key(), Some("OPENROUTER_API_KEY"));
-        assert_eq!(provider.protocol(), Protocol::OpenAiCompat);
-        assert!(model.supports_api(Api::OpenAiChatCompletions));
+        assert!(model.supports_api(Api::OpenAiCompatChatCompletions));
         assert_eq!(model.model(), "anthropic/claude-sonnet-4");
     }
 
@@ -311,10 +312,11 @@ mod tests {
     /// an exclusion here rather than being quietly made to serve chat.
     ///
     /// Serving nothing MORE is the roster rule that a surface is listed only
-    /// once warpllm can serve it. `openai_responses` is real, and every OpenAI
-    /// model here really does serve it, and it is still absent — because there
-    /// is no code behind it, so an entry claiming it would record a capability
-    /// nothing can act on. This is what catches it being added early.
+    /// once warpllm can serve it. `openai_compat_responses` is real, and every
+    /// OpenAI model here really does serve it, and it is still absent — because
+    /// there is no code behind it, so an entry claiming it would record a
+    /// capability nothing can act on. This is what catches it being added
+    /// early.
     ///
     /// It also means the shipped roster can no longer show two models of one
     /// provider differing. That is proved over fixtures instead, by
@@ -326,30 +328,11 @@ mod tests {
             assert_eq!(
                 spec.supported_apis(),
                 [SupportedApi {
-                    api: Api::OpenAiChatCompletions
+                    api: Api::OpenAiCompatChatCompletions
                 }],
                 "`{model_str}` lists a surface warpllm does not implement, or \
                  omits the one it does"
             );
-        }
-    }
-
-    /// Every surface on every entry is spoken in the protocol its provider
-    /// speaks — the invariant `lint::serves` enforces, stated here over the
-    /// table a caller actually routes against.
-    #[test]
-    fn no_model_names_a_surface_its_provider_cannot_speak() {
-        for (model_str, spec) in &REGISTRY.models {
-            let (provider, _) = fetch_model(model_str).unwrap();
-            for entry in spec.supported_apis() {
-                assert_eq!(
-                    entry.api().protocol(),
-                    provider.protocol(),
-                    "`{model_str}` claims `{:?}`, which `{}` does not speak",
-                    entry.api(),
-                    provider.name()
-                );
-            }
         }
     }
 

--- a/crates/warpllm/src/registry/specs.yaml
+++ b/crates/warpllm/src/registry/specs.yaml
@@ -1,230 +1,176 @@
-# warpllm's model registry.
+# warpllm's model registry: every provider and model warpllm can route to.
 #
-# THIS FILE IS THE ROSTER. Adding a provider or a model is an edit here and
-# nowhere else: `mod.rs` next door compiles it into the binary with
-# `include_str!` and resolves it once, on the first lookup.
+# This file is the whole roster — adding, changing, or removing an entry is an
+# edit here and nowhere else. Run `cargo test -p warpllm` before opening a PR;
+# a malformed or untidy roster fails there, and CI runs the same suite.
 #
-# Two gates catch a bad edit, and `cargo test -p warpllm` is where both bite,
-# so run it before you open a PR. Anything that leaves no usable spec — a
-# syntax error, an unknown field, a malformed key, a missing required field —
-# fails to LOAD. Everything else about a good roster, listed below as a rule,
-# is a lint. Neither can reach a release: CI runs the suite on every PR.
-#
-# Two levels, and they stay separate
-# ----------------------------------
-# A PROVIDER is how an API is reached and what it serves: one host, one
-# credential, one wire format, one list of API surfaces. A MODEL is one name
-# routable under that provider, and carries ONLY what differs between models
-# of the same provider — its limits.
-#
+# Shape
+# -----
 #   providers:
-#     openai:                        transport and surface, stated once
-#       base_url: ...
+#     openai:                                 # how the API is reached
+#       base_url: "https://api.openai.com/v1"
+#       env_api_key: OPENAI_API_KEY
+#       protocol: openai_compat
 #       models:
-#         openai/gpt-5.6: {}         one routable name
+#         openai/gpt-5.6:                     # what is routable, and what it does
+#           supported_apis:
+#             - {api: openai_chat_completions}
+#           model: gpt-5.6-2026-01-01         # optional
+#           capabilities:                     # optional
+#             max_input_tokens: 400000
 #
-# Two registries, because they answer two questions, and nothing merges them
-# at lookup time: `fetch_model` hands back the provider row and the model row,
-# side by side. Every field belongs to exactly one level, so which level a
-# value came from is never in question.
-#
-# KEEP BOTH MAPS IN ASCENDING KEY ORDER — providers alphabetically, and each
-# provider's models alphabetically within it. The tests fail otherwise. A new
-# entry then has exactly one place it can go, and two PRs adding different
-# providers do not collide.
-#
-# Model keys
-# ----------
-# A model key is the string a caller routes with, provider prefix included,
-# and it MUST start with the provider it sits under: `openai/gpt-5.6` under
-# `openai:`. The repetition is the point — the key is greppable as the exact
-# string a request carries — and a key filed under the wrong provider fails to
-# load.
-#
-# What follows the prefix is the model NAME. It may contain further slashes
-# (`openai/org/custom-model`); those are part of the name and group nothing.
-# There is no nesting and no inheritance between models: a model's limits are
-# its own, and everything else comes from its provider.
-#
-# Unlisted models
-# ---------------
-# A model with no entry is an error, NOT a silent fallback — a typo must not
-# reach a provider as a live request. Every name warpllm routes to is listed
-# here, so what this file says is routable is exactly what is.
-#
-# There is no catch-all and no pattern. A key is read literally, character for
-# character, so `openai/*` is not a wildcard — it registers a model whose name
-# is `*`, which no caller routes to and no provider serves. Write the name you
-# mean; a `*` anywhere in a key is a mistake nothing here will catch for you.
-#
-# That is a deliberate trade, and it costs something. A model a provider
-# shipped this morning is not routable until an entry for it lands here and a
-# release goes out. The alternative — matching whatever the caller asked for —
-# turns `openai/gpt-4oo` into a live, billed request that fails upstream, and
-# moves the error from this file to production. A name warpllm has never heard
-# of failing HERE, before a request is sent, is the point of the roster.
+# A provider is a host; a model is a routable name under it. Nothing is
+# inherited — not between the two levels, and not between models.
 #
 # Provider fields
 # ---------------
-# - `base_url` includes any version prefix (e.g. `/v1`) and carries no
-#   trailing slash: endpoints append their own path (`/chat/completions`).
-# - `env_api_key` names the environment variable warpllm reads the API key from.
-#   It is the only source today and not a secret store; per-provider overrides
-#   in client configuration are a later addition, added when an embedder that
-#   keeps keys elsewhere turns up. Two providers may not share one — the tests
-#   reject it, because a shared variable silently authenticates one provider
-#   with the other's credentials.
-#
-#   OPTIONAL, and the only provider field that is. Omitting it means the
-#   provider cannot be authenticated at all: a request routed to one fails
-#   saying so instead of naming a variable nothing reads. That is allowed so an
-#   entry can land before its key plumbing does — it is not a way to opt into
-#   per-caller keys. An empty string is rejected — that is a half-finished edit,
-#   not an opt-out.
-# - `protocol` names the wire format spoken. One of: openai_compat.
-# - `supported_apis` names the API surfaces this provider serves. These are
-#   CAPABILITIES, not URL paths: which path an API is reached at belongs to the
-#   protocol that implements it, and two protocols may serve the same API at
-#   different paths. The vocabulary is closed, so a misspelling fails to LOAD
-#   rather than 404 against a live provider:
-#
-#     chat_completions
-#       One request, one whole reply. The only surface warpllm serves today.
-#
-#     chat_completions_stream
-#       The same request asked to stream, delivered as incremental chunks.
-#       Listed separately because a provider can serve one without the other —
-#       declaring `chat_completions` never implies this one, so a provider that
-#       streams has to say so.
-#
-#     responses
-#       OpenAI's newer, stateful successor to chat completions.
-#
-#   A provider may serve FEWER of these than its protocol defines, never one
-#   the protocol has never heard of; the tests reject that. It is one claim for
-#   the whole provider, and a model cannot narrow it: a name that serves a
-#   different surface needs a provider entry of its own.
+#   base_url      Required. Any version prefix included, no trailing slash.
+#   env_api_key   Optional. The environment variable holding the API key. Omit
+#                 it if the provider has no key plumbing yet — a request routed
+#                 there then fails saying exactly that.
+#   protocol      Required. The wire format spoken. One of: openai_compat.
+#   models        The models routable under this provider.
 #
 # Model fields
 # ------------
-# - `model` is the name sent upstream on the wire. Defaults to the key's last
-#   segment, so set it only when warpllm's routing alias differs from the
-#   provider's actual model name.
-# - `capabilities` carries the published per-model limits, each optional:
-#   `max_input_tokens`, `max_output_tokens`, `max_concurrent_requests`. A model
-#   with none of them recorded is `{}` — it exists to make that name routable.
-# - Omit a capability you have not verified. Undocumented is NOT unlimited, so
-#   leaving a limit off is the honest answer, never a guess.
-# - Cite your source. Every value below traces to a public spec — don't
-#   invent per-model data, and split a model out only once a real,
-#   documented difference is confirmed.
+#   supported_apis  Required. Every surface this model serves, each written
+#                   `- {api: <surface>}`. A model serves exactly what it lists.
+#   model           Optional. The name sent upstream. Defaults to the key's
+#                   last segment; set it when warpllm's alias differs from the
+#                   provider's own name.
+#   capabilities    Optional, and so is each limit in it: max_input_tokens,
+#                   max_output_tokens, max_concurrent_requests.
+#
+# Surfaces
+# --------
+# Only list a surface warpllm implements. One it doesn't would load fine and
+# then refuse the request.
+#
+#   openai_chat_completions         One request, one whole reply. IMPLEMENTED.
+#   openai_chat_completions_stream  The same, streamed. Not implemented yet.
+#   openai_responses                OpenAI's Responses API. Not implemented yet.
+#
+# Rules the tests enforce
+# -----------------------
+# - Both maps stay in ascending key order: providers, and models within each.
+# - A model key starts with the provider it sits under — `openai/gpt-5.6` under
+#   `openai:`. The rest is the model name, and may contain further slashes.
+# - Only listed models are routable, and there is no wildcard: `openai/*`
+#   registers a model literally named `*`. An unlisted name is an error, never
+#   a guess at what was meant.
+# - Two providers may not share an `env_api_key`.
+# - A surface must be one its provider's protocol speaks, and may not repeat.
+# - Cite the provider's docs in a comment for anything you record. Undocumented
+#   is not unlimited — omit a limit rather than guess it.
 
 providers:
   # <https://api-docs.deepseek.com/api/create-chat-completion> (checked
-  # 2026-07-24).
+  # 2026-07-24). The legacy `deepseek-chat` / `deepseek-reasoner` names were
+  # discontinued 2026-07-24 and map to V4-Flash modes.
   deepseek:
     base_url: "https://api.deepseek.com"
     env_api_key: DEEPSEEK_API_KEY
     protocol: openai_compat
-    supported_apis:
-      - chat_completions
     models:
-      # The V4 pair; the legacy `deepseek-chat` / `deepseek-reasoner` names were
-      # discontinued 2026-07-24 and map to V4-Flash modes. The pair diverges on
-      # exactly one field: Flash serves 5x what Pro does.
       deepseek/deepseek-v4-flash:
+        supported_apis:
+          - {api: openai_chat_completions}
         capabilities:
           max_concurrent_requests: 2500
       deepseek/deepseek-v4-pro:
+        supported_apis:
+          - {api: openai_chat_completions}
         capabilities:
           max_concurrent_requests: 500
 
-  # <https://platform.openai.com/docs/api-reference>. API entries grow
-  # as warpllm implements them.
+  # <https://platform.openai.com/docs/api-reference>. These models also serve
+  # the Responses API; it is left off until warpllm implements that surface.
   openai:
     base_url: "https://api.openai.com/v1"
     env_api_key: OPENAI_API_KEY
     protocol: openai_compat
-    supported_apis:
-      - chat_completions
-      - responses
     models:
       # Sorts before the 5.6 family because `-` (0x2D) precedes `.` (0x2E).
-      openai/gpt-5-nano: {}
-      # The GPT-5.6 family. No published limits are recorded for it yet: these
-      # entries exist to make the four names routable. Add token limits and
-      # concurrency here once the numbers are in hand.
-      openai/gpt-5.6: {}
-      openai/gpt-5.6-luna: {}
-      openai/gpt-5.6-sol: {}
-      openai/gpt-5.6-terra: {}
+      openai/gpt-5-nano:
+        supported_apis:
+          - {api: openai_chat_completions}
+      # The GPT-5.6 family. No published limits recorded yet — add them here
+      # once the numbers are in hand.
+      openai/gpt-5.6:
+        supported_apis:
+          - {api: openai_chat_completions}
+      openai/gpt-5.6-luna:
+        supported_apis:
+          - {api: openai_chat_completions}
+      openai/gpt-5.6-sol:
+        supported_apis:
+          - {api: openai_chat_completions}
+      openai/gpt-5.6-terra:
+        supported_apis:
+          - {api: openai_chat_completions}
 
   # <https://openrouter.ai/docs/api-reference> (checked 2026-08-06).
+  #
+  # An aggregator, so each entry below is a curated pick from its catalog and
+  # there is no `openrouter/*` catch-all. OpenRouter's own identifier is a
+  # two-segment slug, which the key's last-segment default would truncate, so
+  # every entry sets `model:` to the full slug. Limits come from each model's
+  # OpenRouter page; it publishes no per-slug concurrency ceiling, only
+  # per-key rate limits on the caller's account.
   openrouter:
     base_url: "https://openrouter.ai/api/v1"
     env_api_key: OPENROUTER_API_KEY
     protocol: openai_compat
-    supported_apis:
-      - chat_completions
     models:
-      # OpenRouter is an AGGREGATOR: it routes to many models across vendors,
-      # each identified by its own slug (`anthropic/claude-sonnet-4`, …). The
-      # roster's closed-key rule therefore applies per slug — there is no
-      # `openrouter/*` catch-all, and adding a model you want routable is an
-      # entry here, exactly as under any other provider.
-      #
-      # The key repeats the vendor prefix (`openrouter/anthropic/…`) and the
-      # `model:` field ships the FULL slug upstream: OpenRouter's own identifier
-      # is the two-segment `anthropic/claude-sonnet-4`, which the key's
-      # last-segment default would truncate. Each entry below is a CURATED pick
-      # from the catalog, with the limits OpenRouter itself publishes on each
-      # model's page: what OpenRouter serves IS the vendor's model, so the
-      # input figure is OpenRouter's context window and the output figure its
-      # max generation. `max_concurrent_requests` is recorded for none of them —
-      # OpenRouter publishes no concurrency ceiling per slug, only per-key rate
-      # limits on the caller's own account.
-      #
-      # `openrouter/auto` is the exception that needs no `model:` field and can
-      # carry no limits: OpenRouter's own alias for letting IT pick the model
-      # for each request, so the wire name IS the key's last segment and both
-      # limits are the backend's, chosen per call.
-      #
-      # OpenRouter (checked 2026-08-07): 200K context, 32K max output.
+      # Checked 2026-08-07: 200K context, 32K max output.
       # <https://openrouter.ai/anthropic/claude-opus-4>
       openrouter/anthropic/claude-opus-4:
+        supported_apis:
+          - {api: openai_chat_completions}
         model: anthropic/claude-opus-4
         capabilities:
           max_input_tokens: 200000
           max_output_tokens: 32000
-      # OpenRouter (checked 2026-08-07): 1M context, 64K max output.
+      # Checked 2026-08-07: 1M context, 64K max output.
       # <https://openrouter.ai/anthropic/claude-sonnet-4>
       openrouter/anthropic/claude-sonnet-4:
+        supported_apis:
+          - {api: openai_chat_completions}
         model: anthropic/claude-sonnet-4
         capabilities:
           max_input_tokens: 1000000
           max_output_tokens: 64000
-      openrouter/auto: {}
-      # OpenRouter (checked 2026-08-07): 1M context, 65,536 max output.
+      # OpenRouter's alias for letting IT pick the model per request: the wire
+      # name is the key's last segment, and the limits are whichever backend
+      # it chooses.
+      openrouter/auto:
+        supported_apis:
+          - {api: openai_chat_completions}
+      # Checked 2026-08-07: 1M context, 65,536 max output.
       # <https://openrouter.ai/google/gemini-2.5-pro>
       openrouter/google/gemini-2.5-pro:
+        supported_apis:
+          - {api: openai_chat_completions}
         model: google/gemini-2.5-pro
         capabilities:
           max_input_tokens: 1048576
           max_output_tokens: 65536
-      # OpenRouter (checked 2026-08-07): `gpt-5.6` is OpenAI's alias that
-      # routes to `gpt-5.6-sol`, so the limits are Sol's as OpenRouter lists
-      # them: 1M context, 128K max output.
+      # Checked 2026-08-07: `gpt-5.6` is OpenAI's alias for `gpt-5.6-sol`, so
+      # these are Sol's limits — 1M context, 128K max output.
       # <https://openrouter.ai/openai/gpt-5.6-sol>
       openrouter/openai/gpt-5.6:
+        supported_apis:
+          - {api: openai_chat_completions}
         model: openai/gpt-5.6
         capabilities:
           max_input_tokens: 1050000
           max_output_tokens: 128000
-      # OpenRouter (checked 2026-08-07): the `~deepseek/…-latest` alias, which
-      # always redirects to the newest DeepSeek V4 Flash revision: 1M context,
-      # 64K max output.
+      # Checked 2026-08-07: the `~deepseek/…-latest` alias, always the newest
+      # DeepSeek V4 Flash revision — 1M context, 64K max output.
       # <https://openrouter.ai/~deepseek/deepseek-v4-flash-latest>
       openrouter/~deepseek/deepseek-v4-flash-latest:
+        supported_apis:
+          - {api: openai_chat_completions}
         model: ~deepseek/deepseek-v4-flash-latest
         capabilities:
           max_input_tokens: 1000000

--- a/crates/warpllm/src/registry/specs.yaml
+++ b/crates/warpllm/src/registry/specs.yaml
@@ -10,11 +10,10 @@
 #     openai:                                 # how the API is reached
 #       base_url: "https://api.openai.com/v1"
 #       env_api_key: OPENAI_API_KEY
-#       protocol: openai_compat
 #       models:
 #         openai/gpt-5.6:                     # what is routable, and what it does
 #           supported_apis:
-#             - {api: openai_chat_completions}
+#             - {api: openai_compat_chat_completions}
 #           model: gpt-5.6-2026-01-01         # optional
 #           capabilities:                     # optional
 #             max_input_tokens: 400000
@@ -28,7 +27,6 @@
 #   env_api_key   Optional. The environment variable holding the API key. Omit
 #                 it if the provider has no key plumbing yet — a request routed
 #                 there then fails saying exactly that.
-#   protocol      Required. The wire format spoken. One of: openai_compat.
 #   models        The models routable under this provider.
 #
 # Model fields
@@ -43,12 +41,19 @@
 #
 # Surfaces
 # --------
+# A surface name is `<protocol>_<endpoint>`, so it says which wire format it is
+# spoken in — the only place this file records one. A provider entry names no
+# protocol; its models do, once each per surface.
+#
 # Only list a surface warpllm implements. One it doesn't would load fine and
 # then refuse the request.
 #
-#   openai_chat_completions         One request, one whole reply. IMPLEMENTED.
-#   openai_chat_completions_stream  The same, streamed. Not implemented yet.
-#   openai_responses                OpenAI's Responses API. Not implemented yet.
+#   openai_compat_chat_completions         One request, one whole reply.
+#                                          IMPLEMENTED.
+#   openai_compat_chat_completions_stream  The same, streamed. Not implemented
+#                                          yet.
+#   openai_compat_responses                OpenAI's Responses API. Not
+#                                          implemented yet.
 #
 # Rules the tests enforce
 # -----------------------
@@ -59,7 +64,7 @@
 #   registers a model literally named `*`. An unlisted name is an error, never
 #   a guess at what was meant.
 # - Two providers may not share an `env_api_key`.
-# - A surface must be one its provider's protocol speaks, and may not repeat.
+# - A model may not list the same surface twice.
 # - Cite the provider's docs in a comment for anything you record. Undocumented
 #   is not unlimited — omit a limit rather than guess it.
 
@@ -70,16 +75,15 @@ providers:
   deepseek:
     base_url: "https://api.deepseek.com"
     env_api_key: DEEPSEEK_API_KEY
-    protocol: openai_compat
     models:
       deepseek/deepseek-v4-flash:
         supported_apis:
-          - {api: openai_chat_completions}
+          - {api: openai_compat_chat_completions}
         capabilities:
           max_concurrent_requests: 2500
       deepseek/deepseek-v4-pro:
         supported_apis:
-          - {api: openai_chat_completions}
+          - {api: openai_compat_chat_completions}
         capabilities:
           max_concurrent_requests: 500
 
@@ -88,26 +92,25 @@ providers:
   openai:
     base_url: "https://api.openai.com/v1"
     env_api_key: OPENAI_API_KEY
-    protocol: openai_compat
     models:
       # Sorts before the 5.6 family because `-` (0x2D) precedes `.` (0x2E).
       openai/gpt-5-nano:
         supported_apis:
-          - {api: openai_chat_completions}
+          - {api: openai_compat_chat_completions}
       # The GPT-5.6 family. No published limits recorded yet — add them here
       # once the numbers are in hand.
       openai/gpt-5.6:
         supported_apis:
-          - {api: openai_chat_completions}
+          - {api: openai_compat_chat_completions}
       openai/gpt-5.6-luna:
         supported_apis:
-          - {api: openai_chat_completions}
+          - {api: openai_compat_chat_completions}
       openai/gpt-5.6-sol:
         supported_apis:
-          - {api: openai_chat_completions}
+          - {api: openai_compat_chat_completions}
       openai/gpt-5.6-terra:
         supported_apis:
-          - {api: openai_chat_completions}
+          - {api: openai_compat_chat_completions}
 
   # <https://openrouter.ai/docs/api-reference> (checked 2026-08-06).
   #
@@ -120,13 +123,12 @@ providers:
   openrouter:
     base_url: "https://openrouter.ai/api/v1"
     env_api_key: OPENROUTER_API_KEY
-    protocol: openai_compat
     models:
       # Checked 2026-08-07: 200K context, 32K max output.
       # <https://openrouter.ai/anthropic/claude-opus-4>
       openrouter/anthropic/claude-opus-4:
         supported_apis:
-          - {api: openai_chat_completions}
+          - {api: openai_compat_chat_completions}
         model: anthropic/claude-opus-4
         capabilities:
           max_input_tokens: 200000
@@ -135,7 +137,7 @@ providers:
       # <https://openrouter.ai/anthropic/claude-sonnet-4>
       openrouter/anthropic/claude-sonnet-4:
         supported_apis:
-          - {api: openai_chat_completions}
+          - {api: openai_compat_chat_completions}
         model: anthropic/claude-sonnet-4
         capabilities:
           max_input_tokens: 1000000
@@ -145,12 +147,12 @@ providers:
       # it chooses.
       openrouter/auto:
         supported_apis:
-          - {api: openai_chat_completions}
+          - {api: openai_compat_chat_completions}
       # Checked 2026-08-07: 1M context, 65,536 max output.
       # <https://openrouter.ai/google/gemini-2.5-pro>
       openrouter/google/gemini-2.5-pro:
         supported_apis:
-          - {api: openai_chat_completions}
+          - {api: openai_compat_chat_completions}
         model: google/gemini-2.5-pro
         capabilities:
           max_input_tokens: 1048576
@@ -160,7 +162,7 @@ providers:
       # <https://openrouter.ai/openai/gpt-5.6-sol>
       openrouter/openai/gpt-5.6:
         supported_apis:
-          - {api: openai_chat_completions}
+          - {api: openai_compat_chat_completions}
         model: openai/gpt-5.6
         capabilities:
           max_input_tokens: 1050000
@@ -170,7 +172,7 @@ providers:
       # <https://openrouter.ai/~deepseek/deepseek-v4-flash-latest>
       openrouter/~deepseek/deepseek-v4-flash-latest:
         supported_apis:
-          - {api: openai_chat_completions}
+          - {api: openai_compat_chat_completions}
         model: ~deepseek/deepseek-v4-flash-latest
         capabilities:
           max_input_tokens: 1000000

--- a/crates/warpllm/src/registry/testing.rs
+++ b/crates/warpllm/src/registry/testing.rs
@@ -1,25 +1,25 @@
 //! Roster fixtures shared by the three modules' tests.
 //!
-//! Here rather than duplicated because the line numbers matter: [`PROVIDER`]
-//! is nine lines and ends on its `models:` key, so a case that appends model
-//! entries knows its first one lands on line 10 — which is what the sort
-//! check's error message is asserted against.
+//! Here rather than duplicated because the line numbers matter, and because
+//! `supported_apis` is required of every model: a case that only needs a
+//! routable name says [`model`] rather than spelling out three lines of
+//! surface it has no opinion about.
 
 use super::load::load;
 use super::types::Registry;
 
-/// One provider serving two APIs, with no models yet — the base most cases
-/// diverge from. Cases append their own model entries, already indented six
-/// spaces, so appended keys start at line 10.
+/// One provider with no models yet — the base most cases diverge from.
+///
+/// Six lines, ending on its `models:` key, so a case that appends entries
+/// knows its first key lands on line 7 — which is what the sort check's error
+/// message is asserted against. A [`model`] entry is three lines, so the
+/// second key lands on line 10.
 pub(super) const PROVIDER: &str = "\
 providers:
   demo:
     base_url: \"https://api.demo.test/v1\"
     env_api_key: DEMO_API_KEY
     protocol: openai_compat
-    supported_apis:
-      - chat_completions
-      - responses
     models:
 ";
 
@@ -34,11 +34,33 @@ pub(super) const OTHER_PROVIDER: &str = "  other:
     base_url: \"https://api.other.test\"
     env_api_key: OTHER_API_KEY
     protocol: openai_compat
-    supported_apis:
-      - chat_completions
     models:
-      other/plain: {}
+      other/plain:
+        supported_apis:
+          - {api: openai_chat_completions}
 ";
+
+/// The one line every model entry must carry, indented to sit under a key at
+/// six spaces.
+///
+/// `supported_apis` is required and inherits nothing, so there is no such
+/// thing as a bare `demo/plain: {}` any more. Cases that have no opinion about
+/// surfaces say so through [`model`] rather than repeating this.
+pub(super) const CHAT: &str =
+    "        supported_apis:\n          - {api: openai_chat_completions}\n";
+
+/// The minimal valid entry for `key`: it serves chat completions and says
+/// nothing else.
+pub(super) fn model(key: &str) -> String {
+    format!("      {key}:\n{CHAT}")
+}
+
+/// The minimal valid entries for several keys, in the order given — which is
+/// the order they will appear in the file, so a case testing the sort check
+/// can hand them over deliberately unsorted.
+pub(super) fn models(keys: &[&str]) -> String {
+    keys.iter().map(|key| model(key)).collect()
+}
 
 pub(super) fn with(models: &str) -> String {
     format!("{PROVIDER}{models}")

--- a/crates/warpllm/src/registry/testing.rs
+++ b/crates/warpllm/src/registry/testing.rs
@@ -10,16 +10,15 @@ use super::types::Registry;
 
 /// One provider with no models yet — the base most cases diverge from.
 ///
-/// Six lines, ending on its `models:` key, so a case that appends entries
-/// knows its first key lands on line 7 — which is what the sort check's error
+/// Five lines, ending on its `models:` key, so a case that appends entries
+/// knows its first key lands on line 6 — which is what the sort check's error
 /// message is asserted against. A [`model`] entry is three lines, so the
-/// second key lands on line 10.
+/// second key lands on line 9.
 pub(super) const PROVIDER: &str = "\
 providers:
   demo:
     base_url: \"https://api.demo.test/v1\"
     env_api_key: DEMO_API_KEY
-    protocol: openai_compat
     models:
 ";
 
@@ -33,11 +32,10 @@ providers:
 pub(super) const OTHER_PROVIDER: &str = "  other:
     base_url: \"https://api.other.test\"
     env_api_key: OTHER_API_KEY
-    protocol: openai_compat
     models:
       other/plain:
         supported_apis:
-          - {api: openai_chat_completions}
+          - {api: openai_compat_chat_completions}
 ";
 
 /// The one line every model entry must carry, indented to sit under a key at
@@ -47,7 +45,7 @@ pub(super) const OTHER_PROVIDER: &str = "  other:
 /// thing as a bare `demo/plain: {}` any more. Cases that have no opinion about
 /// surfaces say so through [`model`] rather than repeating this.
 pub(super) const CHAT: &str =
-    "        supported_apis:\n          - {api: openai_chat_completions}\n";
+    "        supported_apis:\n          - {api: openai_compat_chat_completions}\n";
 
 /// The minimal valid entry for `key`: it serves chat completions and says
 /// nothing else.

--- a/crates/warpllm/src/registry/types.rs
+++ b/crates/warpllm/src/registry/types.rs
@@ -1,11 +1,17 @@
 //! What the registry holds, and how a caller reads it.
 //!
 //! Two levels, two types, because they answer two questions. A
-//! [`ProviderSpec`] is how an API is reached and what it serves — one host,
-//! one credential, one wire format, one list of surfaces. A [`ModelSpec`] is
-//! one routable name under that provider, carrying only what differs between
-//! models of the same one. [`crate::fetch_model`] hands back one of each and
-//! merges nothing.
+//! [`ProviderSpec`] is how an API is reached: one host, one credential, one
+//! wire format. A [`ModelSpec`] is one routable name under that provider,
+//! carrying what differs between models of the same one — its limits, and
+//! which API surfaces it serves. [`crate::fetch_model`] hands back one of each
+//! and merges nothing.
+//!
+//! `supported_apis` is the MODEL's, and only the model's. A provider is a
+//! host, not a capability: one host commonly serves chat completions,
+//! embeddings, and moderation from three disjoint sets of models, so a
+//! provider-level list could only ever be their union — true of the host and
+//! false of every model under it.
 //!
 //! These are READ SURFACES, not the YAML schema: `load` next door owns the
 //! schema and does the settling, which is why nothing here is an `Option`
@@ -39,19 +45,18 @@ pub(crate) struct Registry {
     pub(crate) models: HashMap<String, ModelSpec>,
 }
 
-/// One provider: where its API is, how to authenticate, what protocol it
-/// speaks, and which surfaces it serves.
+/// One provider: where its API is, how to authenticate, and what protocol it
+/// speaks.
 ///
-/// Everything here is true of every model the provider serves. What varies
-/// per model is in [`ModelSpec`], and the split is what keeps a provider's
-/// transport stated exactly once.
+/// Transport, and nothing else. Everything here is true of every model the
+/// provider serves, which is what keeps it stated exactly once — and it is why
+/// what a model can DO is not here.
 #[derive(Debug, Clone)]
 pub struct ProviderSpec {
     pub(crate) name: String,
     pub(crate) base_url: String,
     pub(crate) env_api_key: Option<String>,
     pub(crate) protocol: Protocol,
-    pub(crate) supported_apis: Vec<Api>,
 }
 
 impl ProviderSpec {
@@ -83,28 +88,14 @@ impl ProviderSpec {
     pub fn protocol(&self) -> Protocol {
         self.protocol
     }
-
-    /// The API surfaces this provider serves — never empty, since a provider
-    /// that served nothing could not be routed to and would fail to load.
-    pub fn supported_apis(&self) -> &[Api] {
-        &self.supported_apis
-    }
-
-    /// Whether this provider serves `api`.
-    ///
-    /// Each variant is its own claim: a provider declaring
-    /// [`Api::ChatCompletions`] has said nothing about
-    /// [`Api::ChatCompletionsStream`].
-    pub fn supports_api(&self, api: Api) -> bool {
-        self.supported_apis.contains(&api)
-    }
 }
 
-/// One routable model: the name it ships upstream, and its published limits.
+/// One routable model: the name it ships upstream, the surfaces it serves,
+/// and its published limits.
 ///
-/// Deliberately thin. Everything shared with the provider's other models
-/// lives in [`ProviderSpec`], so an entry here is only what makes this model
-/// different from its siblings — which for most models is nothing at all.
+/// Deliberately thin. The transport lives in [`ProviderSpec`], so an entry
+/// here is only what makes this model different from its siblings — which for
+/// most models is nothing at all.
 #[derive(Debug, Clone)]
 pub struct ModelSpec {
     /// The provider serving this model — the key its [`ProviderSpec`] is
@@ -114,6 +105,10 @@ pub struct ModelSpec {
     /// last segment, so it differs only when warpllm's routing alias differs
     /// from the provider's own model name.
     pub(crate) model: String,
+    /// Every surface this model serves, written out in the roster. Required
+    /// and never inherited: a model that says nothing serves nothing, which is
+    /// a load failure rather than a silent claim on everything its host does.
+    pub(crate) supported_apis: Vec<SupportedApi>,
     pub(crate) capabilities: Capabilities,
 }
 
@@ -128,9 +123,69 @@ impl ModelSpec {
         &self.model
     }
 
+    /// Every surface this model serves, with what the roster records about
+    /// each, in the order the file lists them. Never empty.
+    ///
+    /// Each names its protocol as well as its surface, so a model answering
+    /// the same idea in two wire formats lists both and nothing has to decide
+    /// they are the same thing.
+    pub fn supported_apis(&self) -> &[SupportedApi] {
+        &self.supported_apis
+    }
+
+    /// This model's entry for `api`, or `None` if it does not serve it. The
+    /// gate a request passes before it is routed anywhere.
+    ///
+    /// Hands back the ENTRY rather than a `bool` so that a caller asking
+    /// whether the model serves something already holds what the roster
+    /// records about serving it — the shape that survives
+    /// [`SupportedApi`] gaining fields.
+    ///
+    /// One method for every surface, rather than one method each: [`Api`]
+    /// carries no payload, so it can simply be passed in.
+    pub fn supported_api(&self, api: Api) -> Option<&SupportedApi> {
+        self.supported_apis.iter().find(|entry| entry.api == api)
+    }
+
+    /// Whether this model serves `api` at all.
+    pub fn supports_api(&self, api: Api) -> bool {
+        self.supported_api(api).is_some()
+    }
+
     /// What this model's published limits are.
     pub fn capabilities(&self) -> &Capabilities {
         &self.capabilities
+    }
+}
+
+/// One entry in a model's `supported_apis`: a surface it serves, and what the
+/// roster records about serving it.
+///
+/// Written `- {api: openai_chat_completions}`. The surface is a field rather
+/// than the entry's own shape, and that is the whole design: a field added here
+/// belongs to EVERY surface at once. `input_modalities` recorded per-surface
+/// would otherwise mean three payload types to add it to and keep in step, with
+/// nothing to catch the one that was missed.
+///
+/// Carries only `api` today. An entry is therefore one key wide, which is why
+/// the roster writes it on one line.
+///
+/// A YAML schema in its own right, like [`Capabilities`] and for the same
+/// reason: it maps one-to-one onto what the file writes, with nothing to
+/// settle, so a second struct to deserialize into would be a copy to keep in
+/// step. `deny_unknown_fields` is what turns a contributor's `apis:` typo into
+/// an error rather than an entry that quietly names no surface.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct SupportedApi {
+    pub(crate) api: Api,
+}
+
+impl SupportedApi {
+    /// Which surface this entry is about.
+    pub fn api(&self) -> Api {
+        self.api
     }
 }
 

--- a/crates/warpllm/src/registry/types.rs
+++ b/crates/warpllm/src/registry/types.rs
@@ -1,17 +1,22 @@
 //! What the registry holds, and how a caller reads it.
 //!
 //! Two levels, two types, because they answer two questions. A
-//! [`ProviderSpec`] is how an API is reached: one host, one credential, one
-//! wire format. A [`ModelSpec`] is one routable name under that provider,
-//! carrying what differs between models of the same one — its limits, and
-//! which API surfaces it serves. [`crate::fetch_model`] hands back one of each
-//! and merges nothing.
+//! [`ProviderSpec`] is how an API is reached: one host and one credential. A
+//! [`ModelSpec`] is one routable name under that provider, carrying what
+//! differs between models of the same one — its limits, and which API surfaces
+//! it serves. [`crate::fetch_model`] hands back one of each and merges nothing.
 //!
 //! `supported_apis` is the MODEL's, and only the model's. A provider is a
 //! host, not a capability: one host commonly serves chat completions,
 //! embeddings, and moderation from three disjoint sets of models, so a
 //! provider-level list could only ever be their union — true of the host and
 //! false of every model under it.
+//!
+//! Which WIRE FORMAT is spoken is the model's too, by the same argument and
+//! one step further: an [`Api`] names its own protocol, so a provider-level
+//! field could only restate what every surface under it already says, or
+//! contradict it. A host is free to serve one model over one protocol and its
+//! neighbour over another, and nothing here has to be taught that.
 //!
 //! These are READ SURFACES, not the YAML schema: `load` next door owns the
 //! schema and does the settling, which is why nothing here is an `Option`
@@ -29,7 +34,7 @@
 
 use std::collections::HashMap;
 
-use crate::types::{Api, Protocol};
+use crate::types::Api;
 
 /// The resolved roster: providers, and every routable `model_str` under them.
 ///
@@ -45,18 +50,16 @@ pub(crate) struct Registry {
     pub(crate) models: HashMap<String, ModelSpec>,
 }
 
-/// One provider: where its API is, how to authenticate, and what protocol it
-/// speaks.
+/// One provider: where its API is, and how to authenticate.
 ///
 /// Transport, and nothing else. Everything here is true of every model the
 /// provider serves, which is what keeps it stated exactly once — and it is why
-/// what a model can DO is not here.
+/// what a model can DO, and which wire format that is spoken in, are not here.
 #[derive(Debug, Clone)]
 pub struct ProviderSpec {
     pub(crate) name: String,
     pub(crate) base_url: String,
     pub(crate) env_api_key: Option<String>,
-    pub(crate) protocol: Protocol,
 }
 
 impl ProviderSpec {
@@ -82,11 +85,6 @@ impl ProviderSpec {
     /// variable nothing reads.
     pub fn env_api_key(&self) -> Option<&str> {
         self.env_api_key.as_deref()
-    }
-
-    /// The wire format this provider speaks.
-    pub fn protocol(&self) -> Protocol {
-        self.protocol
     }
 }
 
@@ -128,7 +126,8 @@ impl ModelSpec {
     ///
     /// Each names its protocol as well as its surface, so a model answering
     /// the same idea in two wire formats lists both and nothing has to decide
-    /// they are the same thing.
+    /// they are the same thing. It is also the only place the roster records a
+    /// wire format at all.
     pub fn supported_apis(&self) -> &[SupportedApi] {
         &self.supported_apis
     }
@@ -161,7 +160,7 @@ impl ModelSpec {
 /// One entry in a model's `supported_apis`: a surface it serves, and what the
 /// roster records about serving it.
 ///
-/// Written `- {api: openai_chat_completions}`. The surface is a field rather
+/// Written `- {api: openai_compat_chat_completions}`. The surface is a field rather
 /// than the entry's own shape, and that is the whole design: a field added here
 /// belongs to EVERY surface at once. `input_modalities` recorded per-surface
 /// would otherwise mean three payload types to add it to and keep in step, with

--- a/crates/warpllm/src/types.rs
+++ b/crates/warpllm/src/types.rs
@@ -1,17 +1,27 @@
 //! The vocabulary three layers agree on: which wire format a provider speaks,
-//! and which API surfaces it serves.
+//! and which API surfaces a model serves.
 //!
 //! These live above both [`crate::protocol`] and [`crate::gateway`] rather than
 //! inside either, because both need them and neither owns them. [`Protocol`]
 //! names a protocol, keys the gateway `ext` bags, and is the word the registry
-//! YAML uses; [`Api`] names a surface and is the module path that implements it.
-//! Filing them under the protocol layer would make the canonical forms in
-//! `gateway::types` — which are supposed to be protocol-neutral — reach into the
-//! module tree that defines the protocols to name their own bag keys.
+//! YAML uses; [`Api`] names one protocol's surface and is the module path that
+//! implements it. Filing them under the protocol layer would make the canonical
+//! forms in `gateway::types` — which are supposed to be protocol-neutral — reach
+//! into the module tree that defines the protocols to name their own bag keys.
 //!
-//! Vocabulary, not data: the shapes that cross the wire are
-//! `protocol::<name>::<api>::types`, and their canonical counterparts are
-//! `gateway::types`. What is here is fieldless by nature — names, not payloads.
+//! # An [`Api`] names its protocol
+//!
+//! `openai_chat_completions`, not `chat_completions`. The surface alone is
+//! ambiguous the moment a second protocol serves something comparable: chat
+//! completions and Anthropic's messages are the same idea in two wire formats,
+//! and a model may well serve both. Qualifying the name is what lets one model
+//! list `openai_chat_completions` and `anthropic_messages` side by side without
+//! either the roster or this enum having to decide they are the same thing.
+//!
+//! [`Api`] itself is a bare name. What a roster records ABOUT a surface lives
+//! on [`crate::SupportedApi`], one struct holding every surface's fields — so a
+//! field like `input_modalities` is declared once and every surface has it,
+//! rather than being added to three payloads and kept in step by hand.
 
 /// How a provider's wire protocol is spoken. One variant per wire format,
 /// not per provider — the exhaustive `match` in `client.rs` stays small
@@ -50,64 +60,84 @@ impl Protocol {
             Protocol::OpenAiCompat => "openai_compat",
         }
     }
-
-    /// The APIs this wire format defines.
-    ///
-    /// A registry entry naming an API its protocol does not serve is a
-    /// protocol mismatch, which is what `registry::lint` reads this for.
-    /// Widening a protocol's surface is an edit here — not in the roster.
-    ///
-    /// While `OpenAiCompat` is the only protocol and serves every [`Api`],
-    /// that lint cannot fail; it earns its keep the moment a protocol lands
-    /// that serves a subset, which is why it is written now rather than
-    /// retrofitted then.
-    ///
-    /// `cfg(test)` because that lint is its only reader, and the lint itself
-    /// is test-only. Nothing on a request path consults this: a spec carries
-    /// its OWN api list, already checked against this one.
-    #[cfg(test)]
-    pub(crate) fn apis(self) -> &'static [Api] {
-        match self {
-            Protocol::OpenAiCompat => &[
-                Api::ChatCompletions,
-                Api::ChatCompletionsStream,
-                Api::Responses,
-            ],
-        }
-    }
 }
 
-/// One API surface a provider can serve, as named in a registry provider's
-/// `supported_apis`.
+/// One API surface a model can serve — the `api:` of an entry in a registry
+/// model's `supported_apis`.
 ///
-/// A capability, not a URL: two protocols can serve the same API at different
-/// paths, so the path belongs to the protocol module that implements it. Being
-/// an enum is what makes a misspelling fail to LOAD rather than 404 against a
-/// live provider at request time.
+/// A capability, not a URL: the path a surface is reached at belongs to the
+/// protocol module implementing it. Being an enum is what makes a misspelling
+/// fail to LOAD rather than 404 against a live provider at request time.
 ///
-/// The snake_case name is also the module name that implements the API, so
-/// `chat_completions` is reached at `protocol::openai_compat::chat_completions`
-/// and `gateway::openai_compat::api::chat_completions`, and the two cannot
-/// drift from the variant by a rename.
+/// A bare name, carrying nothing. What the roster records about a surface is
+/// [`crate::SupportedApi`]'s, so that a field belongs to every surface at once
+/// — see this module's own docs. The name is also the module path that
+/// implements it, so `openai_chat_completions` is reached at
+/// `protocol::openai_compat::chat_completions`, and the two cannot drift by a
+/// rename.
+///
+/// The renames are spelled out rather than derived for the same reason
+/// [`Protocol`]'s is: `rename_all = "snake_case"` reads the camel hump in
+/// `OpenAi` and would give `open_ai_chat_completions`. `api_names_match_serde`
+/// pins every one of them.
 ///
 /// `non_exhaustive` for the same reason as [`Protocol`]: this exists to grow
 /// as warpllm implements more of each provider's surface, and without it every
 /// downstream `match` would break on a release that adds one.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize)]
 #[non_exhaustive]
-#[serde(rename_all = "snake_case")]
 pub enum Api {
-    /// Chat completions: one request, one whole reply. The only surface
-    /// warpllm serves today.
-    ChatCompletions,
-    /// Chat completions asked to stream, delivering the reply as incremental
-    /// chunks.
+    /// Chat completions as OpenAI-compatible providers speak them: one
+    /// request, one whole reply. The only surface warpllm serves today.
+    #[serde(rename = "openai_chat_completions")]
+    OpenAiChatCompletions,
+    /// The same request asked to stream, delivered as incremental chunks.
     ///
-    /// Separate from [`Api::ChatCompletions`] because a model can serve one
-    /// without the other, so declaring that one never implies this one.
-    ChatCompletionsStream,
+    /// Separate from [`Api::OpenAiChatCompletions`] because a model can serve
+    /// one without the other, so declaring that one never implies this one.
+    #[serde(rename = "openai_chat_completions_stream")]
+    OpenAiChatCompletionsStream,
     /// OpenAI's newer, stateful successor to chat completions.
-    Responses,
+    #[serde(rename = "openai_responses")]
+    OpenAiResponses,
+}
+
+impl Api {
+    /// This surface's name as a string: the spelling the registry YAML uses,
+    /// and the one an error names it by.
+    ///
+    /// One source of truth for that string, so a message cannot drift from the
+    /// roster line a reader would go and fix — `Debug` would say
+    /// `OpenAiChatCompletions`, which appears nowhere a contributor can act on.
+    /// `api_names_match_serde` pins it to the `serde(rename)` above, which
+    /// matters because both are hand-written.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Api::OpenAiChatCompletions => "openai_chat_completions",
+            Api::OpenAiChatCompletionsStream => "openai_chat_completions_stream",
+            Api::OpenAiResponses => "openai_responses",
+        }
+    }
+
+    /// The protocol this surface is spoken in — read off the variant, which
+    /// names it.
+    ///
+    /// The inverse of the list [`Protocol`] used to carry, and the better
+    /// direction: a surface belongs to exactly one protocol, while a protocol
+    /// serves many. `registry::lint` reads it to hold a model's surfaces
+    /// against the provider serving them.
+    ///
+    /// `cfg(test)` because that lint is its only reader and is itself
+    /// test-only. Nothing on a request path consults it — dispatch reads the
+    /// provider's own [`Protocol`].
+    #[cfg(test)]
+    pub(crate) fn protocol(self) -> Protocol {
+        match self {
+            Api::OpenAiChatCompletions
+            | Api::OpenAiChatCompletionsStream
+            | Api::OpenAiResponses => Protocol::OpenAiCompat,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -115,8 +145,53 @@ mod tests {
     use super::*;
 
     /// Every variant, for the checks below. A new protocol goes here — the
-    /// same standing obligation [`Protocol::apis`] carries.
+    /// same standing obligation [`Api::protocol`] carries in the other
+    /// direction.
     const ALL: &[Protocol] = &[Protocol::OpenAiCompat];
+
+    /// Every surface, so a new variant has one place to be added for the
+    /// checks below to cover it.
+    const EVERY_API: &[(&str, Api)] = &[
+        ("openai_chat_completions", Api::OpenAiChatCompletions),
+        (
+            "openai_chat_completions_stream",
+            Api::OpenAiChatCompletionsStream,
+        ),
+        ("openai_responses", Api::OpenAiResponses),
+    ];
+
+    /// The roster spells these by hand, and so do the `serde(rename)` on each
+    /// variant and [`Api::as_str`]. All three are the same string by contract,
+    /// so a rename that touches one and not the others has to fail here rather
+    /// than as an "unknown variant" against a contributor's perfectly good
+    /// roster line — or, worse, as an error message naming a surface that
+    /// appears nowhere in the file.
+    #[test]
+    fn api_names_match_serde() {
+        for &(name, expected) in EVERY_API {
+            let parsed: Api = serde_json::from_value(serde_json::json!(name))
+                .unwrap_or_else(|e| panic!("`api: {name}` is what the roster writes: {e}"));
+            assert_eq!(parsed, expected, "`{name}` deserialized to something else");
+            assert_eq!(parsed.as_str(), name, "`{name}` renders as something else");
+            // The variant names its own protocol, which is the whole reason
+            // the surface is spelled with a prefix.
+            assert_eq!(parsed.protocol(), Protocol::OpenAiCompat, "`{name}`");
+        }
+    }
+
+    /// A surface warpllm has never heard of fails to parse, which is what
+    /// keeps a misspelling out of the roster. The message names the whole
+    /// vocabulary so the line can be fixed without opening this file.
+    #[test]
+    fn an_unknown_surface_is_rejected() {
+        let err = serde_json::from_value::<Api>(serde_json::json!("anthropic_messages"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unknown variant"), "{err}");
+        for (known, _) in EVERY_API {
+            assert!(err.contains(known), "vocabulary missing {known}: {err}");
+        }
+    }
 
     /// [`Protocol::as_str`] keys the ext bags; the `serde(rename)` keys the
     /// registry YAML. They are the same string by contract, and hand-written

--- a/crates/warpllm/src/types.rs
+++ b/crates/warpllm/src/types.rs
@@ -1,22 +1,27 @@
-//! The vocabulary three layers agree on: which wire format a provider speaks,
-//! and which API surfaces a model serves.
+//! The vocabulary for API surfaces, and the wire formats they are spoken in.
 //!
-//! These live above both [`crate::protocol`] and [`crate::gateway`] rather than
-//! inside either, because both need them and neither owns them. [`Protocol`]
-//! names a protocol, keys the gateway `ext` bags, and is the word the registry
-//! YAML uses; [`Api`] names one protocol's surface and is the module path that
-//! implements it. Filing them under the protocol layer would make the canonical
-//! forms in `gateway::types` — which are supposed to be protocol-neutral — reach
-//! into the module tree that defines the protocols to name their own bag keys.
+//! [`Api`] is what the registry YAML writes and what an entrypoint gates on:
+//! one surface a model serves. It lives here rather than under
+//! [`crate::protocol`] because the `gateway` layer's canonical forms — which
+//! are supposed to be protocol-neutral — would otherwise reach into the module
+//! tree that defines the protocols in order to name a surface.
+//!
+//! `Protocol` is the smaller thing, and crate-internal: a wire format's name,
+//! used inside `gateway` to key the `ext` passthrough bags and to record what a
+//! value was ingested from. The roster no longer mentions it — a surface names
+//! its own protocol, so recording it a second time on the provider could only
+//! ever restate or contradict.
 //!
 //! # An [`Api`] names its protocol
 //!
-//! `openai_chat_completions`, not `chat_completions`. The surface alone is
-//! ambiguous the moment a second protocol serves something comparable: chat
+//! `openai_compat_chat_completions`, not `chat_completions`. The surface alone
+//! is ambiguous the moment a second protocol serves something comparable: chat
 //! completions and Anthropic's messages are the same idea in two wire formats,
 //! and a model may well serve both. Qualifying the name is what lets one model
-//! list `openai_chat_completions` and `anthropic_messages` side by side without
-//! either the roster or this enum having to decide they are the same thing.
+//! list `openai_compat_chat_completions` and `anthropic_messages` side by side
+//! without either the roster or this enum having to decide they are the same
+//! thing — and it is the only place the roster now says which wire format is in
+//! play.
 //!
 //! [`Api`] itself is a bare name. What a roster records ABOUT a surface lives
 //! on [`crate::SupportedApi`], one struct holding every surface's fields — so a
@@ -24,37 +29,37 @@
 //! rather than being added to three payloads and kept in step by hand.
 
 /// How a provider's wire protocol is spoken. One variant per wire format,
-/// not per provider — the exhaustive `match` in `client.rs` stays small
-/// forever while adding a model is one entry in the registry YAML. A provider
-/// that diverges from its protocol is handled in that protocol's conversions,
-/// never with a variant of its own.
+/// not per provider — a provider that diverges from its protocol is handled in
+/// that protocol's conversions, never with a variant of its own.
+///
+/// Crate-internal, and read only by [`crate::gateway`]: it keys the `ext`
+/// passthrough bags and tags an ingested value with the format it came from.
+/// A caller reaches a surface through [`Api`], which names its protocol, so
+/// there is nothing left for a public [`Protocol`] to answer.
+///
+/// Not deserialized from anything. The roster used to write `protocol:
+/// openai_compat` on every provider; [`Api`] carries that now, so this is a tag
+/// the code constructs rather than a value a file supplies.
 ///
 /// `non_exhaustive` because this enum exists to grow: a new wire format is a
-/// normal addition, and without it every downstream `match` would break on a
-/// release that adds one. Inside warpllm the attribute has no effect, so the
-/// crate's own matches stay exhaustive and a new variant still fails to
-/// compile until every arm handles it.
-///
-/// The `rename` is spelled out rather than derived: `rename_all =
-/// "snake_case"` reads the camel hump in `OpenAi` and produces
-/// `open_ai_compat`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+/// normal addition. Inside warpllm the attribute has no effect, so the crate's
+/// own matches stay exhaustive and a new variant still fails to compile until
+/// every arm handles it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
-pub enum Protocol {
+pub(crate) enum Protocol {
     /// The OpenAI-compatible chat completions wire format, implemented at
     /// [`crate::protocol::openai_compat`].
-    #[serde(rename = "openai_compat")]
     OpenAiCompat,
 }
 
 impl Protocol {
-    /// This protocol's name as a string: the spelling the registry YAML uses,
-    /// and the key its passthrough fields are filed under in the gateway
-    /// `ext` bags.
+    /// This protocol's name as a string: the key its passthrough fields are
+    /// filed under in the gateway `ext` bags, and the provenance an ingested
+    /// value carries.
     ///
-    /// One source of truth for that string, so the YAML vocabulary and the ext
-    /// namespace cannot drift apart — `protocol_name_matches_serde` pins them
-    /// together, which matters because the `serde(rename)` above is hand-written.
+    /// One source of truth for that string, so the three call sites that key a
+    /// bag cannot drift apart.
     pub(crate) fn as_str(self) -> &'static str {
         match self {
             Protocol::OpenAiCompat => "openai_compat",
@@ -72,34 +77,37 @@ impl Protocol {
 /// A bare name, carrying nothing. What the roster records about a surface is
 /// [`crate::SupportedApi`]'s, so that a field belongs to every surface at once
 /// — see this module's own docs. The name is also the module path that
-/// implements it, so `openai_chat_completions` is reached at
+/// implements it, so `openai_compat_chat_completions` is reached at
 /// `protocol::openai_compat::chat_completions`, and the two cannot drift by a
 /// rename.
 ///
-/// The renames are spelled out rather than derived for the same reason
-/// [`Protocol`]'s is: `rename_all = "snake_case"` reads the camel hump in
-/// `OpenAi` and would give `open_ai_chat_completions`. `api_names_match_serde`
-/// pins every one of them.
+/// The renames are spelled out rather than derived: `rename_all = "snake_case"`
+/// reads the camel hump in `OpenAiCompat` and would give
+/// `open_ai_compat_chat_completions`. `api_names_match_serde` pins every one of
+/// them.
 ///
-/// `non_exhaustive` for the same reason as [`Protocol`]: this exists to grow
-/// as warpllm implements more of each provider's surface, and without it every
-/// downstream `match` would break on a release that adds one.
+/// `non_exhaustive` because this exists to grow as warpllm implements more of
+/// each provider's surface, and without it every downstream `match` would break
+/// on a release that adds one. Inside warpllm the attribute has no effect, so
+/// the crate's own matches stay exhaustive and a new variant still fails to
+/// compile until every arm handles it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize)]
 #[non_exhaustive]
 pub enum Api {
     /// Chat completions as OpenAI-compatible providers speak them: one
     /// request, one whole reply. The only surface warpllm serves today.
-    #[serde(rename = "openai_chat_completions")]
-    OpenAiChatCompletions,
+    #[serde(rename = "openai_compat_chat_completions")]
+    OpenAiCompatChatCompletions,
     /// The same request asked to stream, delivered as incremental chunks.
     ///
-    /// Separate from [`Api::OpenAiChatCompletions`] because a model can serve
-    /// one without the other, so declaring that one never implies this one.
-    #[serde(rename = "openai_chat_completions_stream")]
-    OpenAiChatCompletionsStream,
+    /// Separate from [`Api::OpenAiCompatChatCompletions`] because a model can
+    /// serve one without the other, so declaring that one never implies this
+    /// one.
+    #[serde(rename = "openai_compat_chat_completions_stream")]
+    OpenAiCompatChatCompletionsStream,
     /// OpenAI's newer, stateful successor to chat completions.
-    #[serde(rename = "openai_responses")]
-    OpenAiResponses,
+    #[serde(rename = "openai_compat_responses")]
+    OpenAiCompatResponses,
 }
 
 impl Api {
@@ -108,34 +116,14 @@ impl Api {
     ///
     /// One source of truth for that string, so a message cannot drift from the
     /// roster line a reader would go and fix — `Debug` would say
-    /// `OpenAiChatCompletions`, which appears nowhere a contributor can act on.
-    /// `api_names_match_serde` pins it to the `serde(rename)` above, which
-    /// matters because both are hand-written.
+    /// `OpenAiCompatChatCompletions`, which appears nowhere a contributor can
+    /// act on. `api_names_match_serde` pins it to the `serde(rename)` above,
+    /// which matters because both are hand-written.
     pub(crate) fn as_str(self) -> &'static str {
         match self {
-            Api::OpenAiChatCompletions => "openai_chat_completions",
-            Api::OpenAiChatCompletionsStream => "openai_chat_completions_stream",
-            Api::OpenAiResponses => "openai_responses",
-        }
-    }
-
-    /// The protocol this surface is spoken in — read off the variant, which
-    /// names it.
-    ///
-    /// The inverse of the list [`Protocol`] used to carry, and the better
-    /// direction: a surface belongs to exactly one protocol, while a protocol
-    /// serves many. `registry::lint` reads it to hold a model's surfaces
-    /// against the provider serving them.
-    ///
-    /// `cfg(test)` because that lint is its only reader and is itself
-    /// test-only. Nothing on a request path consults it — dispatch reads the
-    /// provider's own [`Protocol`].
-    #[cfg(test)]
-    pub(crate) fn protocol(self) -> Protocol {
-        match self {
-            Api::OpenAiChatCompletions
-            | Api::OpenAiChatCompletionsStream
-            | Api::OpenAiResponses => Protocol::OpenAiCompat,
+            Api::OpenAiCompatChatCompletions => "openai_compat_chat_completions",
+            Api::OpenAiCompatChatCompletionsStream => "openai_compat_chat_completions_stream",
+            Api::OpenAiCompatResponses => "openai_compat_responses",
         }
     }
 }
@@ -144,20 +132,29 @@ impl Api {
 mod tests {
     use super::*;
 
-    /// Every variant, for the checks below. A new protocol goes here — the
-    /// same standing obligation [`Api::protocol`] carries in the other
-    /// direction.
-    const ALL: &[Protocol] = &[Protocol::OpenAiCompat];
-
-    /// Every surface, so a new variant has one place to be added for the
-    /// checks below to cover it.
-    const EVERY_API: &[(&str, Api)] = &[
-        ("openai_chat_completions", Api::OpenAiChatCompletions),
+    /// Every surface with the protocol it is spoken in, so a new variant has
+    /// one place to be added for the checks below to cover it.
+    ///
+    /// The protocol is test data rather than a method on [`Api`]: nothing on a
+    /// request path asks which protocol a surface belongs to — an entrypoint
+    /// knows its own — so the mapping exists only to hold the naming
+    /// convention below.
+    const EVERY_API: &[(&str, Api, Protocol)] = &[
         (
-            "openai_chat_completions_stream",
-            Api::OpenAiChatCompletionsStream,
+            "openai_compat_chat_completions",
+            Api::OpenAiCompatChatCompletions,
+            Protocol::OpenAiCompat,
         ),
-        ("openai_responses", Api::OpenAiResponses),
+        (
+            "openai_compat_chat_completions_stream",
+            Api::OpenAiCompatChatCompletionsStream,
+            Protocol::OpenAiCompat,
+        ),
+        (
+            "openai_compat_responses",
+            Api::OpenAiCompatResponses,
+            Protocol::OpenAiCompat,
+        ),
     ];
 
     /// The roster spells these by hand, and so do the `serde(rename)` on each
@@ -168,14 +165,27 @@ mod tests {
     /// appears nowhere in the file.
     #[test]
     fn api_names_match_serde() {
-        for &(name, expected) in EVERY_API {
+        for &(name, expected, _) in EVERY_API {
             let parsed: Api = serde_json::from_value(serde_json::json!(name))
                 .unwrap_or_else(|e| panic!("`api: {name}` is what the roster writes: {e}"));
             assert_eq!(parsed, expected, "`{name}` deserialized to something else");
             assert_eq!(parsed.as_str(), name, "`{name}` renders as something else");
-            // The variant names its own protocol, which is the whole reason
-            // the surface is spelled with a prefix.
-            assert_eq!(parsed.protocol(), Protocol::OpenAiCompat, "`{name}`");
+        }
+    }
+
+    /// Every surface names the protocol it is spoken in, which is the whole
+    /// reason the roster no longer records one per provider. With the
+    /// provider-level field gone, the name is the ONLY place a reader learns
+    /// the wire format — so a variant that dropped the prefix would leave the
+    /// roster saying nothing about it at all.
+    #[test]
+    fn every_api_name_carries_its_protocol() {
+        for &(name, _, protocol) in EVERY_API {
+            assert!(
+                name.starts_with(protocol.as_str()),
+                "`{name}` does not name `{}`, the protocol it is spoken in",
+                protocol.as_str()
+            );
         }
     }
 
@@ -188,27 +198,8 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("unknown variant"), "{err}");
-        for (known, _) in EVERY_API {
+        for (known, _, _) in EVERY_API {
             assert!(err.contains(known), "vocabulary missing {known}: {err}");
-        }
-    }
-
-    /// [`Protocol::as_str`] keys the ext bags; the `serde(rename)` keys the
-    /// registry YAML. They are the same string by contract, and hand-written
-    /// in two places — so a rename that touches one and not the other has to
-    /// fail here rather than in a passthrough field that silently stops
-    /// round-tripping.
-    #[test]
-    fn protocol_name_matches_serde() {
-        for &protocol in ALL {
-            let from_name: Protocol =
-                serde_json::from_value(serde_json::json!(protocol.as_str())).unwrap();
-            assert_eq!(
-                from_name,
-                protocol,
-                "{} deserializes to something else",
-                protocol.as_str()
-            );
         }
     }
 }


### PR DESCRIPTION
Closes #11.

Two commits. Both are breaking, and both fold into the **unreleased** 0.2.0 — `main` carries that version but it was never tagged or published, so the registries still serve 0.1.4 and there is no migration to write for anyone but a fork.

### 1. `supported_apis` moves onto the model

A provider is a host, not a capability. One host commonly serves chat completions, embeddings, and moderation from three disjoint sets of models, so a provider-level list could only ever be their union — true of the host and false of every model under it. Mistral is the case that forced it, publishing per-model capabilities against one base URL.

It is now **required and inherits nothing**. Silence is a load failure rather than a silent claim on everything the host serves, which would fail open: an embeddings model would be admitted to a chat request and discover the truth as a 404 upstream.

`serves_chat_completions` becomes `validate_api(model, api, …)`, parameterized on the surface so the second entrypoint reuses it and no refusal can name the wrong surface. `openai_responses` leaves the roster — there is no code behind it, so an entry claiming it would record a capability nothing can act on.

### 2. `protocol:` leaves the roster

An `Api` already names the wire format it is spoken in, so a model listing a surface is by definition saying it accepts that protocol's body at that endpoint. The provider field could only restate that or contradict it — and it had the wrong shape besides, since a host is free to serve one model over one protocol and its neighbour over another.

The surfaces are renamed `openai_compat_*` to match. With `protocol:` gone the word `openai_compat` would otherwise appear nowhere in the roster, and `openai_chat_completions` reads as the `openai:` *provider's* chat completions rather than the OpenAI-*compatible* protocol's. It also makes the name the module path for the first time: `openai_compat_chat_completions` is served at `protocol::openai_compat::chat_completions`.

Falling out of that:

* `lint::serves` loses its provider argument — with no protocol recorded there is nothing left to disagree with, which is the point.
* `client.rs` loses its `match provider.protocol()`. The surface the entrypoint gates on *is* the choice of module; a second protocol arrives as a second entrypoint rather than an arm here.
* `Protocol` stays as `gateway`'s ext-namespace tag and is now `pub(crate)` — nothing public returns one.

### The resulting shape

```yaml
  deepseek:
    base_url: "https://api.deepseek.com"
    env_api_key: DEEPSEEK_API_KEY
    models:
      deepseek/deepseek-v4-flash:
        supported_apis:
          - {api: openai_compat_chat_completions}
        capabilities:
          max_concurrent_requests: 2500
```

One deliberate divergence from the sketch in #11: the entry is `- {api: <surface>}` rather than a surface-keyed map with the settings nested under it. Both express the same thing today, but the flat form means a field like `input_modalities` is declared **once**, on `SupportedApi`, and belongs to every surface at once — instead of being added to three payload types and kept in step by hand, with nothing to catch the one that was missed. (Modalities remain out of scope here, as the issue says.)

### Migration

A fork's roster will be stale in both ways at once, so each fails loudly rather than silently:

* a leftover `protocol:` line is rejected by `deny_unknown_fields`;
* `api: openai_chat_completions` fails as an unknown variant, and the message names the new vocabulary.

### Verification

Everything CI runs, green: `cargo fmt --check`, `clippy --workspace --all-targets -D warnings`, 222 Rust tests across 12 suites, 18 pytest, 14 vitest. `cargo run -p warpllm-codegen` is a no-op — no wire type changed, so the generated Python and TypeScript are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
