### PR TITLE
Register OpenAI's chat-completion models, and record deprecation dates

### DIFF
--- a/crates/warpllm/src/client.rs
+++ b/crates/warpllm/src/client.rs
@@ -195,6 +195,7 @@ mod tests {
             model: "demo-embed".into(),
             supported_apis,
             capabilities: Capabilities::blank(),
+            deprecation_date: None,
         }))
     }
 
@@ -365,6 +366,7 @@ mod tests {
                 api: Api::OpenAiCompatChatCompletions,
             }],
             capabilities: Capabilities::blank(),
+            deprecation_date: None,
         }));
         let client = client(ClientConfig::default());
         let request = CreateChatCompletionRequest {

--- a/crates/warpllm/src/registry/load.rs
+++ b/crates/warpllm/src/registry/load.rs
@@ -72,6 +72,7 @@ struct ModelEntry {
     /// not want.
     #[serde(default = "Capabilities::blank")]
     capabilities: Capabilities,
+    deprecation_date: Option<String>,
 }
 
 /// Reads the roster into the provider and model tables.
@@ -126,6 +127,7 @@ fn build(key: &str, provider: &str, entry: ModelEntry) -> Result<ModelSpec, Stri
         model: entry.model.unwrap_or_else(|| name.to_string()),
         supported_apis: entry.supported_apis,
         capabilities: entry.capabilities,
+        deprecation_date: entry.deprecation_date,
     })
 }
 
@@ -244,6 +246,18 @@ mod tests {
         assert_eq!(spec.model(), "plain");
         assert_eq!(spec.capabilities().max_input_tokens(), None);
         assert_eq!(spec.capabilities().max_concurrent_requests(), None);
+        assert_eq!(spec.deprecation_date(), None);
+    }
+
+    /// A recorded retirement reaches the spec verbatim. Nothing else reads the
+    /// field, so this is what keeps it from silently ceasing to load.
+    #[test]
+    fn a_deprecation_date_is_read_when_present() {
+        let registry = clean(&with(&format!(
+            "      demo/plain:\n{CHAT}        deprecation_date: \"2026-10-23\"\n"
+        )));
+        let spec = registry.models.get("demo/plain").unwrap();
+        assert_eq!(spec.deprecation_date(), Some("2026-10-23"));
     }
 
     /// Limits are per model and nothing else is: the shipped V4 pair is two

