### PR TITLE
Stream chat completions, normalized through a gateway representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,43 @@ Everything under "Changed" is breaking, so this releases as `0.3.0`.
 
 ### Added
 
+- **Streaming chat completions.** `Client::chat_completions_stream` returns a
+  `ChatCompletionStream` of `CreateChatCompletionStreamResponse` chunks, read
+  off the wire as they arrive:
+
+  ```rust
+  let mut stream = client.chat_completions_stream(request).await?;
+  while let Some(chunk) = stream.next().await {
+      for choice in &chunk?.choices {
+          if let Some(Some(text)) = &choice.delta.content {
+              print!("{text}");
+          }
+      }
+  }
+  ```
+
+  The chunk shape already shipped; what is new is everything that produces one.
+  Server-sent events are framed in the protocol layer — partial lines and
+  multi-byte characters split across reads are rejoined, `:` keepalive comments
+  are ignored, and `[DONE]` ends the stream rather than arriving as a chunk.
+  Each event is then normalized through a gateway representation and rendered
+  back, losslessly: an explicit `null` returns as a `null`, an absent key stays
+  absent, an opening `"content": ""` survives as itself, and per-chunk fields no
+  specification names — OpenAI's `obfuscation` among them — reach the caller
+  verbatim. Both recorded transcripts are checked event by event through that
+  round trip.
+
+  Every model on the roster now declares `openai_compat_chat_completions_stream`
+  alongside its whole-reply surface, each provider's `stream` parameter cited in
+  `specs.yaml`. Streaming remains its own surface, so a future model that serves
+  one without the other still says so.
+
+  `Client::chat_completions` refuses `stream: true` rather than serving the
+  wrong shape, naming the entrypoint that serves it. That advice is Rust's
+  alone: the HTTP gateway and the Node and Python bindings have no second
+  entrypoint to point a caller at, so each reports an unimplemented SURFACE and
+  answers `stream: true` with 501 exactly as before.
+
 - **Kimi, and the rest of OpenAI's chat-completion roster.** A new `kimi`
   provider, reached at `api.moonshot.ai` with `MOONSHOT_API_KEY`, serving
   `kimi/kimi-k3`, `kimi/kimi-k2.6`, and the two `kimi-k2.7-code` variants —

--- a/crates/warpllm-server/src/handlers.rs
+++ b/crates/warpllm-server/src/handlers.rs
@@ -28,7 +28,17 @@ pub(crate) async fn chat_completions(State(state): State<AppState>, body: Bytes)
         stream = request.stream.unwrap_or(false),
         "chat completion request"
     );
-    // `stream: true` is rejected inside the client as NotImplemented → 501.
+    // The library streams; this surface does not yet, and the refusal is now
+    // its own to state. `Client::chat_completions` refuses `stream: true` by
+    // naming the Rust entrypoint that serves it — advice with nothing behind
+    // it over HTTP, where there is no second endpoint to be sent to. So an
+    // unimplemented SURFACE is what a caller is told, which is the truth here
+    // and answers 501 rather than 400.
+    if request.stream == Some(true) {
+        return error_response(&warpllm::Error::NotImplemented(
+            "streaming over the HTTP gateway",
+        ));
+    }
     match state.client.chat_completions(request).await {
         Ok(completion) => Json(completion).into_response(),
         Err(e) => error_response(&e),

--- a/crates/warpllm/src/client.rs
+++ b/crates/warpllm/src/client.rs
@@ -7,7 +7,7 @@ use crate::credentials::Credentials;
 use crate::error::{Error, Result};
 use crate::gateway::openai_compat;
 use crate::protocol::openai_compat::chat_completions::types::{
-    CreateChatCompletionRequest, CreateChatCompletionResponse,
+    CreateChatCompletionRequest, CreateChatCompletionResponse, CreateChatCompletionStreamResponse,
 };
 use crate::registry::{ModelSpec, ProviderSpec, fetch_model};
 use crate::types::Api;
@@ -52,7 +52,12 @@ impl Client {
         request: CreateChatCompletionRequest,
     ) -> Result<CreateChatCompletionResponse> {
         if request.stream == Some(true) {
-            return Err(Error::NotImplemented("streaming"));
+            // Not "unimplemented": it IS implemented, on a method whose return
+            // type can carry chunks. A whole reply cannot, so this entrypoint
+            // says where to go rather than quietly serving the wrong shape.
+            return Err(Error::InvalidInput(
+                "stream: true asks for chunks; call chat_completions_stream".into(),
+            ));
         }
         let requested_model = request.model.clone();
         // Half one: the roster. Closed, so an unregistered name stops here.
@@ -90,6 +95,50 @@ impl Client {
         // Echo the caller's provider-prefixed string, not the upstream echo.
         completion.model = requested_model;
         Ok(completion)
+    }
+
+    /// Serves one OpenAI-compatible chat completion as a stream of chunks.
+    ///
+    /// The same two admission halves as [`Client::chat_completions`], in the
+    /// same order, against a DIFFERENT surface: streaming is its own entry in
+    /// the roster, so a model that serves whole replies says nothing about
+    /// whether it serves streamed ones.
+    ///
+    /// `stream` is set on the caller's behalf rather than required: the method
+    /// name already states the intent, and a request that contradicts it would
+    /// have nothing useful to mean.
+    ///
+    /// The [`Result`] covers only what can fail before the first chunk. Once
+    /// the stream is open, failures arrive as items on it.
+    pub async fn chat_completions_stream(
+        &self,
+        mut request: CreateChatCompletionRequest,
+    ) -> Result<ChatCompletionStream> {
+        request.stream = Some(true);
+        let requested_model = request.model.clone();
+        let (provider, model) = fetch_model(&requested_model)?;
+        Self::validate_api(
+            model,
+            Api::OpenAiCompatChatCompletionsStream,
+            provider,
+            &requested_model,
+        )?;
+        let api_key = self.api_key(provider)?;
+
+        let normalized =
+            openai_compat::api::chat_completions::ingest_request(request, model.model());
+        Ok(ChatCompletionStream {
+            chunks: openai_compat::api::chat_completions::exchange_stream(
+                &normalized,
+                &self.http,
+                provider.name(),
+                self.base_url(provider),
+                api_key,
+            )
+            .await?,
+            provider: provider.name(),
+            model: requested_model,
+        })
     }
 
     /// The routed provider's key, from the snapshot this client took of the
@@ -151,6 +200,54 @@ impl Client {
             .base_url
             .as_deref()
             .unwrap_or(provider.base_url())
+    }
+}
+
+/// The chunks of one streamed reply, in the shape the caller asked in.
+///
+/// Returned by [`Client::chat_completions_stream`]. Iterate it to exhaustion:
+///
+/// ```no_run
+/// # async fn demo(client: &warpllm::Client, request: warpllm::CreateChatCompletionRequest)
+/// # -> warpllm::Result<()> {
+/// let mut stream = client.chat_completions_stream(request).await?;
+/// while let Some(chunk) = stream.next().await {
+///     for choice in &chunk?.choices {
+///         if let Some(Some(text)) = &choice.delta.content {
+///             print!("{text}");
+///         }
+///     }
+/// }
+/// # Ok(())
+/// # }
+/// ```
+///
+/// An inherent `next` rather than a [`Stream`](std::iter::Iterator)
+/// implementation: a `while let` loop needs no combinators, and the bindings
+/// that wrap this iterate it the same way.
+#[derive(Debug)]
+pub struct ChatCompletionStream {
+    chunks: openai_compat::api::chat_completions::ChatChunkStream,
+    provider: &'static str,
+    /// The caller's provider-prefixed string, echoed onto every chunk in place
+    /// of the upstream's own — the streaming counterpart of the one
+    /// [`Client::chat_completions`] performs on a whole reply.
+    model: String,
+}
+
+impl ChatCompletionStream {
+    /// The next chunk, or `None` once the stream ends.
+    ///
+    /// An error item is terminal: whatever produced it also ended the stream,
+    /// so the next call returns `None`.
+    pub async fn next(&mut self) -> Option<Result<CreateChatCompletionStreamResponse>> {
+        let chunk = self.chunks.next().await?;
+        Some(chunk.map(|chunk| {
+            let mut rendered =
+                openai_compat::api::chat_completions::render_chunk(&chunk, self.provider);
+            rendered.model = self.model.clone();
+            rendered
+        }))
     }
 }
 

--- a/crates/warpllm/src/gateway/openai_compat/api/chat_completions/exchange.rs
+++ b/crates/warpllm/src/gateway/openai_compat/api/chat_completions/exchange.rs
@@ -3,9 +3,11 @@
 use crate::error::Result;
 use crate::gateway::openai_compat::error::error_from_body;
 use crate::gateway::types;
-use crate::protocol::openai_compat::chat_completions::transport::{self, Outcome};
+use crate::protocol::openai_compat::chat_completions::transport::{
+    self, ChunkStream, Outcome, StreamOutcome,
+};
 
-use super::{ingest_response, render_request};
+use super::{ingest_chunk, ingest_response, render_request};
 
 /// Renders the gateway request for this protocol, posts it, and ingests the
 /// reply — the one place this protocol's order is stated.
@@ -43,5 +45,53 @@ pub(crate) async fn exchange(
             retry_after,
             request_id,
         )),
+    }
+}
+
+/// [`exchange`] for a streamed reply: gateway types on both ends, the same
+/// order stated once, and the same error mapping.
+///
+/// The failure it can report is only the one that happens BEFORE any chunk —
+/// a refused request, a rate limit, an unreachable host. Once the stream is
+/// open, a failure has no status left to map and surfaces on the stream itself.
+pub(crate) async fn exchange_stream(
+    request: &types::ChatRequest,
+    http: &reqwest::Client,
+    provider: &'static str,
+    base_url: &str,
+    api_key: &str,
+) -> Result<ChatChunkStream> {
+    let wire = render_request(request, provider)?;
+    match transport::post_stream(http, provider, base_url, api_key, &wire).await? {
+        StreamOutcome::Ok(chunks) => Ok(ChatChunkStream { chunks }),
+        StreamOutcome::Status {
+            status,
+            body,
+            retry_after,
+            request_id,
+        } => Err(error_from_body(
+            provider,
+            status,
+            &body,
+            retry_after,
+            request_id,
+        )),
+    }
+}
+
+/// The gateway's view of a stream: wire chunks in, [`types::ChatResponseChunk`]
+/// out, one for one.
+///
+/// Thin on purpose. Ingest is infallible, so this adds nothing to the transport
+/// but the conversion — which is exactly the seam a second protocol needs, and
+/// the reason this is not just [`ChunkStream`] handed to the client.
+#[derive(Debug)]
+pub(crate) struct ChatChunkStream {
+    chunks: ChunkStream,
+}
+
+impl ChatChunkStream {
+    pub(crate) async fn next(&mut self) -> Option<Result<types::ChatResponseChunk>> {
+        Some(self.chunks.next().await?.map(ingest_chunk))
     }
 }

--- a/crates/warpllm/src/gateway/openai_compat/api/chat_completions/mod.rs
+++ b/crates/warpllm/src/gateway/openai_compat/api/chat_completions/mod.rs
@@ -5,7 +5,9 @@
 mod exchange;
 mod request;
 mod response;
+mod stream;
 
-pub(crate) use exchange::exchange;
+pub(crate) use exchange::{ChatChunkStream, exchange, exchange_stream};
 pub(crate) use request::{ingest_request, render_request};
 pub(crate) use response::{ingest_response, render_response};
+pub(crate) use stream::{ingest_chunk, render_chunk};

--- a/crates/warpllm/src/gateway/openai_compat/api/chat_completions/request.rs
+++ b/crates/warpllm/src/gateway/openai_compat/api/chat_completions/request.rs
@@ -84,8 +84,13 @@ fn ingest_message(message: ChatCompletionRequestMessage) -> types::Message {
 /// provider is the authority on its own parameters and rejects what it
 /// doesn't accept. Same-protocol round trips are lossless modulo three
 /// documented transformations: the provider prefix is stripped from
-/// `model`, `stream` is dropped, and an empty `stop` list is omitted, each
-/// of them exactly reversible or resolved before ingest.
+/// `model`, `stream: false` is dropped, and an empty `stop` list is omitted,
+/// each of them exactly reversible or resolved before ingest.
+///
+/// `stream` is emitted only when it is true. The wire field is optional and
+/// defaults to false, so an absent key and an explicit `false` ask the
+/// provider for the same thing — and ingest already reads them as the same
+/// thing, which is what keeps dropping it lossless.
 pub(crate) fn render_request(
     request: &types::ChatRequest,
     provider: &'static str,
@@ -104,7 +109,7 @@ pub(crate) fn render_request(
         max_tokens: params.max_tokens,
         top_p: params.top_p,
         stop: (!params.stop.is_empty()).then(|| params.stop.clone()),
-        stream: None,
+        stream: request.stream.then_some(true),
         unknown_fields,
     })
 }

--- a/crates/warpllm/src/gateway/openai_compat/api/chat_completions/response.rs
+++ b/crates/warpllm/src/gateway/openai_compat/api/chat_completions/response.rs
@@ -198,7 +198,7 @@ fn ingest_tool_call(call: ChatCompletionMessageToolCallUnion) -> ContentBlock {
     }
 }
 
