### PR TITLE
Add Kimi to the provider roster, direct and through OpenRouter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,31 @@ Everything under "Changed" is breaking, so this releases as `0.3.0`.
 
 ### Added
 
+- **Kimi, and the rest of OpenAI's chat-completion roster.** A new `kimi`
+  provider, reached at `api.moonshot.ai` with `MOONSHOT_API_KEY`, serving
+  `kimi/kimi-k3`, `kimi/kimi-k2.6`, and the two `kimi-k2.7-code` variants —
+  plus `kimi-k3`, `kimi-k2.6` and `kimi-k2.7-code` through OpenRouter, added
+  to that provider's curated set. On the OpenAI side the roster grows from
+  five models to eighteen: the 4.1 and 4o families, GPT-5 through 5.5, and
+  o3.
+
+  Every entry was checked against the provider's own model page for whether it
+  actually serves chat completions, and its context window taken from wherever
+  the provider publishes an exact figure — for Kimi that is the pricing page,
+  since the model list rounds to "1M" and "256k". OpenRouter entries record
+  the narrowest limit any endpoint behind the slug offers, since a slug fans
+  out across every host serving those weights and an unpinned request may land
+  on any of them. Models that serve only OpenAI's Responses API, that are
+  gated, or that the provider has already scheduled for retirement are
+  deliberately absent, and `specs.yaml` records which and why rather than
+  leaving the gap to be guessed at.
+
+- **`deprecation_date` on a model entry**, `YYYY-MM-DD`, recording the day a
+  provider stops serving a model, and readable in Rust through
+  `ModelSpec::deprecation_date()`. Nothing acts on it: routing does not consult
+  it, and the loader takes the string as written without checking it against a
+  calendar.
+
 - **`CreateChatCompletionStreamResponse`**, the reply shape for a chat
   completion requested with `stream: true`, in all three languages. The request
   is unchanged — `CreateChatCompletionRequest` already carries `stream` — but
@@ -28,6 +53,19 @@ Everything under "Changed" is breaking, so this releases as `0.3.0`.
   No transport yet: nothing in the SDK returns one of these. This settles the
   shape, and its generated Python and Node types, so the client work has
   something fixed to build against.
+
+### Fixed
+
+- **`openrouter/anthropic/claude-sonnet-4` recorded a 1,000,000 token context
+  window it could not guarantee**, and now records 200,000. The slug is served
+  by two platforms: Vertex offers the larger window, Bedrock 200,000, and an
+  unpinned request may be routed to either. A caller sizing a prompt against
+  the old figure could have it rejected upstream.
+
+  This is the general hazard with an aggregator, and `specs.yaml` now says so
+  where the OpenRouter entries live: take limits from the per-slug
+  `endpoints` listing and record the narrowest, because one slug fans out
+  across every host serving it.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ the provider needs and change the model string. Nothing else moves.
 | --- | --- |
 | `openai/gpt-5-nano` | `OPENAI_API_KEY` |
 | `deepseek/deepseek-v4-flash` | `DEEPSEEK_API_KEY` |
+| `kimi/kimi-k3` | `MOONSHOT_API_KEY` |
 | `openrouter/anthropic/claude-sonnet-4` | `OPENROUTER_API_KEY` |
 
 The `provider/` prefix is required. warpllm matches the whole string against its
@@ -132,6 +133,7 @@ This project is to lay out the most resilient open source productionization laye
 | OpenAI chat completions, non-streaming | Yes | Yes |
 | `provider/model` routing strings | Provider registry | Provider registry |
 | DeepSeek, OpenRouter | Yes | Yes |
+| Kimi | — | Yes |
 | OpenAI-compatible HTTP gateway | — | Unreleased |
 | Streaming | — | — |
 | Failover, load balancing, caching, metrics | — | — |