--- a/crates/warpllm/src/registry/mod.rs
+++ b/crates/warpllm/src/registry/mod.rs
@@ -224,11 +224,24 @@ mod tests {
             vec![
                 "deepseek/deepseek-v4-flash",
                 "deepseek/deepseek-v4-pro",
+                "openai/gpt-4.1",
+                "openai/gpt-4.1-mini",
+                "openai/gpt-4o",
+                "openai/gpt-4o-mini",
+                "openai/gpt-5",
+                "openai/gpt-5-mini",
                 "openai/gpt-5-nano",
+                "openai/gpt-5.1",
+                "openai/gpt-5.2",
+                "openai/gpt-5.4",
+                "openai/gpt-5.4-mini",
+                "openai/gpt-5.4-nano",
+                "openai/gpt-5.5",
                 "openai/gpt-5.6",
                 "openai/gpt-5.6-luna",
                 "openai/gpt-5.6-sol",
                 "openai/gpt-5.6-terra",
+                "openai/o3",
                 "openrouter/anthropic/claude-opus-4",
                 "openrouter/anthropic/claude-sonnet-4",
                 "openrouter/auto",
@@ -366,9 +379,13 @@ mod tests {
 
     /// The registry is closed: an unlisted name is an error, not a fallback.
     /// `openai/*` is in the list because a pattern matches nothing either.
+    ///
+    /// `openai/gpt-5-pro` is real upstream and still rejected here: it serves
+    /// the Responses API and not chat completions, so the roster leaves it out
+    /// rather than register a name every request would fail on.
     #[test]
     fn unregistered_models_are_rejected() {
-        for model_str in ["openai/gpt-4o", "deepseek/deepseek-v5", "openai/*"] {
+        for model_str in ["openai/gpt-5-pro", "deepseek/deepseek-v5", "openai/*"] {
             let msg = fetch_model(model_str).unwrap_err().to_string();
             assert!(msg.contains(model_str), "{msg}");
             assert!(msg.contains("no registered model spec"), "{msg}");

--- a/crates/warpllm/src/registry/specs.yaml
+++ b/crates/warpllm/src/registry/specs.yaml
@@ -31,18 +31,37 @@
 #
 # Model fields
 # ------------
-#   supported_apis  Required. Every surface this model serves, each written
-#                   `- {api: <surface>}`. A model serves exactly what it lists.
-#   model           Optional. The name sent upstream. Defaults to the key's
-#                   last segment; set it when warpllm's alias differs from the
-#                   provider's own name.
-#   capabilities    Optional, and so is each limit in it: max_input_tokens,
-#                   max_output_tokens, max_concurrent_requests.
-#                   `max_input_tokens` is the provider's context window, taken
-#                   verbatim. A provider's own "maximum input tokens" is
-#                   usually the window minus its output ceiling; the window is
-#                   what belongs here, since a completion may spend far fewer
-#                   output tokens than the ceiling allows.
+#   supported_apis    Required. Every surface this model serves, each written
+#                     `- {api: <surface>}`. A model serves exactly what it
+#                     lists.
+#   model             Optional. The name sent upstream. Defaults to the key's
+#                     last segment; set it when warpllm's alias differs from
+#                     the provider's own name.
+#   deprecation_date  Optional, `YYYY-MM-DD`. The day the provider stops
+#                     serving this model, when one has been announced. Where a
+#                     provider publishes two dates — the announcement, and the
+#                     later day access ends — record the second: a deprecated
+#                     model still answers, and the day routing to it breaks is
+#                     the one worth having. Absent is the ordinary case and
+#                     means nothing is scheduled, never that the model is
+#                     permanent.
+#
+#                     Nothing acts on it: an entry keeps resolving past its
+#                     date, and removing it is a deliberate edit. The value is
+#                     taken as written and never checked against a calendar.
+#
+#                     Look for it on the provider's DEPRECATIONS page, not the
+#                     model's own page. OpenAI's model pages say nothing about
+#                     a retirement even when one is weeks away, so a new entry
+#                     checked only against its model page will look healthy and
+#                     be dead on arrival.
+#   capabilities      Optional, and so is each limit in it: max_input_tokens,
+#                     max_output_tokens, max_concurrent_requests.
+#                     `max_input_tokens` is the provider's context window,
+#                     taken verbatim. A provider's own "maximum input tokens"
+#                     is usually the window minus its output ceiling; the
+#                     window is what belongs here, since a completion may spend
+#                     far fewer output tokens than the ceiling allows.
 #
 # Surfaces
 # --------
@@ -104,9 +123,12 @@ providers:
           max_output_tokens: 384000
           max_concurrent_requests: 500
 
-  # <https://developers.openai.com/api/docs/models> (checked 2026-08-09). These
-  # models also serve the Responses API; it is left off until warpllm
-  # implements that surface.
+  # <https://developers.openai.com/api/docs/models/all> (checked 2026-08-11).
+  # Every model below was confirmed on its own model page to mark
+  # `v1/chat/completions` supported; each entry carries that page's link.
+  #
+  # They also serve the Responses API; it is left off until warpllm implements
+  # that surface.
   #
   # The windows below are OpenAI's context windows. The "maximum input tokens"
   # shown beside each one is that window minus the model's output ceiling, so
@@ -115,17 +137,130 @@ providers:
   # No `max_concurrent_requests` anywhere below: OpenAI documents throughput as
   # per-account tier rate limits, not a per-model ceiling on requests in
   # flight.
+  #
+  # Deliberately absent, each checked on its own model page 2026-08-11:
+  # - Models whose page marks `v1/chat/completions` "Not supported" — they
+  #   serve the Responses API instead: gpt-5-pro, gpt-5.2-pro, gpt-5.3-codex,
+  #   gpt-5.4-pro, gpt-5.5-pro, o3-pro. Note the pinned `openai` SDK's
+  #   `ChatModel` union disagrees and lists gpt-5.2-pro; the docs are the
+  #   source of truth, and the SDK is only an oracle.
+  # - Gated behind the Daybreak programme, and not on chat completions either:
+  #   daybreak-blue-latest, daybreak-red-latest, gpt-5.6-cyber.
+  # - Open-weight downloads rather than anything api.openai.com serves:
+  #   gpt-oss-120b, gpt-oss-20b.
+  # - Everything on a surface warpllm has no `api:` for: embeddings,
+  #   moderation, images, audio, realtime, and legacy completions.
+  # - Models already deprecated: gpt-4.1-nano and o4-mini both stop serving
+  #   2026-10-23, and OpenAI names gpt-5.6-luna and gpt-5.6-terra as the
+  #   replacements. Registering a name that breaks within the quarter would be
+  #   handing callers a migration; both replacements are below. Neither model's
+  #   own page mentions it — the deprecations page is the only place it
+  #   appears.
+  #   <https://developers.openai.com/api/docs/deprecations>
+  # - chat-latest. It serves chat completions, but OpenAI moves the snapshot
+  #   underneath it and points production traffic at GPT-5.6 instead, so the
+  #   limits recorded here would go stale without the file changing.
+  # - OpenAI's deprecated roster, and dated snapshots such as
+  #   gpt-5-2025-08-07. The aliases below are what callers name.
   openai:
     base_url: "https://api.openai.com/v1"
     env_api_key: OPENAI_API_KEY
     models:
-      # Sorts before the 5.6 family because `-` (0x2D) precedes `.` (0x2E).
+      # The 4.1 family, both sharing one pair of limits. The window is
+      # 1,047,576 rather than a round million, and is recorded as published.
+      # <https://developers.openai.com/api/docs/models/gpt-4.1>
+      openai/gpt-4.1:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        capabilities:
+          max_input_tokens: 1047576
+          max_output_tokens: 32768
+      # <https://developers.openai.com/api/docs/models/gpt-4.1-mini>
+      openai/gpt-4.1-mini:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        capabilities:
+          max_input_tokens: 1047576
+          max_output_tokens: 32768
+      # <https://developers.openai.com/api/docs/models/gpt-4o>
+      openai/gpt-4o:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        capabilities:
+          max_input_tokens: 128000
+          max_output_tokens: 16384
+      # <https://developers.openai.com/api/docs/models/gpt-4o-mini>
+      openai/gpt-4o-mini:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        capabilities:
+          max_input_tokens: 128000
+          max_output_tokens: 16384
+      # The GPT-5 family. These sort before the 5.1+ entries because `-`
+      # (0x2D) precedes `.` (0x2E).
+      # <https://developers.openai.com/api/docs/models/gpt-5>
+      openai/gpt-5:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        capabilities:
+          max_input_tokens: 400000
+          max_output_tokens: 128000
+      # <https://developers.openai.com/api/docs/models/gpt-5-mini>
+      openai/gpt-5-mini:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        capabilities:
+          max_input_tokens: 400000
+          max_output_tokens: 128000
       # <https://developers.openai.com/api/docs/models/gpt-5-nano>
       openai/gpt-5-nano:
         supported_apis:
           - {api: openai_compat_chat_completions}
         capabilities:
           max_input_tokens: 400000
+          max_output_tokens: 128000
+      # <https://developers.openai.com/api/docs/models/gpt-5.1>
+      openai/gpt-5.1:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        capabilities:
+          max_input_tokens: 400000
+          max_output_tokens: 128000
+      # <https://developers.openai.com/api/docs/models/gpt-5.2>
+      openai/gpt-5.2:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        capabilities:
+          max_input_tokens: 400000
+          max_output_tokens: 128000
+      # 5.4 carries the larger window; its mini and nano do not.
+      # <https://developers.openai.com/api/docs/models/gpt-5.4>
+      openai/gpt-5.4:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        capabilities:
+          max_input_tokens: 1050000
+          max_output_tokens: 128000
+      # <https://developers.openai.com/api/docs/models/gpt-5.4-mini>
+      openai/gpt-5.4-mini:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        capabilities:
+          max_input_tokens: 400000
+          max_output_tokens: 128000
+      # <https://developers.openai.com/api/docs/models/gpt-5.4-nano>
+      openai/gpt-5.4-nano:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        capabilities:
+          max_input_tokens: 400000
+          max_output_tokens: 128000
+      # <https://developers.openai.com/api/docs/models/gpt-5.5>
+      openai/gpt-5.5:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        capabilities:
+          max_input_tokens: 1050000
           max_output_tokens: 128000
       # The GPT-5.6 family, all three sharing one pair of limits. `gpt-5.6` is
       # OpenAI's alias for Sol rather than a model of its own, so it is
@@ -158,6 +293,15 @@ providers:
         capabilities:
           max_input_tokens: 1050000
           max_output_tokens: 128000
+      # The last o-series model here: o4-mini shuts down, and every `-pro`
+      # sibling serves the Responses API instead.
+      # <https://developers.openai.com/api/docs/models/o3>
+      openai/o3:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        capabilities:
+          max_input_tokens: 200000
+          max_output_tokens: 100000
 
   # <https://openrouter.ai/docs/api-reference> (checked 2026-08-06).
   #

--- a/crates/warpllm/src/registry/types.rs
+++ b/crates/warpllm/src/registry/types.rs
@@ -108,6 +108,15 @@ pub struct ModelSpec {
     /// a load failure rather than a silent claim on everything its host does.
     pub(crate) supported_apis: Vec<SupportedApi>,
     pub(crate) capabilities: Capabilities,
+    /// The day the provider stops serving this model, `YYYY-MM-DD`, when one
+    /// has been announced.
+    ///
+    /// Where a provider publishes two dates — the day it announces the
+    /// deprecation and the later day access actually ends — this holds the
+    /// second. A deprecated model still answers, so the date worth recording
+    /// is the one after which routing to it breaks. `None` is the ordinary
+    /// case and means nothing is scheduled, never that the model is permanent.
+    pub(crate) deprecation_date: Option<String>,
 }
 
 impl ModelSpec {
@@ -130,6 +139,17 @@ impl ModelSpec {
     /// wire format at all.
     pub fn supported_apis(&self) -> &[SupportedApi] {
         &self.supported_apis
+    }
+
+    /// The day the provider stops serving this model, `YYYY-MM-DD`, or `None`
+    /// when the roster records no scheduled retirement.
+    ///
+    /// Nothing acts on it: routing does not consult it, and a model whose date
+    /// has passed still resolves. The string is whatever the roster wrote —
+    /// the loader does not check it against a calendar — so a caller reading
+    /// it parses it.
+    pub fn deprecation_date(&self) -> Option<&str> {
+        self.deprecation_date.as_deref()
     }
 
     /// This model's entry for `api`, or `None` if it does not serve it. The


### PR DESCRIPTION
Registers the OpenAI models warpllm can actually route, and records where a
retirement has been announced.

## The models

13 added, bringing the OpenAI roster to 18. Every one was checked on its own
model page for whether it marks `v1/chat/completions` supported, and every
entry links the page it came from.

| Window | Models | Max output |
|---|---|---|
| 1,050,000 | gpt-5.4, gpt-5.5, gpt-5.6 (+ luna, sol, terra) | 128,000 |
| 1,047,576 | gpt-4.1, gpt-4.1-mini | 32,768 |
| 400,000 | gpt-5, -mini, -nano, gpt-5.1, gpt-5.2, gpt-5.4-mini, -nano | 128,000 |
| 200,000 | o3 | 100,000 |
| 128,000 | gpt-4o, gpt-4o-mini | 16,384 |

`gpt-4.1`'s window is 1,047,576, not a round million — recorded as published.
All values are context windows verbatim, per the file's existing rule.

## What is deliberately absent, and why

The roster fails closed, so an absence is a decision. The file now records
each one:

- **`v1/chat/completions` marked "Not supported"** — these serve the Responses
  API instead: `gpt-5-pro`, `gpt-5.2-pro`, `gpt-5.3-codex`, `gpt-5.4-pro`,
  `gpt-5.5-pro`, `o3-pro`.
- **Gated behind the Daybreak programme**, and not on chat completions either:
  `daybreak-blue-latest`, `daybreak-red-latest`, `gpt-5.6-cyber`.
- **Open-weight downloads**, not served by api.openai.com: `gpt-oss-120b`,
  `gpt-oss-20b`.
- **Surfaces warpllm has no `api:` for**: embeddings, moderation, images,
  audio, realtime, legacy completions.
- **`chat-latest`** — it does serve chat completions, but OpenAI moves the
  snapshot underneath it, so any limits recorded here go stale silently.
- **Already deprecated**: `gpt-4.1-nano` and `o4-mini` both stop serving
  **2026-10-23**, replaced by gpt-5.6-luna and gpt-5.6-terra. See below — this
  one is the reason the PR touches `ModelSpec` at all.
- OpenAI's deprecated roster, and dated snapshots like `gpt-5-2025-08-07`.

Worth flagging: the pinned `openai` SDK's `ChatModel` union lists
`gpt-5.2-pro` as a chat model, and the docs say it is Responses-only. Trusting
the SDK would have registered a name every request 404s on. The docs are the
source of truth and the SDK is an oracle — that is now written at the entry.

## `deprecation_date`

`gpt-4.1-nano` and `o4-mini` were on the verified list and are not in the
roster, because both stop serving **2026-10-23**. Neither model page says so —
only the deprecations page carries it, which means a model checked against its
own page alone can look healthy and be dead on arrival. Registering a name
that breaks within the quarter is handing callers a migration, so they are
left out rather than carried with a date; both replacements are in the roster
already.

That near-miss is what `deprecation_date` exists for. `ModelSpec` gains it as
an optional `YYYY-MM-DD`, for the entry warpllm does decide to live with:

```yaml
openai/some-model:
  supported_apis:
    - {api: openai_compat_chat_completions}
  deprecation_date: "2027-04-01"
```

Where a provider publishes two dates — the day it announces the deprecation
and the later day access ends — the field holds the second. A deprecated model
still answers, so the day routing to it breaks is the one worth having.

**Nothing acts on it.** Routing does not consult it, the loader takes the
string as written and never checks it against a calendar, and no entry in the
shipped roster carries one — dropping those two models took the only
candidates with them.

So two things are true and worth knowing rather than discovering:
`deprecation_date: "soon"` loads fine, meaning anything that reads the field
parses defensively or brings its own format check; and the field's one test
asserts only that a date written in the roster reaches
`ModelSpec::deprecation_date()` verbatim, which keeps it from silently ceasing
to load.

## Tests

- `deprecation_date` round-trips from the roster into the spec, and is `None`
  on an entry that omits it.
- The shipped-roster test lists all 32 keys, as it did before.
- `unregistered_models_are_rejected` used `openai/gpt-4o` as its unlisted
  example, which this PR registers. It now uses `openai/gpt-5-pro`: real
  upstream, deliberately absent here, so the test documents why fail-closed
  rejects it rather than just that it does.

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
and `cargo test --workspace` (236 passed, 1 ignored) are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
