### PR TITLE
Put a runnable quickstart at the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,94 @@ A warp-speed, robust AI gateway written for rust, node, and python applications 
 [![PyPI](https://img.shields.io/pypi/v/warpllm?logo=pypi&logoColor=white&label=PyPI)](https://pypi.org/project/warpllm/)
 [![npm](https://img.shields.io/npm/v/%40warpllm%2Fwarpllm?logo=npm&label=npm)](https://www.npmjs.com/package/@warpllm/warpllm)
 
+## Quickstart
+
+```bash
+pip install warpllm              # python
+npm install @warpllm/warpllm     # node
+cargo add warpllm                # rust
+```
+
+```bash
+export OPENAI_API_KEY=sk-...
+```
+
+**Python**
+
+```python
+from warpllm import WarpLLM
+
+client = WarpLLM()
+
+completion = client.chat_completions({
+    "model": "openai/gpt-5-nano",
+    "messages": [{"role": "user", "content": "Hello!"}],
+})
+
+print(completion["choices"][0]["message"]["content"])
+```
+
+**Node**
+
+```ts
+import { WarpLLM } from '@warpllm/warpllm'
+
+const client = new WarpLLM()
+
+const completion = await client.chatCompletions({
+  model: 'openai/gpt-5-nano',
+  messages: [{ role: 'user', content: 'Hello!' }],
+})
+
+console.log(completion.choices[0].message.content)
+```
+
+**Rust** — `chat_completions` is `async` and warpllm ships no runtime, so bring
+your own: `cargo add tokio --features macros,rt-multi-thread`.
+
+```rust
+use warpllm::{ChatCompletionRequestMessage, Client, ClientConfig, CreateChatCompletionRequest};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new(ClientConfig::default())?;
+
+    let completion = client
+        .chat_completions(CreateChatCompletionRequest {
+            model: "openai/gpt-5-nano".to_string(),
+            messages: vec![ChatCompletionRequestMessage {
+                role: "user".to_string(),
+                content: "Hello!".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        })
+        .await?;
+
+    let content = completion.choices[0].message.content.as_deref();
+    println!("{}", content.unwrap_or_default());
+    Ok(())
+}
+```
+
+### Switching providers is a string change
+
+Keys are read from the environment when the client is built, so export the one
+the provider needs and change the model string. Nothing else moves.
+
+| Model string | Key it needs |
+| --- | --- |
+| `openai/gpt-5-nano` | `OPENAI_API_KEY` |
+| `deepseek/deepseek-v4-flash` | `DEEPSEEK_API_KEY` |
+| `openrouter/anthropic/claude-sonnet-4` | `OPENROUTER_API_KEY` |
+
+The `provider/` prefix is required. warpllm matches the whole string against its
+roster, so a bare `gpt-5-nano` — or any name it doesn't know — is an error
+rather than a guess at an upstream default.
+
+Runnable versions of all three, with comments, are in
+[`examples/`](examples/).
+
 ## Mission
 
 This project is to lay out the most resilient open source productionization layer for AI-deployments. Designed for you if you want:
@@ -32,14 +120,6 @@ This project is to lay out the most resilient open source productionization laye
 >
 > The OpenAI-compatible HTTP gateway has landed on `main` but is **not
 > released yet**. Streaming is not implemented.
-
-Install the published SDK:
-
-```bash
-cargo add warpllm                # rust
-pip install warpllm              # python
-npm install @warpllm/warpllm     # node
-```
 
 | | Released (0.2.0) | On `main` |
 | --- | --- | --- |


### PR DESCRIPTION
The README said what warpllm is and how to install it, then never showed a call. Someone landing on the repo had to open `examples/` to find out what using it looks like.

Quickstart now sits directly under the badges — install, export a key, one complete chat completion in each language — followed by the table that makes the case:

| Model string | Key it needs |
| --- | --- |
| `openai/gpt-5-nano` | `OPENAI_API_KEY` |
| `deepseek/deepseek-v4-flash` | `DEEPSEEK_API_KEY` |
| `openrouter/anthropic/claude-sonnet-4` | `OPENROUTER_API_KEY` |

The code is lifted from `examples/` rather than written fresh, so the two cannot drift into disagreeing about the API.

## Verified against the published packages

Not against the working tree — against what a reader actually installs. Each block was extracted from `README.md` programmatically and run as-is, so what executed is byte-for-byte what someone copies:

| | Installed | Result |
|---|---|---|
| Python | `warpllm` 0.2.0 (PyPI) | `Hi there! How can I help today?…` |
| Node | `@warpllm/warpllm` 0.2.0 (npm) | `Hello! Nice to meet you. What would you like help with today?…` |
| Rust | `warpllm` 0.2.0 (crates.io) | `Hello! Nice to meet you. How can I help you today?…` |

All exit 0. The documented rejection of bare model names was checked too:

```
BadRequestError: invalid model string 'gpt-5-nano': no registered model spec
```

Not verified: the DeepSeek and OpenRouter rows. Their model strings match the roster, but no key for either provider was available, so neither has seen a live call.

## Rust and tokio

The tokio dependency moved out of the install block to sit beside the Rust snippet, with the reason attached — `chat_completions` is `async` and the crate ships no runtime. Features are narrowed to the two that are required, `macros` and `rt-multi-thread`, replacing `full`.

Bare `cargo add tokio` compiles today as well, but only because Cargo unifies features and warpllm's own dep enables `macros`/`rt-multi-thread`. warpllm needs `macros` solely for its tests and examples, so trimming it later would break every downstream quickstart with a confusing "cannot find attribute `main`". Not documented for that reason.

## Also

Drops the install block that was buried under **Status**, now that Quickstart owns it and two copies would drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