--- a/crates/warpllm/src/registry/mod.rs
+++ b/crates/warpllm/src/registry/mod.rs
@@ -217,13 +217,17 @@ mod tests {
         let registry = load::load(yaml).unwrap();
         assert_eq!(
             providers(&registry),
-            vec!["deepseek", "openai", "openrouter"]
+            vec!["deepseek", "kimi", "openai", "openrouter"]
         );
         assert_eq!(
             keys(&registry),
             vec![
                 "deepseek/deepseek-v4-flash",
                 "deepseek/deepseek-v4-pro",
+                "kimi/kimi-k2.6",
+                "kimi/kimi-k2.7-code",
+                "kimi/kimi-k2.7-code-highspeed",
+                "kimi/kimi-k3",
                 "openai/gpt-4.1",
                 "openai/gpt-4.1-mini",
                 "openai/gpt-4o",
@@ -246,6 +250,9 @@ mod tests {
                 "openrouter/anthropic/claude-sonnet-4",
                 "openrouter/auto",
                 "openrouter/google/gemini-2.5-pro",
+                "openrouter/moonshotai/kimi-k2.6",
+                "openrouter/moonshotai/kimi-k2.7-code",
+                "openrouter/moonshotai/kimi-k3",
                 "openrouter/openai/gpt-5.6",
                 "openrouter/~deepseek/deepseek-v4-flash-latest",
             ]

--- a/crates/warpllm/src/registry/specs.yaml
+++ b/crates/warpllm/src/registry/specs.yaml
@@ -123,6 +123,63 @@ providers:
           max_output_tokens: 384000
           max_concurrent_requests: 500
 
+  # <https://platform.kimi.ai/docs/models> (checked 2026-08-11). The API is
+  # OpenAI-compatible. The platform is branded Kimi while the host kept
+  # Moonshot's name, which is why the two disagree below.
+  # <https://platform.kimi.ai/docs/api/chat> — base URL and MOONSHOT_API_KEY
+  #
+  # Windows come from each model's PRICING page, which publishes the exact
+  # figure; the model list rounds the same numbers to "1M" and "256k". Both
+  # round down from a power of two, so the exact ones are what is recorded.
+  #
+  # No `max_concurrent_requests`: Kimi documents concurrency per account tier,
+  # not per model. <https://platform.kimi.ai/docs/pricing/limits>
+  #
+  # No `max_output_tokens` on any entry: Kimi publishes no output ceiling for
+  # any model. What the docs give is `max_completion_tokens`, the request
+  # parameter — a default of 32,768, or 131,072 for kimi-k3, and for kimi-k3
+  # an upper bound of 1,048,576 on what may be ASKED for. That is the range
+  # the parameter accepts, described as "the length of tokens you expect us to
+  # return", not a length the model is documented to reach.
+  # <https://platform.kimi.ai/docs/api/chat>
+  #
+  # Deliberately absent, checked 2026-08-11:
+  # - kimi-k2.5 and the whole moonshot-v1 series, `-vision-preview` variants
+  #   included: no longer available to newly registered users, and sunset
+  #   August 31 — the docs give the day without the year. Registering a model
+  #   a new account cannot reach would fail every request made to it.
+  # - Already discontinued: the kimi-k2 series (2026-05-25), kimi-latest
+  #   (2026-01-28), kimi-thinking-preview (2025-11-11).
+  kimi:
+    base_url: "https://api.moonshot.ai/v1"
+    env_api_key: MOONSHOT_API_KEY
+    models:
+      # <https://platform.kimi.ai/docs/pricing/chat-k26>
+      kimi/kimi-k2.6:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        capabilities:
+          max_input_tokens: 262144
+      # <https://platform.kimi.ai/docs/pricing/chat-k27-code>
+      kimi/kimi-k2.7-code:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        capabilities:
+          max_input_tokens: 262144
+      # The same limits as kimi-k2.7-code; the two differ in throughput.
+      # <https://platform.kimi.ai/docs/pricing/chat-k27-code>
+      kimi/kimi-k2.7-code-highspeed:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        capabilities:
+          max_input_tokens: 262144
+      # <https://platform.kimi.ai/docs/pricing/chat-k3>
+      kimi/kimi-k3:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        capabilities:
+          max_input_tokens: 1048576
+
   # <https://developers.openai.com/api/docs/models/all> (checked 2026-08-11).
   # Every model below was confirmed on its own model page to mark
   # `v1/chat/completions` supported; each entry carries that page's link.
@@ -308,9 +365,19 @@ providers:
   # An aggregator, so each entry below is a curated pick from its catalog and
   # there is no `openrouter/*` catch-all. OpenRouter's own identifier is a
   # two-segment slug, which the key's last-segment default would truncate, so
-  # every entry sets `model:` to the full slug. Limits come from each model's
-  # OpenRouter page; it publishes no per-slug concurrency ceiling, only
-  # per-key rate limits on the caller's account.
+  # every entry sets `model:` to the full slug. It publishes no per-slug
+  # concurrency ceiling, only per-key rate limits on the caller's account.
+  #
+  # Take limits from `/api/v1/models/<slug>/endpoints`, and record the
+  # NARROWEST any endpoint offers. A slug is not one model on one host: it
+  # fans out across every provider serving those weights, and they disagree —
+  # kimi-k2.6 alone runs across 21 endpoints whose max output spans 16,384 to
+  # 262,144. An unpinned request may land on any of them, so the smallest
+  # figure is the only one a caller can rely on, and a limit the endpoints
+  # disagree about too widely is better omitted than promised.
+  #
+  # Do NOT read `top_provider` from `/api/v1/models`. It is one endpoint's
+  # numbers, not the slug's, and it reads like a summary of them.
   openrouter:
     base_url: "https://openrouter.ai/api/v1"
     env_api_key: OPENROUTER_API_KEY
@@ -324,14 +391,17 @@ providers:
         capabilities:
           max_input_tokens: 200000
           max_output_tokens: 32000
-      # Checked 2026-08-07: 1M context, 64K max output.
-      # <https://openrouter.ai/anthropic/claude-sonnet-4>
+      # Checked 2026-08-11, 5 endpoints, and they are two platforms counted
+      # per region: Vertex serves a 1,000,000 window, Bedrock 200,000. An
+      # unpinned request may get either, so 200,000 is what is recorded. All
+      # five agree on 64,000 max output.
+      # <https://openrouter.ai/api/v1/models/anthropic/claude-sonnet-4/endpoints>
       openrouter/anthropic/claude-sonnet-4:
         supported_apis:
           - {api: openai_compat_chat_completions}
         model: anthropic/claude-sonnet-4
         capabilities:
-          max_input_tokens: 1000000
+          max_input_tokens: 200000
           max_output_tokens: 64000
       # OpenRouter's alias for letting IT pick the model per request: the wire
       # name is the key's last segment, and the limits are whichever backend
@@ -348,6 +418,43 @@ providers:
         capabilities:
           max_input_tokens: 1048576
           max_output_tokens: 65536
+      # Kimi through the aggregator. Every figure below is the NARROWEST any
+      # endpoint serving the slug offers, because an unpinned request may land
+      # on any of them — see the note above the provider.
+      #
+      # Checked 2026-08-11, 21 endpoints: windows are 256,000 (StreamLake,
+      # Venice), 262,000 (BaseTen) or 262,144, so 256,000 is what a caller can
+      # count on. No max output: the endpoints span 16,384 (DeepInfra) to
+      # 262,144, a sixteenfold spread with no model-level ceiling behind it.
+      # <https://openrouter.ai/api/v1/models/moonshotai/kimi-k2.6/endpoints>
+      openrouter/moonshotai/kimi-k2.6:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        model: moonshotai/kimi-k2.6
+        capabilities:
+          max_input_tokens: 256000
+      # Checked 2026-08-11, 15 endpoints: windows are 256,000 or 262,144, and
+      # max output spans 16,384 to 262,144. The `:batch` variant of this slug
+      # is left off — it is OpenRouter's batch surface, not chat completions.
+      # <https://openrouter.ai/api/v1/models/moonshotai/kimi-k2.7-code/endpoints>
+      openrouter/moonshotai/kimi-k2.7-code:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        model: moonshotai/kimi-k2.7-code
+        capabilities:
+          max_input_tokens: 256000
+      # Checked 2026-08-11, 13 endpoints. Moonshot's own window is 1,048,576
+      # and most endpoints match it, but Sail Research serves 974,842 and
+      # Together 1,000,000, so that is the figure recorded — the alternative
+      # is promising a window a routed request may not get. Max output spans
+      # 16,384 to 1,048,576.
+      # <https://openrouter.ai/api/v1/models/moonshotai/kimi-k3/endpoints>
+      openrouter/moonshotai/kimi-k3:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+        model: moonshotai/kimi-k3
+        capabilities:
+          max_input_tokens: 974842
       # Checked 2026-08-07: `gpt-5.6` is OpenAI's alias for `gpt-5.6-sol`, so
       # these are Sol's limits — 1M context, 128K max output.
       # <https://openrouter.ai/openai/gpt-5.6-sol>


### PR DESCRIPTION
Adds Kimi as a provider, the same way #30 added OpenAI's roster: verified
against the vendor's own docs, with the absences recorded rather than left to
be guessed at.

The API is OpenAI-compatible, so this is a `specs.yaml` edit and no Rust.

## Direct, under a new `kimi` provider

| Model | Context window | Max output |
|---|---|---|
| `kimi/kimi-k3` | 1,048,576 | not published |
| `kimi/kimi-k2.6` | 262,144 | not published |
| `kimi/kimi-k2.7-code` | 262,144 | not published |
| `kimi/kimi-k2.7-code-highspeed` | 262,144 | not published |

Reached at `https://api.moonshot.ai/v1` with `MOONSHOT_API_KEY`. The platform
is branded Kimi while the host kept Moonshot's name, which is why the provider
key and the base URL disagree; the file says so at the entry.

**The windows come from the pricing pages, not the model list.** The model
list rounds to "1M" and "256k". The pricing tables publish 1,048,576 and
262,144 — both round *down* from a power of two, so taking the rounded figure
would have understated every Kimi entry. Recorded exact.

**No `max_output_tokens` on any Kimi entry.** Kimi publishes no output ceiling
for any model. What the docs give is `max_completion_tokens`, the *request
parameter* — a default of 32,768, or 131,072 for `kimi-k3`, and for `kimi-k3`
an upper bound of 1,048,576 on what may be **asked for**. The same page calls
it "the length of tokens you expect us to return." That is the range the
parameter accepts, not a length the model is documented to reach, so under the
file's rule ("undocumented is not unlimited — omit a limit rather than guess
it") every Kimi entry records a window and nothing else.

**No `max_concurrent_requests` anywhere.** Kimi documents concurrency per
account tier — Tier0 gets 1, Tier5 gets 1,000 — not per model. Same shape as
OpenAI's rate limits, and the same conclusion.

## And through OpenRouter

Three more, added to that provider's curated set.

| Model | Context window | Max output |
|---|---|---|
| `openrouter/moonshotai/kimi-k3` | 974,842 | omitted |
| `openrouter/moonshotai/kimi-k2.6` | 256,000 | omitted |
| `openrouter/moonshotai/kimi-k2.7-code` | 256,000 | omitted |

**These are floors, not the headline figures, and that is the point.** An
OpenRouter slug is not one model on one host — it fans out across every
provider serving those weights, and they disagree. `kimi-k2.6` runs across 21
endpoints:

```
Chutes      max_completion=65535     DeepInfra   max_completion=16384
Venice      max_completion=65536     StreamLake  ctx=256000
Decart      max_completion=262144    BaseTen     ctx=262000
```

A sixteenfold spread in output, and three distinct windows. An unpinned
request may land on any of them, so the narrowest figure is the only one a
caller can rely on. Output ceilings that disagree this widely are omitted
rather than promised.

`kimi-k3` is the sharpest case: Moonshot's own window is 1,048,576 and most
endpoints match, but Sail Research serves **974,842** and Together 1,000,000.
Recording 1,048,576 would promise a window a routed request may not get.

`~moonshotai/kimi-latest` is **not** included. It lists no endpoints of its
own, and the Kimi family runs from 262,144 to 1,048,576 — so unlike
`openrouter/~deepseek/deepseek-v4-flash-latest`, whose family shares one
window, that alias can resolve to something narrower than its newest member,
and nothing recorded about it would survive the move.

The provider comment now carries this rule, including "do not read
`top_provider` from `/api/v1/models`" — it is one endpoint's numbers while
reading like a summary of them, and it is what produced a first draft of this
PR with three wrong entries.

`moonshotai/kimi-k2.7-code:batch` is left off — that suffix is OpenRouter's
batch surface, not chat completions.

## What is absent, and why

- **`kimi-k2.5` and the entire `moonshot-v1` series** (including the three
  `-vision-preview` variants): no longer available to newly registered users,
  and sunset **August 31** — the docs give the day without a year. Either
  reading disqualifies it: a model a new account cannot reach is one warpllm
  would register and then fail every request to.
- **Already discontinued**: the `kimi-k2` series (2026-05-25), `kimi-latest`
  (2026-01-28), `kimi-thinking-preview` (2025-11-11).

OpenRouter still serves the K2 generation — `kimi-k2`, `kimi-k2-0905`,
`kimi-k2-thinking` — and `kimi-k2.5`, because those are open weights hosted by
third parties and do not vanish when Moonshot's own API drops them. They are
genuinely routable there. The curated pick leaves them out anyway, for the
same reason the direct provider does: they are a generation behind, and the
roster is a considered list rather than a mirror of a catalog.

None of these carry a `deprecation_date` in the roster, because none of them
are *in* the roster — the field is for a model warpllm decides to keep
serving, and there still is not one.

## The changelog covers #30 too

That PR merged without a changelog entry, so thirteen OpenAI models and the
`deprecation_date` field are currently unrecorded in `[Unreleased]`. Adding an
entry for Kimi alone would have implied the OpenAI work had not shipped, so
the entry covers both. Slightly wider than this branch's diff, deliberately.

## Tests

The shipped-roster test lists all 33 keys and now four providers. That is the
whole test surface here: no Rust changed, so there is nothing else to exercise.

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
and `cargo test --workspace` are clean.

## Sources

- <https://platform.kimi.ai/docs/models>
- <https://platform.kimi.ai/docs/api/chat> — base URL, `MOONSHOT_API_KEY`
- <https://platform.kimi.ai/docs/pricing/chat-k3>,
  <https://platform.kimi.ai/docs/pricing/chat-k26>,
  <https://platform.kimi.ai/docs/pricing/chat-k27-code> — the exact windows
- <https://platform.kimi.ai/docs/pricing/limits> — per-tier concurrency
- `https://openrouter.ai/api/v1/models/<slug>/endpoints` — every OpenRouter
  figure above, per endpoint

## An existing entry corrected by the same rule

`openrouter/anthropic/claude-sonnet-4` recorded `max_input_tokens: 1000000`.
Its five endpoints are two platforms counted per region:

```
Google  google-vertex/global      ctx=1,000,000
Google  google-vertex/europe      ctx=1,000,000
Google  google-vertex             ctx=1,000,000
Amazon Bedrock  amazon-bedrock            ctx=  200,000
Amazon Bedrock  amazon-bedrock/eu-west-1  ctx=  200,000
```

Only Vertex serves the larger window, so an unpinned request may be routed to
a platform offering a fifth of what the roster promised — enough for a caller
sizing a prompt against it to be rejected upstream. Now records 200,000. All
five agree on 64,000 max output, so that is unchanged.

The other three existing OpenRouter entries check out and are untouched:
`claude-opus-4` (a single endpoint), `gemini-2.5-pro` and `openai/gpt-5.6`
(all endpoints agree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