-fn ingest_usage(usage: CompletionUsage) -> types::Usage {
+pub(super) fn ingest_usage(usage: CompletionUsage) -> types::Usage {
     let CompletionUsage {
         completion_tokens,
         prompt_tokens,
@@ -341,7 +341,7 @@ fn render_message(message: &types::Message, provider: &str) -> ChatCompletionRes
     }
 }
 
-fn render_usage(usage: &types::Usage, provider: &str) -> CompletionUsage {
+pub(super) fn render_usage(usage: &types::Usage, provider: &str) -> CompletionUsage {
     let mut unknown_fields = merged_ext(&usage.ext, provider);
     let prompt_details = render_details(
         unknown_fields.remove("prompt_tokens_details"),
@@ -387,7 +387,7 @@ fn render_details<T: DeserializeOwned>(
     serde_json::from_value(Value::Object(fields)).ok()
 }
 
-fn take_string(fields: &mut UnknownFields, key: &str) -> Option<String> {
+pub(super) fn take_string(fields: &mut UnknownFields, key: &str) -> Option<String> {
     match fields.remove(key) {
         Some(Value::String(value)) => Some(value),
         _ => None,
@@ -398,7 +398,10 @@ fn take_string(fields: &mut UnknownFields, key: &str) -> Option<String> {
 /// absent comes back absent, and an explicit `null` comes back as one. The
 /// typed fields get this for free — `take_typed::<Option<T>>` reads a stashed
 /// `null` as `Some(None)` — and only a bare string needs it spelled out.
-fn take_nullable_string(fields: &mut UnknownFields, key: &str) -> Option<Option<String>> {
+pub(super) fn take_nullable_string(
+    fields: &mut UnknownFields,
+    key: &str,
+) -> Option<Option<String>> {
     match fields.remove(key) {
         Some(Value::String(value)) => Some(Some(value)),
         Some(Value::Null) => Some(None),
@@ -407,14 +410,14 @@ fn take_nullable_string(fields: &mut UnknownFields, key: &str) -> Option<Option<
     }
 }
 
-fn take_typed<T: DeserializeOwned>(fields: &mut UnknownFields, key: &str) -> Option<T> {
+pub(super) fn take_typed<T: DeserializeOwned>(fields: &mut UnknownFields, key: &str) -> Option<T> {
     fields
         .remove(key)
         .and_then(|value| serde_json::from_value(value).ok())
 }
 
 /// Wire structs are plain serde data; serialization cannot fail.
-fn plain<T: serde::Serialize>(value: &T) -> Value {
+pub(super) fn plain<T: serde::Serialize>(value: &T) -> Value {
     serde_json::to_value(value).expect("wire data serializes")
 }
 

--- a/crates/warpllm/src/gateway/openai_compat/api/chat_completions/stream.rs
+++ b/crates/warpllm/src/gateway/openai_compat/api/chat_completions/stream.rs
@@ -1,0 +1,824 @@
+//! Chunk conversions: OpenAI-compatible wire → gateway (ingest) and gateway →
+//! wire (render), one value per chunk. The whole-reply counterpart, and the
+//! model for everything here, is [`super::response`].
+//!
+//! Round trips are lossless with zero permitted transformations, which for a
+//! chunk means holding three distinct states of the same field: a key the
+//! provider never sent stays absent, an explicit `null` comes back as one, and
+//! a value comes back as itself. OpenAI streams `"logprobs": null` on every
+//! chunk, `"usage": null` on every chunk but the last, and opens with
+//! `"content": ""` — all three appear in one live stream.
+//!
+//! Protocol-specific fields (`object`, `service_tier`, choice `index`,
+//! `refusal`, `obfuscation`, …) ride `ext["openai_compat"]` at their nesting
+//! level and are restored verbatim.
+
+use serde_json::Value;
+
+use crate::gateway::types::{self, ContentDelta, FinishReason, IngestSource};
+use crate::protocol::openai_compat::chat_completions::types::{
+    ChatCompletionMessageToolCallChunk, ChatCompletionStreamResponseDelta,
+    CreateChatCompletionStreamResponse, StreamChoice, ToolCallChunkFunction, UnknownFields,
+};
+use crate::types::Protocol;
+
+use super::response::{
+    ingest_usage, plain, render_usage, take_nullable_string, take_string, take_typed,
+};
+use crate::gateway::openai_compat::{merged_ext, namespaced, role_from_wire, role_to_wire};
+
+/// Permissive and infallible; the exhaustive destructures at every level make
+/// dropping a newly-typed wire field a compile error.
+pub(crate) fn ingest_chunk(chunk: CreateChatCompletionStreamResponse) -> types::ChatResponseChunk {
+    // Wire structs are plain serde data; serialization cannot fail.
+    let body = serde_json::to_value(&chunk).expect("wire chunk serializes");
+    let CreateChatCompletionStreamResponse {
+        id,
+        choices,
+        created,
+        model,
+        object,
+        moderation,
+        service_tier,
+        system_fingerprint,
+        usage,
+        unknown_fields,
+    } = chunk;
+    let mut compat = UnknownFields::new();
+    compat.insert("object".into(), Value::String(object));
+    if let Some(moderation) = moderation {
+        compat.insert("moderation".into(), plain(&moderation));
+    }
+    if let Some(tier) = service_tier {
+        // The outer `Some` is "the key was there"; an explicit null is stashed
+        // as one so the renderer can put it back as one.
+        compat.insert(
+            "service_tier".into(),
+            tier.map_or(Value::Null, Value::String),
+        );
+    }
+    if let Some(fingerprint) = system_fingerprint {
+        compat.insert("system_fingerprint".into(), Value::String(fingerprint));
+    }
+    // `usage` is optional AND nullable, and the null is the common case: it
+    // rides on every chunk of a stream that asked for totals except the one
+    // that carries them. Stashing the null keeps that chunk byte-identical.
+    let usage = match usage {
+        Some(Some(totals)) => Some(ingest_usage(totals)),
+        Some(None) => {
+            compat.insert("usage".into(), Value::Null);
+            None
+        }
+        None => None,
+    };
+    compat.extend(unknown_fields);
+    types::ChatResponseChunk {
+        id,
+        model,
+        created: Some(created),
+        completions: choices.into_iter().map(ingest_stream_choice).collect(),
+        usage,
+        ext: namespaced(compat),
+        source: Some(IngestSource {
+            protocol: Protocol::OpenAiCompat,
+            body,
+        }),
+    }
+}
+
+fn ingest_stream_choice(choice: StreamChoice) -> types::CompletionDelta {
+    let StreamChoice {
+        delta,
+        finish_reason,
+        index,
+        logprobs,
+        unknown_fields,
+    } = choice;
+    let mut compat = UnknownFields::new();
+    compat.insert("index".into(), Value::from(index));
+    if let Some(logprobs) = logprobs {
+        compat.insert("logprobs".into(), plain(&logprobs));
+    }
+    compat.extend(unknown_fields);
+    types::CompletionDelta {
+        delta: ingest_delta(delta),
+        finish_reason: finish_reason.as_deref().map(FinishReason::from_raw),
+        finish_reason_raw: finish_reason,
+        ext: namespaced(compat),
+    }
+}
+
+fn ingest_delta(delta: ChatCompletionStreamResponseDelta) -> types::MessageDelta {
+    let ChatCompletionStreamResponseDelta {
+        content,
+        function_call,
+        refusal,
+        role,
+        tool_calls,
+        unknown_fields,
+    } = delta;
+    let mut compat = UnknownFields::new();
+    let role = role.map(|raw| {
+        let (role, raw_role) = role_from_wire(raw);
+        if let Some(raw) = raw_role {
+            compat.insert("role".into(), Value::String(raw));
+        }
+        role
+    });
+    if let Some(refusal) = refusal {
+        compat.insert("refusal".into(), refusal.map_or(Value::Null, Value::String));
+    }
+    if let Some(function_call) = function_call {
+        compat.insert("function_call".into(), plain(&function_call));
+    }
+    // Reasoning first, since it precedes the answer it led to — the same order
+    // `ingest_message` produces for a whole reply.
+    let mut deltas: Vec<ContentDelta> = reasoning_delta(&unknown_fields).into_iter().collect();
+    match content {
+        // An empty string is a value, not an absence: a stream opens with
+        // `"content": ""`, and dropping it would lose the chunk that says the
+        // answer has started.
+        Some(Some(text)) => deltas.push(ContentDelta::Text { text }),
+        Some(None) => {
+            compat.insert("content".into(), Value::Null);
+        }
+        None => {}
+    }
+    match tool_calls {
+        // `Some([])` is distinguishable from absent; stash it so render
+        // re-emits the empty array byte-for-byte.
+        Some(calls) if calls.is_empty() => {
+            compat.insert("tool_calls".into(), Value::Array(Vec::new()));
+        }
+        Some(calls) => deltas.extend(calls.into_iter().map(ingest_tool_call_chunk)),
+        None => {}
+    }
+    compat.extend(unknown_fields);
+    types::MessageDelta {
+        role,
+        content: deltas,
+        ext: namespaced(compat),
+    }
+}
+
+/// A fragment of `reasoning_content`, the chain-of-thought sibling of
+/// `content`, as a typed delta.
+///
+/// PROMOTE BUT RETAIN, exactly as [`super::response`] does it for a whole
+/// reply: the caller leaves `unknown_fields` intact, so the field still rides
+/// `ext["openai_compat"]` and the renderer replays it verbatim. Nothing could
+/// rebuild it from the delta — `render_delta` drops Reasoning, because the
+/// protocol has no field to render it into.
+///
+/// The emptiness rule differs from the whole-reply one deliberately. There, an
+/// empty string means "the provider sent no thinking" and is not promoted.
+/// Here a provider may well open a reasoning run with an empty fragment the way
+/// it opens `content` with one, so only a non-string or an explicit null is
+/// declined — and the retained ext copy makes the choice unobservable on a
+/// same-protocol round trip either way.
+fn reasoning_delta(fields: &UnknownFields) -> Option<ContentDelta> {
+    Some(ContentDelta::Reasoning {
+        text: fields.get("reasoning_content")?.as_str()?.to_string(),
+        // The same one string the ext namespace is keyed by, so the two cannot
+        // disagree about where this fragment came from.
+        provenance: Some(Protocol::OpenAiCompat.as_str().to_string()),
+    })
+}
+
+/// A plain function fragment becomes a typed delta; anything else — a
+/// nonstandard `type`, a fragment with no `function` at all, or unknown fields
+/// at either level — passes through as an `Unknown` delta, re-emitted verbatim
+/// in array order.
+///
+/// `type` is carried rather than assumed: it arrives on the fragment that opens
+/// a call and is absent on every fragment after it, so restoring a constant
+/// would put a key on the wire the provider never sent.
+fn ingest_tool_call_chunk(call: ChatCompletionMessageToolCallChunk) -> ContentDelta {
+    match &call {
+        ChatCompletionMessageToolCallChunk {
+            index,
+            id,
+            function: Some(function),
+            r#type,
+            unknown_fields,
+        } if r#type.as_deref().is_none_or(|kind| kind == "function")
+            && unknown_fields.is_empty()
+            && function.unknown_fields.is_empty()
+            // `function: {}` carries presence this variant cannot express, so
+            // it takes the verbatim path rather than being flattened away.
+            && (function.name.is_some() || function.arguments.is_some()) =>
+        {
+            ContentDelta::ToolCall {
+                index: *index,
+                id: id.clone(),
+                kind: r#type.clone(),
+                name: function.name.clone(),
+                arguments: function.arguments.clone(),
+            }
+        }
+        _ => ContentDelta::Unknown(plain(&call)),
+    }
+}
+
+/// Infallible: protocol fields restore from ext (a hook that corrupted a
+/// stashed value beyond its wire type falls back to dropping that field).
+pub(crate) fn render_chunk(
+    chunk: &types::ChatResponseChunk,
+    provider: &str,
+) -> CreateChatCompletionStreamResponse {
+    let mut unknown_fields = merged_ext(&chunk.ext, provider);
+    let object = take_string(&mut unknown_fields, "object")
+        .unwrap_or_else(|| "chat.completion.chunk".to_string());
+    // A stashed null and a typed total are the two ways `usage` can be
+    // present; the typed one wins, since only ingest could have produced both.
+    let stashed_usage = unknown_fields.remove("usage");
+    let usage = match (&chunk.usage, stashed_usage) {
+        (Some(usage), _) => Some(Some(render_usage(usage, provider))),
+        (None, Some(Value::Null)) => Some(None),
+        (None, _) => None,
+    };
+    CreateChatCompletionStreamResponse {
+        id: chunk.id.clone(),
+        choices: chunk
+            .completions
+            .iter()
+            .enumerate()
+            .map(|(position, completion)| render_stream_choice(completion, position, provider))
+            .collect(),
+        created: chunk.created.unwrap_or(0),
+        model: chunk.model.clone(),
+        object,
+        moderation: take_typed(&mut unknown_fields, "moderation"),
+        service_tier: take_nullable_string(&mut unknown_fields, "service_tier"),
+        system_fingerprint: take_string(&mut unknown_fields, "system_fingerprint"),
+        usage,
+        unknown_fields,
+    }
+}
+
+fn render_stream_choice(
+    completion: &types::CompletionDelta,
+    position: usize,
+    provider: &str,
+) -> StreamChoice {
+    let mut unknown_fields = merged_ext(&completion.ext, provider);
+    let index = unknown_fields
+        .remove("index")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(position as u64) as u32;
+    StreamChoice {
+        delta: render_delta(&completion.delta, provider),
+        finish_reason: completion.finish_reason_raw.clone(),
+        index,
+        logprobs: take_typed(&mut unknown_fields, "logprobs"),
+        unknown_fields,
+    }
+}
+
+fn render_delta(delta: &types::MessageDelta, provider: &str) -> ChatCompletionStreamResponseDelta {
+    let mut unknown_fields = merged_ext(&delta.ext, provider);
+    let role = match unknown_fields.remove("role") {
+        Some(Value::String(raw)) => Some(raw),
+        _ => delta.role.map(|role| role_to_wire(role).to_string()),
+    };
+    let mut content = None;
+    let mut tool_calls = Vec::new();
+    for fragment in &delta.content {
+        match fragment {
+            ContentDelta::Text { text } => content = Some(Some(text.clone())),
+            ContentDelta::ToolCall {
+                index,
+                id,
+                kind,
+                name,
+                arguments,
+            } => tool_calls.push(ChatCompletionMessageToolCallChunk {
+                index: *index,
+                id: id.clone(),
+                function: Some(ToolCallChunkFunction {
+                    arguments: arguments.clone(),
+                    name: name.clone(),
+                    unknown_fields: UnknownFields::new(),
+                }),
+                r#type: kind.clone(),
+                unknown_fields: UnknownFields::new(),
+            }),
+            ContentDelta::Unknown(value) => {
+                if let Ok(call) = serde_json::from_value(value.clone()) {
+                    tool_calls.push(call);
+                }
+            }
+            // A Reasoning fragment was lifted out of `reasoning_content`,
+            // which is still sitting in ext and about to be emitted verbatim —
+            // PROMOTE BUT RETAIN, read from the other end, so dropping it
+            // loses nothing.
+            ContentDelta::Reasoning { .. } => {}
+        }
+    }
+    // A stashed null only stands in for content nothing else claimed.
+    if content.is_none() && matches!(unknown_fields.get("content"), Some(Value::Null)) {
+        content = Some(None);
+    }
+    unknown_fields.remove("content");
+    if !tool_calls.is_empty() {
+        // Typed fragments are authoritative over any stashed empty array.
+        unknown_fields.remove("tool_calls");
+    }
+    ChatCompletionStreamResponseDelta {
+        content,
+        function_call: take_typed(&mut unknown_fields, "function_call"),
+        refusal: take_nullable_string(&mut unknown_fields, "refusal"),
+        role,
+        tool_calls: (!tool_calls.is_empty()).then_some(tool_calls),
+        unknown_fields,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::gateway::types::Role;
+
+    fn parse(body: Value) -> CreateChatCompletionStreamResponse {
+        serde_json::from_value(body).unwrap()
+    }
+
+    fn round_trip(body: Value, provider: &str) {
+        let normalized = ingest_chunk(parse(body.clone()));
+        let rendered = render_chunk(&normalized, provider);
+        assert_eq!(serde_json::to_value(&rendered).unwrap(), body);
+    }
+
+    /// The maximal chunk: every documented field, unknown fields at every
+    /// nesting level, and a tool-call fragment.
+    fn maximal_chunk() -> Value {
+        json!({
+            "id": "chatcmpl-123",
+            "choices": [{
+                "delta": {
+                    "content": "Hello",
+                    "function_call": {"arguments": "{\"q\":", "name": "legacy_fn"},
+                    "refusal": null,
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call-1",
+                        "function": {"arguments": "{\"z\":1,\"a\":2}", "name": "search"},
+                        "type": "function"
+                    }],
+                    "reasoning_content": "step by step"
+                },
+                "finish_reason": "tool_calls",
+                "index": 3,
+                "logprobs": {
+                    "content": [{
+                        "token": "Hello",
+                        "bytes": [72, 101, 108, 108, 111],
+                        "logprob": -0.1,
+                        "top_logprobs": [{"token": "Hello", "bytes": null, "logprob": -0.1}]
+                    }],
+                    "refusal": null
+                },
+                "new_choice_field": true
+            }],
+            "created": 1_700_000_000,
+            "model": "gpt-5.6",
+            "object": "chat.completion.chunk",
+            "service_tier": "default",
+            "system_fingerprint": "fp_44709d6fcb",
+            "usage": {
+                "completion_tokens": 12,
+                "prompt_tokens": 9,
+                "total_tokens": 21,
+                "prompt_tokens_details": {"cached_tokens": 3}
+            },
+            "obfuscation": "8Xk2p"
+        })
+    }
+
+    /// The mandated test, chunk-side: an OpenAI-compatible chunk must survive
+    /// normalization and come back out with ZERO permitted transformations.
+    #[test]
+    fn openai_compat_chunk_round_trip_is_lossless() {
+        round_trip(maximal_chunk(), "openai");
+
+        // Spot-check the typed views the IR exposes along the way.
+        let normalized = ingest_chunk(parse(maximal_chunk()));
+        assert_eq!(normalized.id, "chatcmpl-123");
+        assert_eq!(normalized.created, Some(1_700_000_000));
+        let completion = &normalized.completions[0];
+        assert_eq!(completion.finish_reason, Some(FinishReason::ToolCalls));
+        assert_eq!(completion.finish_reason_raw.as_deref(), Some("tool_calls"));
+        assert_eq!(completion.ext["openai_compat"]["index"], json!(3));
+        assert_eq!(completion.delta.role, Some(Role::Assistant));
+        assert_eq!(
+            normalized.usage.as_ref().unwrap().cache_read_tokens,
+            Some(3)
+        );
+        assert_eq!(
+            normalized.ext["openai_compat"]["obfuscation"],
+            json!("8Xk2p")
+        );
+    }
+
+    /// The chunk a provider that sends nothing optional would send.
+    #[test]
+    fn a_minimal_chunk_round_trips() {
+        round_trip(
+            json!({
+                "id": "chatcmpl-1",
+                "choices": [{"delta": {}, "finish_reason": null, "index": 0}],
+                "created": 1_700_000_000,
+                "model": "gpt-5.6",
+                "object": "chat.completion.chunk"
+            }),
+            "openai",
+        );
+    }
+
+    /// The three states of `content` a live stream sends, each of which has to
+    /// come back out as itself.
+    #[test]
+    fn absent_null_and_empty_content_stay_distinct() {
+        let chunk = |delta: Value| {
+            json!({
+                "id": "chatcmpl-1",
+                "choices": [{"delta": delta, "finish_reason": null, "index": 0}],
+                "created": 1_700_000_000,
+                "model": "gpt-5.6",
+                "object": "chat.completion.chunk"
+            })
+        };
+
+        for delta in [json!({}), json!({"content": null}), json!({"content": ""})] {
+            round_trip(chunk(delta), "openai");
+        }
+
+        // ...and the IR tells them apart, not merely the bytes.
+        let absent = ingest_chunk(parse(chunk(json!({}))));
+        assert!(absent.completions[0].delta.content.is_empty());
+
+        let nulled = ingest_chunk(parse(chunk(json!({"content": null}))));
+        assert!(nulled.completions[0].delta.content.is_empty());
+        assert_eq!(
+            nulled.completions[0].delta.ext["openai_compat"]["content"],
+            Value::Null
+        );
+
+        let empty = ingest_chunk(parse(chunk(json!({"content": ""}))));
+        assert!(matches!(
+            &empty.completions[0].delta.content[0],
+            ContentDelta::Text { text } if text.is_empty()
+        ));
+    }
+
+    /// The opener names the call and carries `type`; the fragments after it
+    /// carry only an index and more argument text, and must not gain a `type`
+    /// the provider never sent.
+    #[test]
+    fn tool_call_fragments_keep_their_shape() {
+        let fragment = |call: Value| {
+            json!({
+                "id": "chatcmpl-1",
+                "choices": [{
+                    "delta": {"tool_calls": [call]},
+                    "finish_reason": null,
+                    "index": 0
+                }],
+                "created": 1_700_000_000,
+                "model": "deepseek-v4-flash",
+                "object": "chat.completion.chunk"
+            })
+        };
+        let opener = json!({
+            "index": 0,
+            "id": "call_0_5f3a91c2",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": ""}
+        });
+        let continuation = json!({"index": 0, "function": {"arguments": "{\"city\":"}});
+
+        round_trip(fragment(opener.clone()), "deepseek");
+        round_trip(fragment(continuation.clone()), "deepseek");
+
+        let normalized = ingest_chunk(parse(fragment(opener)));
+        assert!(matches!(
+            &normalized.completions[0].delta.content[0],
+            ContentDelta::ToolCall { index: 0, id: Some(id), name: Some(name), .. }
+                if id == "call_0_5f3a91c2" && name == "get_weather"
+        ));
+
+        let normalized = ingest_chunk(parse(fragment(continuation)));
+        assert!(matches!(
+            &normalized.completions[0].delta.content[0],
+            ContentDelta::ToolCall { index: 0, id: None, kind: None, name: None, arguments: Some(a) }
+                if a == "{\"city\":"
+        ));
+    }
+
+    /// A fragment this conversion has no typed shape for passes through
+    /// verbatim rather than being flattened into one that loses its residue.
+    #[test]
+    fn a_nonstandard_tool_call_fragment_passes_through_verbatim() {
+        let chunk = |call: Value| {
+            json!({
+                "id": "chatcmpl-1",
+                "choices": [{
+                    "delta": {"tool_calls": [call]},
+                    "finish_reason": null,
+                    "index": 0
+                }],
+                "created": 1_700_000_000,
+                "model": "gpt-5.6",
+                "object": "chat.completion.chunk"
+            })
+        };
+        let odd = [
+            json!({"index": 0, "type": "custom", "function": {"arguments": "x"}}),
+            json!({"index": 0, "function": {"arguments": "x"}, "vendor_extra": true}),
+            json!({"index": 0, "function": {}}),
+            json!({"index": 0, "id": "call-1"}),
+        ];
+        for call in odd {
+            round_trip(chunk(call.clone()), "openai");
+            let normalized = ingest_chunk(parse(chunk(call.clone())));
+            assert!(
+                matches!(&normalized.completions[0].delta.content[0], ContentDelta::Unknown(v) if *v == call),
+                "{call} was not passed through verbatim"
+            );
+        }
+    }
+
+    /// `usage: null` rides every chunk of a stream that asked for totals
+    /// except the one that carries them, so the null and the totals are both
+    /// ordinary and neither may turn into the other.
+    #[test]
+    fn a_null_usage_is_not_an_absent_one() {
+        let chunk = |usage: Value| {
+            let mut body = json!({
+                "id": "chatcmpl-1",
+                "choices": [],
+                "created": 1_700_000_000,
+                "model": "gpt-5.6",
+                "object": "chat.completion.chunk"
+            });
+            if !usage.is_null() {
+                body.as_object_mut().unwrap().insert("usage".into(), usage);
+            }
+            body
+        };
+
+        round_trip(chunk(Value::Null), "openai");
+        round_trip(chunk(json!(null)), "openai");
+        round_trip(
+            chunk(json!({"completion_tokens": 3, "prompt_tokens": 11, "total_tokens": 14})),
+            "openai",
+        );
+
+        let mut nulled = chunk(Value::Null);
+        nulled
+            .as_object_mut()
+            .unwrap()
+            .insert("usage".into(), Value::Null);
+        let normalized = ingest_chunk(parse(nulled.clone()));
+        assert!(normalized.usage.is_none());
+        assert_eq!(normalized.ext["openai_compat"]["usage"], Value::Null);
+        assert_eq!(
+            serde_json::to_value(render_chunk(&normalized, "openai")).unwrap(),
+            nulled
+        );
+    }
+
+    /// The usage-only chunk `stream_options.include_usage` adds: no choices at
+    /// all, and the totals for the whole request.
+    #[test]
+    fn a_usage_only_chunk_round_trips() {
+        round_trip(
+            json!({
+                "id": "chatcmpl-1",
+                "choices": [],
+                "created": 1_700_000_000,
+                "model": "gpt-5.6",
+                "object": "chat.completion.chunk",
+                "usage": {
+                    "completion_tokens": 3,
+                    "prompt_tokens": 11,
+                    "total_tokens": 14,
+                    "completion_tokens_details": {"reasoning_tokens": 0},
+                    "prompt_tokens_details": {"cached_tokens": 0}
+                }
+            }),
+            "openai",
+        );
+    }
+
+    /// Promoted for any provider on this protocol, ordered before the answer
+    /// it led to, and still replayed from ext — the same PROMOTE BUT RETAIN
+    /// contract the whole-reply path states.
+    #[test]
+    fn reasoning_content_becomes_a_delta_before_the_answer() {
+        let normalized = ingest_chunk(parse(maximal_chunk()));
+        let content = &normalized.completions[0].delta.content;
+
+        assert!(matches!(
+            &content[0],
+            ContentDelta::Reasoning { text, provenance }
+                if text == "step by step" && provenance.as_deref() == Some("openai_compat")
+        ));
+        assert!(
+            matches!(&content[1], ContentDelta::Text { .. }),
+            "the answer must still follow the reasoning: {content:?}"
+        );
+
+        let rendered = render_chunk(&normalized, "deepseek");
+        assert_eq!(
+            rendered.choices[0].delta.unknown_fields["reasoning_content"],
+            json!("step by step")
+        );
+    }
+
+    /// A non-string `reasoning_content` must not panic and must not be
+    /// promoted — ingest does not type this field.
+    #[test]
+    fn only_a_string_reasoning_content_is_promoted() {
+        for value in [json!(null), json!(["not", "a", "string"]), json!(7)] {
+            let mut body = maximal_chunk();
+            body["choices"][0]["delta"]["reasoning_content"] = value.clone();
+            let normalized = ingest_chunk(parse(body.clone()));
+            assert!(
+                !matches!(
+                    normalized.completions[0].delta.content[0],
+                    ContentDelta::Reasoning { .. }
+                ),
+                "{value} was promoted"
+            );
+            round_trip(body, "deepseek");
+        }
+    }
+
+    /// An empty `tool_calls` array is distinguishable from an absent one, and
+    /// has to come back as the empty array it arrived as.
+    #[test]
+    fn an_empty_tool_calls_array_survives() {
+        round_trip(
+            json!({
+                "id": "chatcmpl-1",
+                "choices": [{
+                    "delta": {"content": "hi", "tool_calls": []},
+                    "finish_reason": null,
+                    "index": 0
+                }],
+                "created": 1_700_000_000,
+                "model": "gpt-5.6",
+                "object": "chat.completion.chunk"
+            }),
+            "openai",
+        );
+    }
+
+    /// An unrecognized role keeps its exact wire spelling, so a chunk that
+    /// opens on one still round-trips.
+    #[test]
+    fn an_unknown_role_keeps_its_spelling() {
+        let body = json!({
+            "id": "chatcmpl-1",
+            "choices": [{
+                "delta": {"role": "critic"},
+                "finish_reason": null,
+                "index": 0
+            }],
+            "created": 1_700_000_000,
+            "model": "gpt-5.6",
+            "object": "chat.completion.chunk"
+        });
+        round_trip(body.clone(), "openai");
+        assert_eq!(
+            ingest_chunk(parse(body)).completions[0].delta.ext["openai_compat"]["role"],
+            json!("critic")
+        );
+    }
+
+    #[test]
+    fn ingest_populates_source() {
+        let wire = parse(maximal_chunk());
+        let normalized = ingest_chunk(wire.clone());
+        let source = normalized.source.as_ref().unwrap();
+        assert_eq!(source.protocol, Protocol::OpenAiCompat);
+        assert_eq!(source.body, serde_json::to_value(&wire).unwrap());
+    }
+
+    /// The load-bearing one: whole recorded streams, event by event, rather
+    /// than chunks written to suit the conversion.
+    ///
+    /// A hand-built fixture proves the shapes hold what its author thought to
+    /// put in it. These are the transcripts `tests/protocol/` already checks
+    /// the WIRE types against, so running the same bytes through normalization
+    /// is what says the IR holds a real stream and not just a plausible one —
+    /// including the parts nobody designs for: an opening `content: ""`, a
+    /// `logprobs: null` on every chunk, tool-call arguments split mid-JSON, and
+    /// OpenAI's per-chunk `obfuscation`, which no specification names.
+    ///
+    /// These live here rather than beside the wire-level transcript tests
+    /// because `ingest_chunk` and `render_chunk` are crate-internal; the
+    /// fixtures are shared with `tests/` deliberately, so a captured transcript
+    /// that replaces one is checked from both ends at once.
+    #[test]
+    fn every_recorded_transcript_survives_normalization() {
+        for name in ["openai-text", "deepseek-tool-call"] {
+            let sse = std::fs::read_to_string(format!(
+                "{}/tests/protocol/openai_compat/chat_completions/fixtures/transcript/{name}.sse",
+                env!("CARGO_MANIFEST_DIR")
+            ))
+            .unwrap();
+            let payloads: Vec<&str> = sse
+                .lines()
+                .filter_map(|line| line.strip_prefix("data: "))
+                .filter(|payload| *payload != "[DONE]")
+                .collect();
+            assert!(payloads.len() > 1, "{name} has no events");
+
+            let provider = if name.starts_with("deepseek") {
+                "deepseek"
+            } else {
+                "openai"
+            };
+            for payload in payloads {
+                let body: Value = serde_json::from_str(payload).unwrap();
+                let normalized = ingest_chunk(parse(body.clone()));
+                assert_eq!(
+                    serde_json::to_value(render_chunk(&normalized, provider)).unwrap(),
+                    body,
+                    "{name} lost something on the way through the IR"
+                );
+            }
+        }
+    }
+
+    /// ...and the IR of a real transcript is worth reading, not merely worth
+    /// re-serializing: the pieces a consumer needs are typed, in order, and
+    /// where a fold would look for them.
+    #[test]
+    fn a_recorded_tool_call_is_typed_fragment_by_fragment() {
+        let sse = std::fs::read_to_string(format!(
+            "{}/tests/protocol/openai_compat/chat_completions/fixtures/transcript/\
+             deepseek-tool-call.sse",
+            env!("CARGO_MANIFEST_DIR")
+        ))
+        .unwrap();
+        let normalized: Vec<_> = sse
+            .lines()
+            .filter_map(|line| line.strip_prefix("data: "))
+            .filter(|payload| *payload != "[DONE]")
+            .map(|payload| ingest_chunk(serde_json::from_str(payload).unwrap()))
+            .collect();
+
+        // The reasoning that opened the stream, typed rather than left in ext.
+        assert!(matches!(
+            &normalized[0].completions[0].delta.content[0],
+            ContentDelta::Reasoning { text, .. } if text == "the user wants today's weather"
+        ));
+        assert_eq!(
+            normalized[0].completions[0].delta.role,
+            Some(crate::gateway::types::Role::Assistant)
+        );
+
+        // Every fragment of the call, correlated by index, with the id on the
+        // opener alone — concatenating the arguments yields the whole.
+        let fragments: Vec<_> = normalized
+            .iter()
+            .flat_map(|chunk| &chunk.completions)
+            .flat_map(|completion| &completion.delta.content)
+            .filter_map(|delta| match delta {
+                ContentDelta::ToolCall {
+                    index,
+                    id,
+                    arguments,
+                    ..
+                } => Some((*index, id.clone(), arguments.clone().unwrap_or_default())),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(fragments.len(), 3, "the call arrived in three pieces");
+        assert!(fragments.iter().all(|(index, ..)| *index == 0));
+        assert_eq!(fragments[0].1.as_deref(), Some("call_0_5f3a91c2"));
+        assert!(fragments[1].1.is_none(), "the id arrives once");
+        assert_eq!(
+            fragments
+                .iter()
+                .map(|(_, _, args)| args.as_str())
+                .collect::<String>(),
+            r#"{"city":"Seoul"}"#
+        );
+
+        // The totals ride the last chunk, after the choice already finished.
+        let last = normalized.last().unwrap();
+        assert_eq!(last.usage.as_ref().unwrap().total_tokens, Some(111));
+        assert_eq!(last.usage.as_ref().unwrap().cache_read_tokens, Some(64));
+        assert_eq!(
+            last.completions[0].finish_reason,
+            Some(FinishReason::ToolCalls)
+        );
+    }
+}

--- a/crates/warpllm/src/gateway/types/mod.rs
+++ b/crates/warpllm/src/gateway/types/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod error;
 pub(crate) mod message;
 pub(crate) mod request;
 pub(crate) mod response;
+pub(crate) mod stream;
 
 /// `pub`, not `pub(crate)` like its siblings, so `lib.rs` can re-export these
 /// three. It leaks nothing on its own — `crate::gateway` is a private module,
@@ -13,6 +14,7 @@ pub use error::*;
 pub(crate) use message::*;
 pub(crate) use request::*;
 pub(crate) use response::*;
+pub(crate) use stream::*;
 
 use std::collections::BTreeMap;
 

--- a/crates/warpllm/src/gateway/types/stream.rs
+++ b/crates/warpllm/src/gateway/types/stream.rs
@@ -1,0 +1,338 @@
+//! The gateway chat response, streamed: one value per chunk.
+//!
+//! [`ChatResponseChunk`] mirrors [`ChatResponse`](super::ChatResponse) field for
+//! field, with delta semantics — same names, same `ext` discipline, same
+//! vocabulary ([`Role`], [`FinishReason`], [`Usage`]). Reading the two side by
+//! side is how you see what a chunk is: the completed response with every
+//! guarantee relaxed to "some of this may arrive later, or never".
+//!
+//! # Why the completed form could not be reused
+//!
+//! Four of its invariants are exactly what a chunk breaks:
+//!
+//! - `Completion::finish_reason_raw` is a required `String`; a chunk sends
+//!   `null` on every chunk of a choice but the last.
+//! - `Message::role` is required; a delta carries it once, on the chunk that
+//!   opens the choice.
+//! - `ContentBlock::Text` cannot say it holds a *fragment*, and cannot tell
+//!   absent from `null` from `""` — three states one live OpenAI stream sends.
+//! - `ContentBlock::ToolCall` requires `id`, `name`, and complete `arguments`,
+//!   while a streamed call is correlated by `index` and its arguments arrive
+//!   split mid-JSON. `index` has nowhere to live, and a fragment like
+//!   `{"city":` is not the "exact JSON text" [`RawJson`](super::RawJson)
+//!   promises to hold.
+//!
+//! Relaxing those on the completed form would make every whole-response
+//! consumer unwrap `Option`s that are never `None` on its path, and would still
+//! leave `index` homeless. So this is a second shape — built from the first
+//! one's vocabulary, not beside it.
+//!
+//! # One value per chunk
+//!
+//! The typed union is at the *content* level ([`ContentDelta`]), which is
+//! richer than the wire's one sparse delta object: reasoning, text, and
+//! tool-call fragments are distinct variants rather than sibling keys. The
+//! envelope stays one-for-one with a wire chunk, because a chunk carries fields
+//! that belong to no single semantic event — `system_fingerprint`,
+//! `service_tier`, a repeated `logprobs: null`, and OpenAI's per-chunk
+//! `obfuscation`, which changes on every one. Exploding a chunk into several
+//! events would strand that residue and make re-chunking a guess.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::{FinishReason, IngestSource, ProviderExt, Role, Usage};
+
+/// One chunk of a streaming chat response, normalized.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ChatResponseChunk {
+    /// Identifies the completion, not the chunk: every chunk of one stream
+    /// carries the same value.
+    pub id: String,
+    /// Upstream model name as returned; the client overwrites the wire echo
+    /// with the caller's prefixed string after rendering, on every chunk.
+    pub model: String,
+    /// Not every provider reports a creation timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created: Option<u64>,
+    /// Empty on the usage-only chunk `stream_options.include_usage` adds, and
+    /// on any keepalive a provider sends with no choices.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub completions: Vec<CompletionDelta>,
+    /// Totals for the whole request, not this chunk. Present only when the
+    /// caller asked for them, and only on the chunk that carries them.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<Usage>,
+    #[serde(default, skip_serializing_if = "ProviderExt::is_empty")]
+    pub ext: ProviderExt,
+    #[serde(skip)]
+    #[allow(dead_code)] // staged: read once the passthrough fast path lands
+    pub source: Option<IngestSource>,
+}
+
+/// The streaming counterpart of [`Completion`](super::Completion).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct CompletionDelta {
+    pub delta: MessageDelta,
+    /// Derived from the raw string; for programmatic matching only. `None`
+    /// until the choice ends — which is every chunk of it but the last.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<FinishReason>,
+    /// Authoritative on render — losslessly echoes the provider's value.
+    /// `None` and `Some` track [`Self::finish_reason`] exactly.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finish_reason_raw: Option<String>,
+    /// Carries the wire choice's `index` and `logprobs`.
+    #[serde(default, skip_serializing_if = "ProviderExt::is_empty")]
+    pub ext: ProviderExt,
+}
+
+/// The streaming counterpart of [`Message`](super::Message): every field is a
+/// fragment, so every field is optional — a chunk carrying only `role`, only a
+/// slice of text, or nothing at all is ordinary.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct MessageDelta {
+    /// Sent once, on the chunk that opens the choice.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<Role>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub content: Vec<ContentDelta>,
+    /// Carries the raw role spelling, refusal fragments, and the deprecated
+    /// `function_call`.
+    #[serde(default, skip_serializing_if = "ProviderExt::is_empty")]
+    pub ext: ProviderExt,
+}
+
+/// A fragment of one piece of a message.
+///
+/// Deliberately narrower than [`ContentBlock`](super::ContentBlock): media,
+/// tool results, and cache hints cannot arrive in fragments, so they have no
+/// variant here. What a stream can split, this can hold.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub(crate) enum ContentDelta {
+    /// A slice of the answer. An empty string is a real, distinct value — an
+    /// OpenAI stream opens with `"content": ""` — and is not the same as no
+    /// delta at all.
+    Text { text: String },
+
+    /// A slice of chain-of-thought.
+    ///
+    /// No [`ReasoningDetail`](super::ReasoningDetail), unlike the completed
+    /// form: a signature covers a whole reasoning block and cannot be carried
+    /// by the fragments it is computed over, so a delta that offered the field
+    /// could only ever leave it `None`.
+    Reasoning {
+        text: String,
+        /// Native protocol this fragment originated from; see
+        /// [`ContentBlock::Reasoning`](super::ContentBlock).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        provenance: Option<String>,
+    },
+
+    /// A slice of one tool call. Every part but the index is optional, because
+    /// every part of a streamed call arrives when it arrives.
+    ToolCall {
+        /// The correlation key, and the reason this variant exists rather than
+        /// reusing the completed block: `id` and `name` arrive once, on
+        /// whichever fragment opens the call, and every fragment after it
+        /// carries only this index and more argument text.
+        index: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+        /// What kind of call this is — a function, or whatever else a protocol
+        /// distinguishes. Carried rather than assumed: it arrives on the
+        /// fragment that opens a call and is absent on the rest, so a form
+        /// that restored a constant would put a key on the wire the provider
+        /// never sent.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        kind: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        /// A FRAGMENT of the JSON-encoded arguments, so a `String` and not a
+        /// [`RawJson`](super::RawJson): concatenating one call's fragments
+        /// yields the whole, which is model-generated and so may still be
+        /// invalid JSON. `None` is a fragment that carried no argument text at
+        /// all, which is not the same as one that carried `""`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        arguments: Option<String>,
+    },
+
+    /// Forward-compat, matching the completed form: pass through when
+    /// source == target, else policy.
+    #[serde(untagged)]
+    Unknown(Value),
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::types::Protocol;
+
+    fn round_trip(delta: &ContentDelta) -> Value {
+        let value = serde_json::to_value(delta).unwrap();
+        let back: ContentDelta = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&back).unwrap(), value);
+        value
+    }
+
+    #[test]
+    fn every_delta_variant_round_trips() {
+        let deltas = [
+            ContentDelta::Text {
+                text: "Hello".into(),
+            },
+            ContentDelta::Reasoning {
+                text: "step by step".into(),
+                provenance: Some("openai_compat".into()),
+            },
+            ContentDelta::ToolCall {
+                index: 0,
+                id: Some("call-1".into()),
+                kind: Some("function".into()),
+                name: Some("search".into()),
+                arguments: Some(String::new()),
+            },
+            ContentDelta::ToolCall {
+                index: 0,
+                id: None,
+                kind: None,
+                name: None,
+                arguments: Some(r#"{"city":"#.into()),
+            },
+        ];
+        for delta in &deltas {
+            round_trip(delta);
+        }
+    }
+
+    /// The empty string is a value, not an absence: an OpenAI stream opens
+    /// with `"content": ""`, and a form that collapsed it into "no delta"
+    /// would lose the chunk that told a client the answer had started.
+    #[test]
+    fn an_empty_text_delta_is_not_an_absent_one() {
+        let value = round_trip(&ContentDelta::Text {
+            text: String::new(),
+        });
+        assert_eq!(value, json!({"type": "text", "text": ""}));
+
+        let empty = MessageDelta::default();
+        assert!(empty.content.is_empty());
+        assert_eq!(serde_json::to_value(&empty).unwrap(), json!({}));
+    }
+
+    /// A fragment that opens a call names it; the ones after carry only the
+    /// index and more argument text. Both must survive as themselves.
+    #[test]
+    fn a_tool_call_fragment_keeps_its_index_and_omits_what_it_lacks() {
+        let opener = round_trip(&ContentDelta::ToolCall {
+            index: 2,
+            id: Some("call_0_5f3a91c2".into()),
+            kind: Some("function".into()),
+            name: Some("get_weather".into()),
+            arguments: Some(String::new()),
+        });
+        assert_eq!(opener["index"], 2);
+        assert_eq!(opener["id"], "call_0_5f3a91c2");
+        assert_eq!(opener["arguments"], "");
+
+        let continuation = round_trip(&ContentDelta::ToolCall {
+            index: 2,
+            id: None,
+            kind: None,
+            name: None,
+            arguments: Some(r#""Seoul"}"#.into()),
+        });
+        assert!(continuation.get("id").is_none(), "{continuation}");
+        assert!(continuation.get("kind").is_none(), "{continuation}");
+        assert!(continuation.get("name").is_none(), "{continuation}");
+        assert_eq!(continuation["arguments"], r#""Seoul"}"#);
+    }
+
+    #[test]
+    fn an_unrecognized_delta_becomes_unknown_verbatim() {
+        let value = json!({"type": "hologram", "payload": {"z": 1, "a": 2}});
+        let delta: ContentDelta = serde_json::from_value(value.clone()).unwrap();
+        assert!(matches!(&delta, ContentDelta::Unknown(v) if *v == value));
+        assert_eq!(serde_json::to_value(&delta).unwrap(), value);
+    }
+
+    #[test]
+    fn chunk_round_trips_and_skips_source() {
+        let mut chunk = ChatResponseChunk {
+            id: "chatcmpl-123".into(),
+            model: "gpt-5.6".into(),
+            created: Some(1_700_000_000),
+            completions: vec![CompletionDelta {
+                delta: MessageDelta {
+                    role: Some(Role::Assistant),
+                    content: vec![ContentDelta::Text {
+                        text: "Hello".into(),
+                    }],
+                    ext: ProviderExt::new(),
+                },
+                finish_reason: Some(FinishReason::Stop),
+                finish_reason_raw: Some("stop".into()),
+                ext: ProviderExt::new(),
+            }],
+            usage: None,
+            ext: ProviderExt::new(),
+            source: Some(IngestSource {
+                protocol: Protocol::OpenAiCompat,
+                body: json!({"id": "chatcmpl-123"}),
+            }),
+        };
+        chunk
+            .ext
+            .insert("openai_compat".into(), json!({"obfuscation": "KtQ3nZ8w"}));
+
+        let value = serde_json::to_value(&chunk).unwrap();
+        assert!(value.get("source").is_none(), "source must not serialize");
+
+        let back: ChatResponseChunk = serde_json::from_value(value.clone()).unwrap();
+        assert!(back.source.is_none());
+        assert_eq!(serde_json::to_value(&back).unwrap(), value);
+    }
+
+    /// The usage-only chunk: no choices at all, and the totals for the whole
+    /// request. An empty `completions` must not serialize as `[]` noise.
+    #[test]
+    fn a_usage_only_chunk_carries_no_completions() {
+        let chunk = ChatResponseChunk {
+            id: "chatcmpl-123".into(),
+            model: "gpt-5.6".into(),
+            created: Some(1_700_000_000),
+            completions: Vec::new(),
+            usage: Some(Usage {
+                input_tokens: Some(11),
+                output_tokens: Some(3),
+                total_tokens: Some(14),
+                ..Default::default()
+            }),
+            ext: ProviderExt::new(),
+            source: None,
+        };
+        let value = serde_json::to_value(&chunk).unwrap();
+        assert!(value.get("completions").is_none(), "{value}");
+        assert_eq!(value["usage"]["total_tokens"], 14);
+    }
+
+    /// `finish_reason` and its raw spelling are absent together on every chunk
+    /// of a choice but the last, and present together on that one.
+    #[test]
+    fn an_unfinished_completion_omits_both_finish_fields() {
+        let unfinished = CompletionDelta {
+            delta: MessageDelta::default(),
+            finish_reason: None,
+            finish_reason_raw: None,
+            ext: ProviderExt::new(),
+        };
+        assert_eq!(
+            serde_json::to_value(&unfinished).unwrap(),
+            json!({"delta": {}})
+        );
+    }
+}

--- a/crates/warpllm/src/json_client.rs
+++ b/crates/warpllm/src/json_client.rs
@@ -3,7 +3,7 @@
 //! PyO3 and napi-rs should expose Rust, not each maintain the same serde
 //! adapter. Keeping that adapter here makes both native modules mechanical.
 
-use crate::{Client, ClientConfig, Error, Result};
+use crate::{Client, ClientConfig, CreateChatCompletionRequest, Error, Result};
 
 /// A [`Client`] whose inputs and outputs are JSON strings.
 ///
@@ -24,8 +24,22 @@ impl JsonClient {
     }
 
     pub async fn chat_completions(&self, request_json: &str) -> Result<String> {
-        let request = serde_json::from_str(request_json)
+        let request: CreateChatCompletionRequest = serde_json::from_str(request_json)
             .map_err(|error| Error::InvalidInput(error.to_string()))?;
+        // Refused HERE rather than inherited from [`Client::chat_completions`],
+        // which refuses `stream: true` by naming the Rust method that serves
+        // it. That advice is true of Rust and of nothing on this boundary: a
+        // binding built on it has one method, and telling its caller to reach
+        // for a second one they cannot see is worse than saying no.
+        //
+        // So what a binding caller is told is that the SURFACE does not stream,
+        // which is the truth until this boundary can carry chunks. The HTTP
+        // gateway states the same thing for the same reason.
+        if request.stream == Some(true) {
+            return Err(Error::NotImplemented(
+                "streaming over the language bindings",
+            ));
+        }
         let response = self.inner.chat_completions(request).await?;
         serde_json::to_string(&response).map_err(|error| Error::Internal(error.to_string()))
     }
@@ -41,5 +55,23 @@ mod tests {
             .err()
             .expect("invalid configuration should fail");
         assert!(matches!(error, Error::InvalidInput(_)));
+    }
+
+    /// A binding caller asking to stream is told the SURFACE cannot, not to
+    /// call a Rust method it has no way to reach. Both language suites assert
+    /// this from the other side; pinning it here is what keeps the Rust client
+    /// free to give Rust callers better advice without silently changing what
+    /// a Node or Python caller is told.
+    #[tokio::test]
+    async fn streaming_over_the_json_boundary_is_not_implemented() {
+        let client = JsonClient::new("{}").unwrap();
+        let error = client
+            .chat_completions(r#"{"model":"openai/gpt-5.6","messages":[],"stream":true}"#)
+            .await
+            .expect_err("the boundary cannot carry chunks");
+        assert!(matches!(error, Error::NotImplemented(_)), "{error:?}");
+        // 501, and the word a caller greps for.
+        assert_eq!(error.to_openai().status, Some(501));
+        assert!(error.to_string().contains("streaming"), "{error}");
     }
 }

--- a/crates/warpllm/src/lib.rs
+++ b/crates/warpllm/src/lib.rs
@@ -12,7 +12,7 @@ mod registry;
 pub mod protocol;
 pub mod types;
 
-pub use client::Client;
+pub use client::{ChatCompletionStream, Client};
 pub use config::ClientConfig;
 pub use error::{Error, Origin, Result};
 /// The gateway's canonical form for an upstream failure — the error-side
@@ -37,6 +37,7 @@ pub use json_client::JsonClient;
 /// every time that module gained a type.
 pub use protocol::openai_compat::chat_completions::types::{
     ChatCompletionRequestMessage, CreateChatCompletionRequest, CreateChatCompletionResponse,
+    CreateChatCompletionStreamResponse,
 };
 /// A failure rendered the way an OpenAI-compatible surface reports it, and
 /// the only error shape warpllm shows anyone who is not writing Rust.

--- a/crates/warpllm/src/protocol/openai_compat/chat_completions/transport.rs
+++ b/crates/warpllm/src/protocol/openai_compat/chat_completions/transport.rs
@@ -7,8 +7,12 @@ use std::time::Duration;
 use crate::error::{Error, Result};
 use crate::http::{network_error, read_response};
 use crate::protocol::openai_compat::chat_completions::types::{
-    CreateChatCompletionRequest, CreateChatCompletionResponse,
+    CreateChatCompletionRequest, CreateChatCompletionResponse, CreateChatCompletionStreamResponse,
 };
+
+/// The payload that ends an OpenAI-compatible stream. Not JSON, and not a
+/// chunk — the one `data:` value that has to be recognized rather than parsed.
+const DONE: &str = "[DONE]";
 
 /// What the upstream said. A non-2xx is NOT an [`Err`] here: which [`Error`] a
 /// given status and body becomes is the caller's to decide: a provider may
@@ -75,6 +79,235 @@ pub(crate) async fn post(
             provider,
             message: e.to_string(),
         })
+}
+
+/// [`Outcome`] for a streamed request. Same contract: a non-2xx is DATA, and
+/// only the caller decides which [`Error`] it becomes.
+///
+/// The success arm holds an open socket rather than a decoded body, which is
+/// the whole difference between this and [`Outcome`]: nothing has been read
+/// past the headers, so the status decision is made before the first chunk and
+/// never again.
+#[derive(Debug)]
+pub(crate) enum StreamOutcome {
+    Ok(ChunkStream),
+    /// The status, raw body, and header evidence, verbatim, for the caller to
+    /// map — see [`Outcome::Status`].
+    Status {
+        status: u16,
+        body: String,
+        retry_after: Option<Duration>,
+        request_id: Option<String>,
+    },
+}
+
+/// Sends a `stream: true` request and hands back the events, undecoded until
+/// asked for.
+///
+/// A non-2xx body is read to the end here, exactly as [`post`] does: an error
+/// reply is small, complete, and worth nothing streamed.
+pub(crate) async fn post_stream(
+    http: &reqwest::Client,
+    provider: &'static str,
+    base_url: &str,
+    api_key: &str,
+    body: &CreateChatCompletionRequest,
+) -> Result<StreamOutcome> {
+    let response = http
+        .post(format!(
+            "{}/chat/completions",
+            base_url.trim_end_matches('/')
+        ))
+        .bearer_auth(api_key)
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| network_error(provider, e))?;
+
+    if !(200..300).contains(&response.status().as_u16()) {
+        let parts = read_response(provider, response).await?;
+        return Ok(StreamOutcome::Status {
+            status: parts.status,
+            body: parts.body,
+            retry_after: parts.retry_after,
+            request_id: parts.request_id,
+        });
+    }
+
+    Ok(StreamOutcome::Ok(ChunkStream {
+        response,
+        provider,
+        frames: Frames::default(),
+        ended: false,
+    }))
+}
+
+/// Server-sent event framing, with no socket in it: bytes in, payloads out.
+///
+/// Separate from [`ChunkStream`] because this is the fiddly half and the half
+/// worth testing exhaustively — a read boundary falls wherever TCP puts it,
+/// which is routinely mid-line and can be mid-character. Keeping it free of
+/// I/O means every edge below is a plain function call in a test.
+///
+/// It reads the subset OpenAI-compatible providers actually send:
+///
+/// - `data:` lines accumulate into the current event, joined by newlines when
+///   a provider splits one across several (the specification allows it; none
+///   of them do it today);
+/// - a blank line dispatches the accumulated event;
+/// - `:` comment lines — the usual keepalive — and every other SSE field
+///   (`event:`, `id:`, `retry:`) are ignored;
+/// - the [`DONE`] payload ends the stream rather than becoming an event.
+#[derive(Debug, Default)]
+struct Frames {
+    /// Read but not yet consumed as complete lines.
+    buffer: Vec<u8>,
+    /// The `data:` payload of the event being accumulated.
+    event: String,
+    done: bool,
+}
+
+impl Frames {
+    fn push(&mut self, bytes: &[u8]) {
+        self.buffer.extend_from_slice(bytes);
+    }
+
+    /// The next dispatched payload, or `None` when the bytes so far do not
+    /// contain a complete event — which is the signal to go read more.
+    ///
+    /// Lines are decoded as UTF-8 only once complete, so a multi-byte
+    /// character split across two reads is rejoined rather than mangled.
+    // `std::result::Result` spelled out: the crate's own `Result` alias fixes
+    // the error type, and this one is a UTF-8 failure the caller labels.
+    fn next_payload(&mut self) -> std::result::Result<Option<String>, std::str::Utf8Error> {
+        while !self.done {
+            let Some(line) = self.take_line() else {
+                return Ok(None);
+            };
+            let line = std::str::from_utf8(&line)?;
+            let line = line.strip_suffix('\r').unwrap_or(line);
+            if line.is_empty() {
+                if let Some(payload) = self.dispatch() {
+                    return Ok(Some(payload));
+                }
+            } else if let Some(payload) = line.strip_prefix("data:") {
+                if !self.event.is_empty() {
+                    self.event.push('\n');
+                }
+                // One optional leading space belongs to the framing.
+                self.event
+                    .push_str(payload.strip_prefix(' ').unwrap_or(payload));
+            }
+        }
+        Ok(None)
+    }
+
+    /// The event accumulated so far, for a socket that closed without sending
+    /// its final blank line — providers do end streams that way.
+    fn flush(&mut self) -> Option<String> {
+        self.dispatch()
+    }
+
+    /// The next complete line, `\n` removed, or `None` when the buffer holds
+    /// only a partial one.
+    fn take_line(&mut self) -> Option<Vec<u8>> {
+        let end = self.buffer.iter().position(|byte| *byte == b'\n')?;
+        let mut line: Vec<u8> = self.buffer.drain(..=end).collect();
+        line.pop();
+        Some(line)
+    }
+
+    fn dispatch(&mut self) -> Option<String> {
+        let payload = std::mem::take(&mut self.event);
+        let payload = payload.trim();
+        if payload.is_empty() {
+            return None;
+        }
+        if payload == DONE {
+            self.done = true;
+            return None;
+        }
+        Some(payload.to_string())
+    }
+}
+
+/// The chunks of one streamed reply, read off the socket as they arrive.
+///
+/// [`Frames`] does the framing; this adds the socket and the decode. An
+/// inherent `async fn next` rather than a [`futures::Stream`] implementation:
+/// every caller here is a loop, and a loop needs no combinators, no pinning,
+/// and no dependency.
+#[derive(Debug)]
+pub(crate) struct ChunkStream {
+    response: reqwest::Response,
+    provider: &'static str,
+    frames: Frames,
+    /// The socket is spent — closed, or failed. Distinct from
+    /// [`Frames::done`], which means the sentinel arrived.
+    ended: bool,
+}
+
+impl ChunkStream {
+    /// The next chunk, or `None` once the stream ends.
+    ///
+    /// `None` is terminal: after `[DONE]`, a closed socket, or any error, this
+    /// keeps returning `None` rather than reading a socket with nothing left
+    /// to say.
+    pub(crate) async fn next(&mut self) -> Option<Result<CreateChatCompletionStreamResponse>> {
+        loop {
+            if self.ended || self.frames.done {
+                return None;
+            }
+            // Everything already buffered first; only read when it runs dry.
+            match self.frames.next_payload() {
+                Ok(Some(payload)) => {
+                    let decoded = self.decode(&payload);
+                    // The one path that can hand back an error with the socket
+                    // still open and more events already buffered behind it.
+                    // An error item is terminal, so it ends the stream here
+                    // rather than letting the next call resume past it.
+                    if decoded.is_err() {
+                        self.ended = true;
+                    }
+                    return Some(decoded);
+                }
+                // The sentinel ends the stream where it sits. Falling through
+                // to read again would block on an upstream that holds the
+                // response open after sending it — and the sentinel, not the
+                // socket, is what says a stream is over.
+                Ok(None) if self.frames.done => return None,
+                Ok(None) => {}
+                Err(e) => {
+                    self.ended = true;
+                    return Some(Err(self.decode_error(&e.to_string())));
+                }
+            }
+            match self.response.chunk().await {
+                Ok(Some(bytes)) => self.frames.push(&bytes),
+                Ok(None) => {
+                    self.ended = true;
+                    return self.frames.flush().map(|payload| self.decode(&payload));
+                }
+                Err(e) => {
+                    self.ended = true;
+                    return Some(Err(network_error(self.provider, e)));
+                }
+            }
+        }
+    }
+
+    fn decode(&self, payload: &str) -> Result<CreateChatCompletionStreamResponse> {
+        serde_json::from_str(payload).map_err(|e| self.decode_error(&e.to_string()))
+    }
+
+    /// An event that will not decode is nobody's to reinterpret — the same
+    /// judgement [`post`] makes about a 2xx body.
+    fn decode_error(&self, message: &str) -> Error {
+        Error::Decode {
+            provider: self.provider,
+            message: message.to_string(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -153,6 +386,273 @@ mod tests {
             .await;
 
         assert!(matches!(post_to(&server).await.unwrap(), Outcome::Ok(_)));
+    }
+
+    // -----------------------------------------------------------------------
+    // Framing
+    // -----------------------------------------------------------------------
+
+    /// Every payload the framing yields from one push of bytes.
+    fn payloads(chunks: &[&str]) -> Vec<String> {
+        let mut frames = Frames::default();
+        let mut out = Vec::new();
+        for bytes in chunks {
+            frames.push(bytes.as_bytes());
+            while let Some(payload) = frames.next_payload().unwrap() {
+                out.push(payload);
+            }
+        }
+        out.extend(frames.flush());
+        out
+    }
+
+    /// The ordinary case, one whole body at a time.
+    #[test]
+    fn data_lines_dispatch_on_a_blank_line_and_done_ends_the_stream() {
+        assert_eq!(
+            payloads(&["data: {\"a\":1}\n\ndata: {\"a\":2}\n\ndata: [DONE]\n\n"]),
+            ["{\"a\":1}", "{\"a\":2}"],
+            "the sentinel is the stream ending, never an event"
+        );
+    }
+
+    /// The case no fixture can produce: a read boundary lands mid-line, and
+    /// mid-character. Neither may lose or mangle a byte.
+    #[test]
+    fn an_event_split_across_reads_is_rejoined() {
+        assert_eq!(payloads(&["data: {\"a\":", "1}\n\n"]), ["{\"a\":1}"]);
+        assert_eq!(payloads(&["data: {\"a\":1}", "\n", "\n"]), ["{\"a\":1}"]);
+        // "일" is three bytes; the split falls inside it.
+        let text = "data: {\"a\":\"일\"}\n\n".as_bytes();
+        let (head, tail) = text.split_at(14);
+        let mut frames = Frames::default();
+        frames.push(head);
+        assert_eq!(frames.next_payload().unwrap(), None, "a partial character");
+        frames.push(tail);
+        assert_eq!(
+            frames.next_payload().unwrap().as_deref(),
+            Some("{\"a\":\"일\"}")
+        );
+    }
+
+    /// Keepalive comments and the SSE fields warpllm does not read must not
+    /// become events, and must not disturb the one being accumulated.
+    #[test]
+    fn comments_and_other_fields_are_ignored() {
+        assert_eq!(
+            payloads(&[": ping\nevent: message\nid: 7\nretry: 100\ndata: {\"a\":1}\n\n"]),
+            ["{\"a\":1}"]
+        );
+        assert_eq!(payloads(&[": ping\n\n: ping\n\n"]), [] as [String; 0]);
+    }
+
+    /// CRLF and the optional leading space are framing, not payload.
+    #[test]
+    fn crlf_and_the_optional_space_are_stripped() {
+        assert_eq!(payloads(&["data: {\"a\":1}\r\n\r\n"]), ["{\"a\":1}"]);
+        assert_eq!(payloads(&["data:{\"a\":1}\n\n"]), ["{\"a\":1}"]);
+        // Only ONE space belongs to the framing; the rest is payload, and
+        // `trim` on dispatch is what keeps it decodable either way.
+        assert_eq!(payloads(&["data:  {\"a\":1}\n\n"]), ["{\"a\":1}"]);
+    }
+
+    /// The specification allows one event's data to span several lines; no
+    /// provider does it today, so this pins the behaviour rather than a bug.
+    #[test]
+    fn multi_line_data_joins_with_newlines() {
+        assert_eq!(payloads(&["data: {\"a\":\ndata: 1}\n\n"]), ["{\"a\":\n1}"]);
+    }
+
+    /// The sentinel leaves the framing in the one state a reader must not
+    /// mistake for "send me more bytes": `next_payload` says `Ok(None)` to
+    /// both, and only [`Frames::done`] tells them apart.
+    ///
+    /// That ambiguity is why [`ChunkStream::next`] rechecks `done` before
+    /// awaiting the socket. Without the recheck an upstream that holds the
+    /// response open after `[DONE]` blocks the caller forever — a hang, so the
+    /// symptom is untestable, but the state that causes it is exactly this.
+    #[test]
+    fn the_sentinel_leaves_no_payload_and_a_done_flag() {
+        let mut frames = Frames::default();
+        frames.push(b"data: [DONE]\n\n");
+        assert_eq!(frames.next_payload().unwrap(), None);
+        assert!(frames.done, "only this distinguishes ended from starved");
+
+        let mut starved = Frames::default();
+        starved.push(b"data: {\"a\":1}");
+        assert_eq!(starved.next_payload().unwrap(), None);
+        assert!(!starved.done);
+    }
+
+    /// A body that ends without its final blank line still has an event.
+    #[test]
+    fn a_truncated_final_event_is_flushed() {
+        assert_eq!(payloads(&["data: {\"a\":1}\n"]), ["{\"a\":1}"]);
+        assert_eq!(payloads(&["data: [DONE]\n"]), [] as [String; 0]);
+    }
+
+    /// Invalid UTF-8 is reported rather than replaced: a lossy decode would
+    /// hand the caller a chunk the provider never sent.
+    #[test]
+    fn invalid_utf8_in_a_line_is_an_error() {
+        let mut frames = Frames::default();
+        frames.push(b"data: \xff\xfe\n\n");
+        assert!(frames.next_payload().is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Streaming transport
+    // -----------------------------------------------------------------------
+
+    const SSE: &str = concat!(
+        "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",",
+        "\"created\":1700000000,\"model\":\"demo\",",
+        "\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n",
+        ": keepalive\n\n",
+        "data: [DONE]\n\n",
+    );
+
+    async fn stream_from(server: &MockServer) -> Result<StreamOutcome> {
+        post_stream(
+            &reqwest::Client::new(),
+            "demo",
+            &server.uri(),
+            "sk-demo",
+            &CreateChatCompletionRequest::default(),
+        )
+        .await
+    }
+
+    async fn collect(mut stream: ChunkStream) -> Vec<Result<CreateChatCompletionStreamResponse>> {
+        let mut chunks = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            chunks.push(chunk);
+        }
+        chunks
+    }
+
+    #[tokio::test]
+    async fn a_streamed_body_yields_its_chunks_and_stops_at_done() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("authorization", "Bearer sk-demo"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(SSE),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let StreamOutcome::Ok(stream) = stream_from(&server).await.unwrap() else {
+            panic!("a 200 did not stream");
+        };
+        let chunks = collect(stream).await;
+        assert_eq!(chunks.len(), 1, "the sentinel must not become a chunk");
+        assert_eq!(chunks[0].as_ref().unwrap().id, "chatcmpl-1");
+    }
+
+    /// `None` is terminal: a spent stream keeps saying so rather than reading
+    /// a socket that has nothing left.
+    #[tokio::test]
+    async fn a_finished_stream_stays_finished() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SSE))
+            .mount(&server)
+            .await;
+
+        let StreamOutcome::Ok(mut stream) = stream_from(&server).await.unwrap() else {
+            panic!("a 200 did not stream");
+        };
+        assert!(stream.next().await.is_some());
+        assert!(stream.next().await.is_none());
+        assert!(stream.next().await.is_none());
+    }
+
+    /// The same contract [`post`] states, on the streaming path: a non-2xx is
+    /// DATA, read to the end and handed over verbatim.
+    #[tokio::test]
+    async fn a_non_2xx_comes_back_as_status_without_streaming() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .insert_header("retry-after", "30")
+                    .set_body_string("slow down"),
+            )
+            .mount(&server)
+            .await;
+
+        match stream_from(&server).await.unwrap() {
+            StreamOutcome::Status {
+                status,
+                body,
+                retry_after,
+                ..
+            } => {
+                assert_eq!(status, 429);
+                assert_eq!(body, "slow down");
+                assert_eq!(retry_after, Some(Duration::from_secs(30)));
+            }
+            StreamOutcome::Ok(_) => panic!("a 429 opened a stream"),
+        }
+    }
+
+    /// ...and an event that will not decode ends the stream as an error,
+    /// rather than being skipped as though the provider had sent nothing.
+    ///
+    /// The bad event is deliberately NOT the last one. A body that ended right
+    /// after it would return `None` next whatever this code did, because the
+    /// socket closed — proving the SOCKET ended, not the error. A well-formed
+    /// event queued behind it is what makes the terminal-error contract
+    /// testable at all: resuming would hand a caller a chunk after it had
+    /// already been told the stream failed.
+    #[tokio::test]
+    async fn an_undecodable_event_is_an_error_that_ends_the_stream() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string(format!("data: not json\n\n{SSE}")),
+            )
+            .mount(&server)
+            .await;
+
+        let StreamOutcome::Ok(mut stream) = stream_from(&server).await.unwrap() else {
+            panic!("a 200 did not stream");
+        };
+        assert!(matches!(
+            stream.next().await,
+            Some(Err(Error::Decode {
+                provider: "demo",
+                ..
+            }))
+        ));
+        assert!(
+            stream.next().await.is_none(),
+            "the stream resumed past an error it had already reported"
+        );
+    }
+
+    /// An event queued behind the sentinel is not the caller's: `[DONE]` ends
+    /// the stream where it sits, and nothing after it is read.
+    #[tokio::test]
+    async fn nothing_after_the_sentinel_reaches_the_caller() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string(format!("data: [DONE]\n\n{SSE}")),
+            )
+            .mount(&server)
+            .await;
+
+        let StreamOutcome::Ok(mut stream) = stream_from(&server).await.unwrap() else {
+            panic!("a 200 did not stream");
+        };
+        assert!(stream.next().await.is_none());
+        assert!(stream.next().await.is_none());
     }
 
     /// A trailing slash on the base URL must not double up in the path.

--- a/crates/warpllm/src/registry/mod.rs
+++ b/crates/warpllm/src/registry/mod.rs
@@ -338,20 +338,31 @@ mod tests {
     /// capability nothing can act on. This is what catches it being added
     /// early.
     ///
+    /// Both implemented surfaces are listed for every model because every
+    /// provider on the roster documents `stream` on the chat-completions
+    /// endpoint rather than per model — `specs.yaml` cites each one. A provider
+    /// whose models genuinely differ belongs in an exclusion here, the same way
+    /// a non-chat model would.
+    ///
     /// It also means the shipped roster can no longer show two models of one
     /// provider differing. That is proved over fixtures instead, by
     /// `load::tests::two_models_of_one_provider_serve_different_surfaces`.
     #[test]
-    fn every_shipped_model_serves_exactly_chat_completions() {
+    fn every_shipped_model_serves_exactly_the_implemented_surfaces() {
         assert!(!REGISTRY.models.is_empty(), "the registry is empty");
         for (model_str, spec) in &REGISTRY.models {
             assert_eq!(
                 spec.supported_apis(),
-                [SupportedApi {
-                    api: Api::OpenAiCompatChatCompletions
-                }],
+                [
+                    SupportedApi {
+                        api: Api::OpenAiCompatChatCompletions
+                    },
+                    SupportedApi {
+                        api: Api::OpenAiCompatChatCompletionsStream
+                    }
+                ],
                 "`{model_str}` lists a surface warpllm does not implement, or \
-                 omits the one it does"
+                 omits one it does"
             );
         }
     }

--- a/crates/warpllm/src/registry/specs.yaml
+++ b/crates/warpllm/src/registry/specs.yaml
@@ -74,8 +74,17 @@
 #
 #   openai_compat_chat_completions         One request, one whole reply.
 #                                          IMPLEMENTED.
-#   openai_compat_chat_completions_stream  The same, streamed. Not implemented
-#                                          yet.
+#   openai_compat_chat_completions_stream  The same, streamed as server-sent
+#                                          events. IMPLEMENTED. Every provider
+#                                          on the roster documents `stream` on
+#                                          the endpoint rather than per model,
+#                                          so it is listed for every model that
+#                                          serves chat completions at all:
+#                                          <https://developers.openai.com/api/reference/resources/chat>,
+#                                          <https://api-docs.deepseek.com/api/create-chat-completion>,
+#                                          <https://platform.kimi.ai/docs/api/chat>,
+#                                          <https://openrouter.ai/docs/api-reference/streaming>
+#                                          (all checked 2026-08-12).
 #   openai_compat_responses                OpenAI's Responses API. Not
 #                                          implemented yet.
 #
@@ -111,6 +120,7 @@ providers:
       deepseek/deepseek-v4-flash:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 1000000
           max_output_tokens: 384000
@@ -118,6 +128,7 @@ providers:
       deepseek/deepseek-v4-pro:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 1000000
           max_output_tokens: 384000
@@ -158,12 +169,14 @@ providers:
       kimi/kimi-k2.6:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 262144
       # <https://platform.kimi.ai/docs/pricing/chat-k27-code>
       kimi/kimi-k2.7-code:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 262144
       # The same limits as kimi-k2.7-code; the two differ in throughput.
@@ -171,12 +184,14 @@ providers:
       kimi/kimi-k2.7-code-highspeed:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 262144
       # <https://platform.kimi.ai/docs/pricing/chat-k3>
       kimi/kimi-k3:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 1048576
 
@@ -229,6 +244,7 @@ providers:
       openai/gpt-4.1:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 1047576
           max_output_tokens: 32768
@@ -236,6 +252,7 @@ providers:
       openai/gpt-4.1-mini:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 1047576
           max_output_tokens: 32768
@@ -243,6 +260,7 @@ providers:
       openai/gpt-4o:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 128000
           max_output_tokens: 16384
@@ -250,6 +268,7 @@ providers:
       openai/gpt-4o-mini:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 128000
           max_output_tokens: 16384
@@ -259,6 +278,7 @@ providers:
       openai/gpt-5:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 400000
           max_output_tokens: 128000
@@ -266,6 +286,7 @@ providers:
       openai/gpt-5-mini:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 400000
           max_output_tokens: 128000
@@ -273,6 +294,7 @@ providers:
       openai/gpt-5-nano:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 400000
           max_output_tokens: 128000
@@ -280,6 +302,7 @@ providers:
       openai/gpt-5.1:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 400000
           max_output_tokens: 128000
@@ -287,6 +310,7 @@ providers:
       openai/gpt-5.2:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 400000
           max_output_tokens: 128000
@@ -295,6 +319,7 @@ providers:
       openai/gpt-5.4:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 1050000
           max_output_tokens: 128000
@@ -302,6 +327,7 @@ providers:
       openai/gpt-5.4-mini:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 400000
           max_output_tokens: 128000
@@ -309,6 +335,7 @@ providers:
       openai/gpt-5.4-nano:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 400000
           max_output_tokens: 128000
@@ -316,6 +343,7 @@ providers:
       openai/gpt-5.5:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 1050000
           max_output_tokens: 128000
@@ -326,6 +354,7 @@ providers:
       openai/gpt-5.6:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 1050000
           max_output_tokens: 128000
@@ -333,6 +362,7 @@ providers:
       openai/gpt-5.6-luna:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 1050000
           max_output_tokens: 128000
@@ -340,6 +370,7 @@ providers:
       openai/gpt-5.6-sol:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 1050000
           max_output_tokens: 128000
@@ -347,6 +378,7 @@ providers:
       openai/gpt-5.6-terra:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 1050000
           max_output_tokens: 128000
@@ -356,6 +388,7 @@ providers:
       openai/o3:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         capabilities:
           max_input_tokens: 200000
           max_output_tokens: 100000
@@ -387,6 +420,7 @@ providers:
       openrouter/anthropic/claude-opus-4:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         model: anthropic/claude-opus-4
         capabilities:
           max_input_tokens: 200000
@@ -399,6 +433,7 @@ providers:
       openrouter/anthropic/claude-sonnet-4:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         model: anthropic/claude-sonnet-4
         capabilities:
           max_input_tokens: 200000
@@ -409,11 +444,13 @@ providers:
       openrouter/auto:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
       # Checked 2026-08-07: 1M context, 65,536 max output.
       # <https://openrouter.ai/google/gemini-2.5-pro>
       openrouter/google/gemini-2.5-pro:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         model: google/gemini-2.5-pro
         capabilities:
           max_input_tokens: 1048576
@@ -430,6 +467,7 @@ providers:
       openrouter/moonshotai/kimi-k2.6:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         model: moonshotai/kimi-k2.6
         capabilities:
           max_input_tokens: 256000
@@ -440,6 +478,7 @@ providers:
       openrouter/moonshotai/kimi-k2.7-code:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         model: moonshotai/kimi-k2.7-code
         capabilities:
           max_input_tokens: 256000
@@ -452,6 +491,7 @@ providers:
       openrouter/moonshotai/kimi-k3:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         model: moonshotai/kimi-k3
         capabilities:
           max_input_tokens: 974842
@@ -461,6 +501,7 @@ providers:
       openrouter/openai/gpt-5.6:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         model: openai/gpt-5.6
         capabilities:
           max_input_tokens: 1050000
@@ -474,6 +515,7 @@ providers:
       openrouter/~deepseek/deepseek-v4-flash-latest:
         supported_apis:
           - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
         model: ~deepseek/deepseek-v4-flash-latest
         capabilities:
           max_input_tokens: 1048576

--- a/crates/warpllm/tests/live_stream.rs
+++ b/crates/warpllm/tests/live_stream.rs
@@ -14,16 +14,16 @@
 //! to round-trip is printed in full: that output is a fixture, and belongs
 //! under `fixtures/transcript/` so the keyless suite catches it from then on.
 //!
-//! This speaks HTTP directly rather than through warpllm, since warpllm has no
-//! streaming transport yet — which is exactly why it is worth running now. The
-//! REQUEST is built from [`CreateChatCompletionRequest`], so what it proves
-//! about that shape is real: `stream_options` rides along in `unknown_fields`,
-//! and the provider accepts what warpllm would have sent.
+//! This goes through [`Client::chat_completions_stream`], so it exercises the
+//! whole path a caller uses — the request renderer, the SSE framing, the
+//! gateway IR, and the render back. A chunk that reaches the assertions below
+//! has already survived normalization, which is what makes the round trip it
+//! then checks a statement about warpllm and not merely about serde.
 
-use std::time::Duration;
-
-use warpllm::protocol::openai_compat::chat_completions::types::CreateChatCompletionStreamResponse;
-use warpllm::{ChatCompletionRequestMessage, CreateChatCompletionRequest, fetch_model};
+use warpllm::{
+    ChatCompletionRequestMessage, ClientConfig, CreateChatCompletionRequest,
+    CreateChatCompletionStreamResponse, fetch_model,
+};
 
 /// One model per provider on the roster. Cheap and short-answered on purpose:
 /// this is a shape check, not a capability survey.
@@ -40,24 +40,24 @@ async fn every_configured_provider_streams_chunks_warpllm_can_hold() {
     let mut skipped = Vec::new();
 
     for model_str in MODELS {
-        let (provider, model) = fetch_model(model_str).expect("roster entry");
-        let Some(key) = provider
+        let (provider, _) = fetch_model(model_str).expect("roster entry");
+        if provider
             .env_api_key()
             .and_then(|name| std::env::var(name).ok())
-        else {
+            .is_none()
+        {
             skipped.push(model_str);
             continue;
-        };
+        }
 
         let mut request = CreateChatCompletionRequest {
-            model: model.model().to_owned(),
+            model: model_str.to_owned(),
             messages: vec![ChatCompletionRequestMessage {
                 role: "user".into(),
                 content: "Reply with exactly: hello".into(),
                 unknown_fields: Default::default(),
             }],
             max_tokens: Some(16),
-            stream: Some(true),
             ..Default::default()
         };
         // Unmodeled, and reaching the provider anyway — the catch-all doing
@@ -67,19 +67,22 @@ async fn every_configured_provider_streams_chunks_warpllm_can_hold() {
             serde_json::json!({"include_usage": true}),
         );
 
-        let body = reqwest::Client::new()
-            .post(format!("{}/chat/completions", provider.base_url()))
-            .bearer_auth(key)
-            .json(&request)
-            .timeout(Duration::from_secs(60))
-            .send()
-            .await
-            .unwrap_or_else(|e| panic!("{model_str}: {e}"))
-            .text()
+        let client = warpllm::Client::new(ClientConfig {
+            timeout_secs: Some(60),
+            ..Default::default()
+        })
+        .unwrap_or_else(|e| panic!("{model_str}: {e}"));
+
+        let mut stream = client
+            .chat_completions_stream(request)
             .await
             .unwrap_or_else(|e| panic!("{model_str}: {e}"));
 
-        assert_chunks_round_trip(model_str, &body);
+        let mut chunks = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            chunks.push(chunk.unwrap_or_else(|e| panic!("{model_str}: {e}")));
+        }
+        assert_chunks_are_usable(model_str, &chunks);
         checked.push(model_str);
     }
 
@@ -91,32 +94,20 @@ async fn every_configured_provider_streams_chunks_warpllm_can_hold() {
     );
 }
 
-/// Every event of a live SSE body, parsed and re-emitted verbatim.
-fn assert_chunks_round_trip(model_str: &str, body: &str) {
-    let payloads: Vec<&str> = body
-        .lines()
-        .filter_map(|line| line.strip_prefix("data: "))
-        .filter(|payload| *payload != "[DONE]")
-        .collect();
+/// What a caller needs out of a live stream: text that adds up, a finish
+/// reason, and the caller's own model string echoed back on every chunk.
+fn assert_chunks_are_usable(model_str: &str, chunks: &[CreateChatCompletionStreamResponse]) {
     assert!(
-        payloads.len() > 1,
-        "{model_str} answered with no stream:\n{body}"
+        chunks.len() > 1,
+        "{model_str} answered with no stream: {chunks:#?}"
     );
 
     let mut text = String::new();
     let mut finished = false;
-    for payload in payloads {
-        let value: serde_json::Value = serde_json::from_str(payload)
-            .unwrap_or_else(|e| panic!("{model_str} sent a non-JSON event: {payload}: {e}"));
-        let chunk: CreateChatCompletionStreamResponse = serde_json::from_value(value.clone())
-            .unwrap_or_else(|e| {
-                panic!("{model_str} sent a chunk warpllm cannot hold: {e}\n{value:#}")
-            });
+    for chunk in chunks {
         assert_eq!(
-            serde_json::to_value(&chunk).unwrap(),
-            value,
-            "{model_str} lost a field on re-serialization; add this event to \
-             fixtures/transcript/ and fix the shape:\n{value:#}"
+            chunk.model, model_str,
+            "{model_str} chunk echoes the upstream name, not the caller's"
         );
         for choice in &chunk.choices {
             if let Some(Some(fragment)) = &choice.delta.content {

--- a/crates/warpllm/tests/providers/openai/chat_completions/mod.rs
+++ b/crates/warpllm/tests/providers/openai/chat_completions/mod.rs
@@ -191,20 +191,26 @@ fn unparseable_error_body_falls_back_to_raw_text() {
     });
 }
 
+/// `chat_completions` returns one whole reply, which is a shape chunks do not
+/// fit in — so a request asking for them is refused here and pointed at the
+/// entrypoint whose return type can carry them.
 #[test]
 fn stream_true_is_rejected_before_any_request() {
     with_openai_key(async {
         let server = MockServer::start().await;
         // No mock mounted: a request reaching the server would 404 into a
-        // Provider error, so getting NotImplemented proves we rejected early.
+        // Provider error, so an InvalidInput proves we rejected early.
         let mut req = request("openai/gpt-5.6");
         req.stream = Some(true);
 
         let err = client_for(&server).chat_completions(req).await.unwrap_err();
-        assert!(
-            matches!(&err, Error::NotImplemented("streaming")),
-            "{err:?}"
-        );
+        match &err {
+            Error::InvalidInput(message) => assert!(
+                message.contains("chat_completions_stream"),
+                "the refusal must name where to go instead: {message}"
+            ),
+            other => panic!("{other:?}"),
+        }
         assert!(server.received_requests().await.unwrap().is_empty());
     });
 }
@@ -276,4 +282,147 @@ fn invalid_model_strings_are_rejected() {
             "{err}"
         );
     });
+}
+
+/// The whole streaming path a caller uses, end to end: the request is rendered
+/// with `stream: true`, the SSE body is framed, every event goes through the
+/// gateway IR and back, and what comes out is what the provider sent.
+///
+/// The unit tests either side of the IR prove the halves; this proves they are
+/// joined, and that the caller's own model string survives the trip — the one
+/// thing neither half can check, since neither knows it.
+#[test]
+fn openai_streaming_happy_path() {
+    with_openai_key(async {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("authorization", "Bearer sk-test-openai"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(openai_stream_body()),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut stream = client_for(&server)
+            .chat_completions_stream(request("openai/gpt-5.6"))
+            .await
+            .unwrap();
+        let mut chunks = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            chunks.push(chunk.unwrap());
+        }
+
+        // The `[DONE]` sentinel is the stream ending, never a chunk.
+        assert_eq!(chunks.len(), 3);
+        let text: String = chunks
+            .iter()
+            .flat_map(|chunk| &chunk.choices)
+            .filter_map(|choice| choice.delta.content.as_ref()?.as_deref())
+            .collect();
+        assert_eq!(text, "Hello there!");
+
+        // Every chunk echoes the caller's provider-prefixed string.
+        assert!(chunks.iter().all(|chunk| chunk.model == "openai/gpt-5.6"));
+        assert_eq!(chunks[0].object, "chat.completion.chunk");
+        // Per-chunk residue no specification names still reaches the caller.
+        assert_eq!(chunks[0].unknown_fields["obfuscation"], json!("KtQ3nZ8w"));
+        assert_eq!(chunks[1].choices[0].finish_reason, None);
+        assert_eq!(chunks[2].choices[0].finish_reason.as_deref(), Some("stop"));
+        assert_eq!(
+            chunks[2]
+                .usage
+                .as_ref()
+                .and_then(Option::as_ref)
+                .map(|u| u.total_tokens),
+            Some(14)
+        );
+
+        // The request asked for a stream, whatever the caller left `stream` at.
+        let sent: serde_json::Value = server.received_requests().await.unwrap()[0]
+            .body_json()
+            .unwrap();
+        assert_eq!(sent["stream"], json!(true));
+    });
+}
+
+/// The streaming entrypoint is admitted by the same two halves as the whole
+/// reply one, in the same order — so an unregistered name stops at the roster
+/// rather than opening a socket.
+///
+/// The surface half is unreachable from here while every shipped model serves
+/// both surfaces; `Client::validate_api`'s own tests cover that refusal.
+#[test]
+fn streaming_an_unregistered_model_never_reaches_the_provider() {
+    with_openai_key(async {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let err = client_for(&server)
+            .chat_completions_stream(request("openai/not-a-model"))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(&err, Error::InvalidModel { given } if given == "openai/not-a-model"),
+            "{err:?}"
+        );
+        assert!(server.received_requests().await.unwrap().is_empty());
+    });
+}
+
+/// A non-2xx is mapped before the stream opens, so the caller gets a typed
+/// failure rather than an empty stream that says nothing about why.
+#[test]
+fn a_refused_stream_is_an_error_not_an_empty_stream() {
+    with_openai_key(async {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(429).set_body_json(json!({
+                "error": {"message": "slow down", "type": "rate_limit_error"}
+            })))
+            .mount(&server)
+            .await;
+
+        let err = client_for(&server)
+            .chat_completions_stream(request("openai/gpt-5.6"))
+            .await
+            .unwrap_err();
+        let upstream = err.provider_error().expect("a provider failure");
+        assert_eq!(upstream.status, 429);
+        assert_eq!(upstream.message, "slow down");
+    });
+}
+
+/// The transcript this mirrors is `fixtures/transcript/openai-text.sse`; it is
+/// inlined rather than read so this test states the bytes it depends on.
+fn openai_stream_body() -> String {
+    let envelope = concat!(
+        r#""id":"chatcmpl-C9r2K","object":"chat.completion.chunk","#,
+        r#""created":1753300000,"model":"gpt-5.6","service_tier":"default""#,
+    );
+    format!(
+        concat!(
+            "data: {{{envelope},\"choices\":[{{\"index\":0,\"delta\":",
+            "{{\"role\":\"assistant\",\"content\":\"\",\"refusal\":null}},",
+            "\"logprobs\":null,\"finish_reason\":null}}],\"usage\":null,",
+            "\"obfuscation\":\"KtQ3nZ8w\"}}\n\n",
+            ": keepalive\n\n",
+            "data: {{{envelope},\"choices\":[{{\"index\":0,\"delta\":",
+            "{{\"content\":\"Hello there!\"}},\"logprobs\":null,",
+            "\"finish_reason\":null}}],\"usage\":null}}\n\n",
+            "data: {{{envelope},\"choices\":[{{\"index\":0,\"delta\":{{}},",
+            "\"logprobs\":null,\"finish_reason\":\"stop\"}}],",
+            "\"usage\":{{\"prompt_tokens\":11,\"completion_tokens\":3,",
+            "\"total_tokens\":14}}}}\n\n",
+            "data: [DONE]\n\n",
+        ),
+        envelope = envelope
+    )
 }


### PR DESCRIPTION
Closes #5.

warpllm could hold a streamed chunk but not receive one. `CreateChatCompletionStreamResponse` was already complete and proven lossless by fixtures, a proptest, and a live test — but nothing read a socket, `Client::chat_completions` answered `stream: true` with `NotImplemented`, and `tests/live_stream.rs` spoke raw `reqwest` to work around the gap.

This adds the internal representation the issue asks for **and** the transport that feeds it, so the path works end to end rather than landing as staged dead code. Behaviour is passthrough: OpenAI-compatible chunks in, OpenAI-compatible chunks out. The IR sits between them so the seam exists when a second protocol arrives.

```rust
let mut stream = client.chat_completions_stream(request).await?;
while let Some(chunk) = stream.next().await {
    for choice in &chunk?.choices {
        if let Some(Some(text)) = &choice.delta.content {
            print!("{text}");
        }
    }
}
```

## Why a second shape

`ChatResponse` cannot hold a chunk, and the mismatches are structural rather than stylistic:

| `ChatResponse` | a chunk |
|---|---|
| `Completion::finish_reason_raw`, required | `null` on every chunk of a choice but the last |
| `Message::role`, required | arrives once, on the opening chunk |
| `ContentBlock::Text` | a *fragment* — and absent / `null` / `""` are three states one live stream sends |
| `ContentBlock::ToolCall` | correlated by **`index`**, with `arguments` split mid-JSON |

The last is decisive: `index` has nowhere to live, and a fragment like `{"city":` is not the "exact JSON text" `RawJson` promises to hold. Relaxing those on the completed form would make every whole-reply consumer unwrap `Option`s that are never `None` on its path, and still leave `index` homeless. So it is a second shape built from the first one's vocabulary — `Role`, `FinishReason`, `Usage`, `ProviderExt`, `IngestSource` — not a parallel universe.

## Why one value per chunk

The typed union sits at the *content* level (`ContentDelta`), which is richer than the wire's one sparse delta object: reasoning, text, and tool-call fragments are distinct variants rather than sibling keys. The envelope stays one-for-one with a wire chunk, because a chunk carries fields belonging to no single semantic event — `system_fingerprint`, `service_tier`, a repeated `logprobs: null`, and OpenAI's per-chunk `obfuscation`, which changes on every one. Exploding a chunk into several events would strand that residue and make re-chunking a guess.

## Framing

SSE framing is split from the socket (`Frames`) so its edges are plain function calls in a test rather than a mock server: partial lines and multi-byte characters split across reads are rejoined, `:` keepalive comments and unread SSE fields are ignored, CRLF and the optional leading space are stripped, and `[DONE]` ends the stream rather than arriving as a chunk. An error item is terminal, and the sentinel is rechecked before reading again so an upstream that holds the response open after it cannot block a caller past the end of a stream.

No new dependency: `reqwest::Response::chunk()` needed no feature change, and `Cargo.toml` is untouched.

## Roster

All 33 models now declare `openai_compat_chat_completions_stream` beside their whole-reply surface. Every provider documents `stream` on the endpoint rather than per model, and `specs.yaml` cites each one. Streaming stays its own surface, so a future model serving one without the other still says so.

## Scope

Out: the accumulator (`fold(chunks) -> ChatResponse`), inverse chunking for fake-streaming, binding methods, and `warpllm-server` SSE responses. The HTTP gateway does **not** stream and answers `stream: true` with 501 exactly as before — it now states that itself, since unlike the Rust client it has no second endpoint to point a caller at.

## Verification

`cargo test --workspace` — **274 passed, 1 ignored** (the key-gated live test). `clippy --workspace --all-targets -- -D warnings` clean, `fmt --check` clean, and `warpllm-codegen` reruns with zero drift in the generated bindings.

The load-bearing test runs both recorded SSE transcripts event by event through `ingest_chunk` → `render_chunk`, asserting zero transformation — the same standard whole replies are held to. Those transcripts are what carry the cases nobody designs for: an opening `"content": ""`, `logprobs: null` on every chunk, tool-call arguments split mid-JSON, and per-chunk `obfuscation`.

`tests/live_stream.rs` now goes through `Client::chat_completions_stream` instead of raw `reqwest`, so it exercises the whole path:

```
OPENAI_API_KEY=... DEEPSEEK_API_KEY=... \
  cargo test -p warpllm --test live_stream -- --ignored --nocapture
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
