### PR TITLE
Model the chat-completions request permissively

### DIFF
--- a/bindings/node/__test__/openai-oracle.ts
+++ b/bindings/node/__test__/openai-oracle.ts
@@ -1,5 +1,6 @@
-// Compile-only drift alarm: warpllm's reply shapes measured against OpenAI's
-// own declarations, for both the whole completion and the streamed chunk.
+// Compile-only drift alarm: warpllm's wire shapes measured against OpenAI's
+// own declarations — the request it accepts, the whole completion, and the
+// streamed chunk.
 //
 // `openai` is a devDependency and an ORACLE, never a contract. Nothing here is
 // re-exported, and the package is absent from the published dependency tree —
@@ -23,15 +24,31 @@
 // There are no exceptions to either. If one becomes necessary, it belongs
 // here, spelled as a type: a deviation nobody can read is a deviation nobody
 // weighed.
-import type { ChatCompletion, ChatCompletionChunk, ChatCompletionMessage } from 'openai/resources/chat/completions'
+import type {
+  ChatCompletion,
+  ChatCompletionAllowedToolChoice,
+  ChatCompletionChunk,
+  ChatCompletionCreateParams,
+  ChatCompletionFunctionTool,
+  ChatCompletionMessage,
+  ChatCompletionMessageParam,
+  ChatCompletionNamedToolChoiceCustom,
+  ChatCompletionToolChoiceOption as OpenAIToolChoiceOption,
+} from 'openai/resources/chat/completions'
+import type { FunctionDefinition } from 'openai/resources/shared'
 
 import type {
   ChatCompletionMessageToolCallChunk,
+  ChatCompletionRequestMessage,
   ChatCompletionResponseMessage,
   ChatCompletionStreamResponseDelta,
+  ChatCompletionTool,
+  ChatCompletionToolChoiceOption,
   Choice,
+  CreateChatCompletionRequest,
   CreateChatCompletionResponse,
   CreateChatCompletionStreamResponse,
+  FunctionObject,
   StreamChoice,
 } from '../src-ts/generated/types.js'
 
@@ -48,6 +65,45 @@ type Missing<Upstream, Ours> = Exclude<keyof Upstream, keyof Ours>
 
 export const acceptsAnOpenAICompletion: CreateChatCompletionResponse = {} as ChatCompletion
 export const acceptsAnOpenAIChunk: CreateChatCompletionStreamResponse = {} as ChatCompletionChunk
+
+// The request asks the question in the direction a caller feels it: a body
+// built against the vendor's own SDK has to be one warpllm accepts. Every
+// message role, every content part, every tool shape — including the ones
+// warpllm does not model, which must reach the provider rather than fail to
+// typecheck.
+export const acceptsEveryMessageRole: ChatCompletionRequestMessage = {} as ChatCompletionMessageParam
+
+// The exceptions below share one cause, and it is a limit of what a `.d.ts`
+// can SAY rather than of what warpllm accepts. Every one of these shapes
+// deserializes and re-emits verbatim in Rust, where the field is a
+// `serde_json::Value`.
+//
+// `Value` generates as `JsonValue`, whose object case is the mapped type
+// `{ [key in string]: JsonValue }`. TypeScript will not assign an `interface`
+// to a mapped type (interfaces get no implicit index signature), and will not
+// assign `Record<string, unknown>` to it either (`unknown` is not
+// `JsonValue`). OpenAI's SDK declares both. So the assertions are narrowed to
+// exactly the fields that land on a `Value`, and the rest stays checked —
+// which is the point: this same check is what caught `stop` being modelled as
+// a list when OpenAI's own examples pass a bare string.
+type LandsOnArbitraryJson =
+  // `parameters` on a function, and `schema` on a json_schema format.
+  | 'tools'
+  | 'response_format'
+  // Plus the two tool-choice shapes warpllm holds only in its catch-all.
+  | 'tool_choice'
+
+export const acceptsAnOpenAIRequest: CreateChatCompletionRequest = {} as Omit<
+  ChatCompletionCreateParams,
+  LandsOnArbitraryJson
+>
+
+// ...and `tool_choice` is still checked over everything but those two shapes,
+// rather than dropped whole.
+export const acceptsEveryModelledToolChoice: ChatCompletionToolChoiceOption = {} as Exclude<
+  OpenAIToolChoiceOption,
+  ChatCompletionAllowedToolChoice | ChatCompletionNamedToolChoiceCustom
+>
 
 // ---------------------------------------------------------------------------
 // 2. Anything OpenAI models, warpllm names
@@ -71,3 +127,15 @@ export type DeltaFieldsAreModelled = Nothing<
 export type ToolCallFieldsAreModelled = Nothing<
   Missing<ChatCompletionChunk.Choice.Delta.ToolCall, ChatCompletionMessageToolCallChunk>
 >
+
+// The request is asked this question only where warpllm CHOSE to type a shape
+// whole. `CreateChatCompletionRequest` itself is deliberately a partial typing
+// — `n`, `seed`, `presence_penalty` and a dozen more reach the provider
+// through the catch-all rather than through a field — so comparing its key set
+// to the vendor's would assert something warpllm does not claim. A function
+// tool is the opposite: it is modelled field for field, because translating it
+// to another protocol means reading every part of it.
+export type FunctionToolFieldsAreModelled = Nothing<
+  Missing<ChatCompletionFunctionTool, ChatCompletionTool>
+>
+export type FunctionFieldsAreModelled = Nothing<Missing<FunctionDefinition, FunctionObject>>

--- a/bindings/node/src-ts/generated/types.ts
+++ b/bindings/node/src-ts/generated/types.ts
@@ -48,11 +48,63 @@ export type ChatCompletionModerationResults = { model: string, results: Array<Mo
  */
 type: string, };
 
+export type ChatCompletionNamedToolChoice = {
+/**
+ * Conventionally `"function"`; compatible providers may differ.
+ */
+type: string, function: ToolChoiceFunction, };
+
 export type ChatCompletionRequestMessage = {
 /**
  * Provider-defined role; common values include `"system"` and `"user"`.
  */
-role: string, content: string, };
+role: string, content?: ChatCompletionRequestMessageContent | null,
+/**
+ * Set on the assistant turn that called tools; each entry is answered by
+ * a later message with `role: "tool"` carrying the matching
+ * `tool_call_id`.
+ */
+tool_calls?: Array<ChatCompletionMessageToolCallUnion> | null,
+/**
+ * Which call this message answers. Set on `role: "tool"` messages.
+ */
+tool_call_id?: string | null, };
+
+export type ChatCompletionRequestMessageContent = string | Array<ChatCompletionRequestMessageContentPart>;
+
+export type ChatCompletionRequestMessageContentPart = ChatCompletionRequestMessageContentPartText | ChatCompletionRequestMessageContentPartImage | ChatCompletionRequestMessageContentPartAudio | ChatCompletionRequestMessageContentPartFile | ChatCompletionRequestMessageContentPartRefusal | JsonValue;
+
+export type ChatCompletionRequestMessageContentPartAudio = {
+/**
+ * Conventionally `"input_audio"`; compatible providers may differ.
+ */
+type: string, input_audio: InputAudio, };
+
+export type ChatCompletionRequestMessageContentPartFile = {
+/**
+ * Conventionally `"file"`; compatible providers may differ.
+ */
+type: string, file: FileContent, };
+
+export type ChatCompletionRequestMessageContentPartImage = {
+/**
+ * Conventionally `"image_url"`; compatible providers may differ.
+ */
+type: string, image_url: ImageUrl, };
+
+export type ChatCompletionRequestMessageContentPartRefusal = {
+/**
+ * Conventionally `"refusal"`; compatible providers may differ.
+ */
+type: string, refusal: string, };
+
+export type ChatCompletionRequestMessageContentPartText = {
+/**
+ * Conventionally `"text"`; compatible providers may differ.
+ */
+type: string, text: string, };
+
+export type ChatCompletionResponseFormat = ResponseFormatJsonSchema | ResponseFormatSimple;
 
 export type ChatCompletionResponseMessage = { content: string | null, refusal: string | null,
 /**
@@ -63,6 +115,14 @@ role: string, annotations?: Array<Annotation>, audio?: ChatCompletionAudio | nul
  * Deprecated upstream in favor of `tool_calls`.
  */
 function_call?: FunctionCall | null, tool_calls?: Array<ChatCompletionMessageToolCallUnion>, };
+
+export type ChatCompletionStop = string | Array<string>;
+
+export type ChatCompletionStreamOptions = {
+/**
+ * Ask for a final chunk carrying the whole request's token totals.
+ */
+include_usage?: boolean | null, };
 
 export type ChatCompletionStreamResponseDelta = { content?: string | null,
 /**
@@ -75,6 +135,14 @@ function_call?: DeltaFunctionCall, refusal?: string | null,
 role?: string, tool_calls?: Array<ChatCompletionMessageToolCallChunk>, };
 
 export type ChatCompletionTokenLogprob = { token: string, bytes: Array<number> | null, logprob: number, top_logprobs: Array<TopLogprob>, };
+
+export type ChatCompletionTool = {
+/**
+ * Conventionally `"function"`; compatible providers may differ.
+ */
+type: string, function?: FunctionObject | null, };
+
+export type ChatCompletionToolChoiceOption = ChatCompletionNamedToolChoice | string | JsonValue;
 
 export type Choice = {
 /**
@@ -92,7 +160,16 @@ export type CreateChatCompletionRequest = {
 /**
  * Model string in `provider/model` form, e.g. `"openai/gpt-5.6"`.
  */
-model: string, messages: Array<ChatCompletionRequestMessage>, temperature?: number | null, max_tokens?: number | null, top_p?: number | null, stop?: Array<string> | null, stream?: boolean | null, };
+model: string, messages: Array<ChatCompletionRequestMessage>, temperature?: number | null, max_tokens?: number | null, top_p?: number | null, stop?: ChatCompletionStop | null, stream?: boolean | null, stream_options?: ChatCompletionStreamOptions | null,
+/**
+ * Tools the model may call.
+ */
+tools?: Array<ChatCompletionTool> | null, tool_choice?: ChatCompletionToolChoiceOption | null, response_format?: ChatCompletionResponseFormat | null,
+/**
+ * How much reasoning to spend; provider-defined, commonly `"low"`,
+ * `"medium"`, `"high"`.
+ */
+reasoning_effort?: string | null, };
 
 export type CreateChatCompletionResponse = { id: string, choices: Array<Choice>, created: number,
 /**
@@ -176,6 +253,16 @@ code: string | null, };
 
 export type ErrorClass = "api_connection" | "api_status" | "bad_request" | "authentication" | "permission_denied" | "not_found" | "conflict" | "unprocessable_entity" | "rate_limit" | "internal_server";
 
+export type FileContent = {
+/**
+ * Base64-encoded file bytes, for a file sent inline.
+ */
+file_data?: string | null,
+/**
+ * A file already uploaded to the provider.
+ */
+file_id?: string | null, filename?: string | null, };
+
 export type Function = {
 /**
  * JSON-encoded arguments; model-generated, so may be invalid JSON.
@@ -187,6 +274,44 @@ export type FunctionCall = {
  * JSON-encoded arguments; model-generated, so may be invalid JSON.
  */
 arguments: string, name: string, };
+
+export type FunctionObject = { name: string, description?: string | null,
+/**
+ * JSON Schema for the arguments, passed through verbatim.
+ */
+parameters?: JsonValue | null,
+/**
+ * Whether the provider must adhere exactly to the schema.
+ */
+strict?: boolean | null, };
+
+export type ImageUrl = {
+/**
+ * An `https:` URL, or a `data:` URL carrying base64 image bytes.
+ */
+url: string,
+/**
+ * Provider-defined fidelity hint; commonly `"auto"`, `"low"`, `"high"`.
+ */
+detail?: string | null, };
+
+export type InputAudio = {
+/**
+ * Base64-encoded audio bytes.
+ */
+data: string,
+/**
+ * Provider-defined container; commonly `"wav"`, `"mp3"`.
+ */
+format: string, };
+
+export type JsonSchemaDefinition = { name: string, description?: string | null,
+/**
+ * JSON Schema for the reply, passed through verbatim.
+ */
+schema?: JsonValue | null, strict?: boolean | null, };
+
+export type JsonValue = number | string | boolean | Array<JsonValue> | { [key in string]: JsonValue } | null;
 
 export type ModerationOutcome = ChatCompletionModerationResults | ChatCompletionModerationError;
 
@@ -222,6 +347,19 @@ export type PromptTokensDetails = { audio_tokens?: number,
  */
 cache_write_tokens?: number, cached_tokens?: number, };
 
+export type ResponseFormatJsonSchema = {
+/**
+ * Conventionally `"json_schema"`; compatible providers may differ.
+ */
+type: string, json_schema: JsonSchemaDefinition, };
+
+export type ResponseFormatSimple = {
+/**
+ * Conventionally `"text"` or `"json_object"`; compatible providers may
+ * differ.
+ */
+type: string, };
+
 export type StreamChoice = { delta: ChatCompletionStreamResponseDelta,
 /**
  * Provider-defined reason that generation stopped, and `null` until it
@@ -241,5 +379,7 @@ export type ToolCallChunkFunction = {
  * be invalid JSON.
  */
 arguments?: string, name?: string, };
+
+export type ToolChoiceFunction = { name: string, };
 
 export type TopLogprob = { token: string, bytes: Array<number> | null, logprob: number, };

--- a/bindings/python/python/warpllm/_generated/request.py
+++ b/bindings/python/python/warpllm/_generated/request.py
@@ -3,14 +3,138 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Any, TypeAlias, TypedDict
 
 from typing_extensions import NotRequired
 
 
+class ChatCompletionRequestMessageContentPartText(TypedDict):
+    type: str
+    text: str
+
+
+class ImageUrl(TypedDict):
+    url: str
+    detail: NotRequired[str | None]
+
+
+class InputAudio(TypedDict):
+    data: str
+    format: str
+
+
+class FileContent(TypedDict):
+    file_data: NotRequired[str | None]
+    file_id: NotRequired[str | None]
+    filename: NotRequired[str | None]
+
+
+class ChatCompletionRequestMessageContentPartRefusal(TypedDict):
+    type: str
+    refusal: str
+
+
+class Function(TypedDict):
+    arguments: str
+    name: str
+
+
+class Custom(TypedDict):
+    input: str
+    name: str
+
+
+ChatCompletionStop: TypeAlias = str | list[str]
+
+
+class ChatCompletionStreamOptions(TypedDict):
+    include_usage: NotRequired[bool | None]
+
+
+class FunctionObject(TypedDict):
+    name: str
+    description: NotRequired[str | None]
+    parameters: NotRequired[Any]
+    strict: NotRequired[bool | None]
+
+
+class ToolChoiceFunction(TypedDict):
+    name: str
+
+
+class JsonSchemaDefinition(TypedDict):
+    name: str
+    description: NotRequired[str | None]
+    schema: NotRequired[Any]
+    strict: NotRequired[bool | None]
+
+
+class ResponseFormatSimple(TypedDict):
+    type: str
+
+
+class ChatCompletionRequestMessageContentPartImage(TypedDict):
+    type: str
+    image_url: ImageUrl
+
+
+class ChatCompletionRequestMessageContentPartAudio(TypedDict):
+    type: str
+    input_audio: InputAudio
+
+
+class ChatCompletionRequestMessageContentPartFile(TypedDict):
+    type: str
+    file: FileContent
+
+
+class ChatCompletionMessageToolCall(TypedDict):
+    id: str
+    type: str
+    function: Function
+
+
+class ChatCompletionMessageCustomToolCall(TypedDict):
+    id: str
+    type: str
+    custom: Custom
+
+
+class ChatCompletionTool(TypedDict):
+    type: str
+    function: NotRequired[FunctionObject | None]
+
+
+class ChatCompletionNamedToolChoice(TypedDict):
+    type: str
+    function: ToolChoiceFunction
+
+
+class ResponseFormatJsonSchema(TypedDict):
+    type: str
+    json_schema: JsonSchemaDefinition
+
+
+ChatCompletionRequestMessageContentPart: TypeAlias = ChatCompletionRequestMessageContentPartText | ChatCompletionRequestMessageContentPartImage | ChatCompletionRequestMessageContentPartAudio | ChatCompletionRequestMessageContentPartFile | ChatCompletionRequestMessageContentPartRefusal | Any
+
+
+ChatCompletionMessageToolCallUnion: TypeAlias = ChatCompletionMessageToolCall | ChatCompletionMessageCustomToolCall
+
+
+ChatCompletionToolChoiceOption: TypeAlias = ChatCompletionNamedToolChoice | str | Any
+
+
+ChatCompletionResponseFormat: TypeAlias = ResponseFormatJsonSchema | ResponseFormatSimple
+
+
+ChatCompletionRequestMessageContent: TypeAlias = str | list[ChatCompletionRequestMessageContentPart]
+
+
 class ChatCompletionRequestMessage(TypedDict):
     role: str
-    content: str
+    content: NotRequired[ChatCompletionRequestMessageContent | None]
+    tool_calls: NotRequired[list[ChatCompletionMessageToolCallUnion] | None]
+    tool_call_id: NotRequired[str | None]
 
 
 class CreateChatCompletionRequest(TypedDict):
@@ -19,5 +143,10 @@ class CreateChatCompletionRequest(TypedDict):
     temperature: NotRequired[float | None]
     max_tokens: NotRequired[int | None]
     top_p: NotRequired[float | None]
-    stop: NotRequired[list[str] | None]
+    stop: NotRequired[ChatCompletionStop | None]
     stream: NotRequired[bool | None]
+    stream_options: NotRequired[ChatCompletionStreamOptions | None]
+    tools: NotRequired[list[ChatCompletionTool] | None]
+    tool_choice: NotRequired[ChatCompletionToolChoiceOption | None]
+    response_format: NotRequired[ChatCompletionResponseFormat | None]
+    reasoning_effort: NotRequired[str | None]

--- a/crates/warpllm/src/client.rs
+++ b/crates/warpllm/src/client.rs
@@ -476,11 +476,7 @@ mod tests {
         let client = client(ClientConfig::default());
         let request = CreateChatCompletionRequest {
             model: "demo/chat".into(),
-            messages: vec![ChatCompletionRequestMessage {
-                role: "user".into(),
-                content: "hi".into(),
-                ..Default::default()
-            }],
+            messages: vec![ChatCompletionRequestMessage::new("user", "hi")],
             ..Default::default()
         };
         // What `chat_completions` does, minus the routing it already proved:
@@ -535,11 +531,7 @@ mod tests {
         });
         let request = CreateChatCompletionRequest {
             model: "openai/gpt-5.6".into(),
-            messages: vec![ChatCompletionRequestMessage {
-                role: "user".into(),
-                content: "hi".into(),
-                ..Default::default()
-            }],
+            messages: vec![ChatCompletionRequestMessage::new("user", "hi")],
             ..Default::default()
         };
         let (provider, model) = pair_for("openai/gpt-5.6");

--- a/crates/warpllm/src/gateway/openai_compat/api/chat_completions/request.rs
+++ b/crates/warpllm/src/gateway/openai_compat/api/chat_completions/request.rs
@@ -1,15 +1,54 @@
 //! Request conversions: OpenAI-compatible wire → gateway (ingest) and
 //! gateway → wire (render).
+//!
+//! # Promote but retain
+//!
+//! Every typed field this module lifts into the gateway form is ALSO kept in
+//! `ext["openai_compat"]` exactly as it arrived, and [`render_request`] prefers
+//! the retained value over re-rendering the gateway form. `reasoning_content`
+//! in `response.rs` already works this way; the reason is the same here and
+//! matters more, because content parts and tools carry residue the gateway
+//! shapes have no field for — a part's `type` spelling, a tool's vendor
+//! extensions, the difference between `"hi"` and `[{"type":"text",...}]`.
+//!
+//! So a request that arrives on this protocol and leaves on it is byte-exact,
+//! and one that arrives on ANOTHER protocol has no residue here and is
+//! rendered from the gateway form. Both paths are real: the first is every
+//! request to an OpenAI-compatible backend, the second is what makes a second
+//! protocol reachable at all.
+//!
+//! What "exactly as it arrived" rests on: [`retain`] stores the PARSED value
+//! re-serialized, not the original bytes — by the time this runs the caller
+//! has handed over a struct and the bytes are gone. So the residue is faithful
+//! only as far as the wire types round trip losslessly, and a field that read
+//! an explicit `null` as absent would lose it here no matter what this module
+//! did. That is why every request field the vendor documents as nullable is
+//! `Option<Option<T>>` behind `present_or_null` rather than a plain `Option`.
+//!
+//! The caveat, and it is the same one `reasoning_content` has: something that
+//! edited `ChatRequest::tools` between ingest and render would find the
+//! retained value winning. Nothing does that today, and the moment something
+//! does it will want to drop the residue deliberately rather than have this
+//! guess.
 
 use serde_json::Value;
 
 use crate::error::{Error, Result};
-use crate::gateway::types::{self, ContentBlock, IngestSource};
+use crate::gateway::types::{self, ContentBlock, IngestSource, MediaSource, RawJson};
 use crate::protocol::openai_compat::chat_completions::types::{
-    ChatCompletionRequestMessage, CreateChatCompletionRequest,
+    ChatCompletionMessageToolCall, ChatCompletionMessageToolCallUnion,
+    ChatCompletionNamedToolChoice, ChatCompletionRequestMessage,
+    ChatCompletionRequestMessageContent, ChatCompletionRequestMessageContentPart,
+    ChatCompletionRequestMessageContentPartAudio, ChatCompletionRequestMessageContentPartFile,
+    ChatCompletionRequestMessageContentPartImage, ChatCompletionRequestMessageContentPartText,
+    ChatCompletionResponseFormat, ChatCompletionStop, ChatCompletionStreamOptions,
+    ChatCompletionTool, ChatCompletionToolChoiceOption, CreateChatCompletionRequest, FileContent,
+    Function, FunctionObject, ImageUrl, InputAudio, JsonSchemaDefinition, ResponseFormatJsonSchema,
+    ResponseFormatSimple, ToolChoiceFunction, UnknownFields,
 };
 use crate::types::Protocol;
 
+use super::response::{plain, take_nullable_string, take_string, take_typed};
 use crate::gateway::openai_compat::{merged_ext, namespaced, role_from_wire, role_to_wire};
 
 /// Permissive and infallible: capture, don't validate. `model` is the
@@ -35,19 +74,58 @@ pub(crate) fn ingest_request(
         top_p,
         stop,
         stream,
+        stream_options,
+        tools,
+        tool_choice,
+        response_format,
+        reasoning_effort,
         unknown_fields,
     } = request;
+
+    let mut compat = unknown_fields;
+    retain(&mut compat, "stop", stop.as_ref());
+    retain(&mut compat, "stream_options", stream_options.as_ref());
+    retain(&mut compat, "tools", tools.as_ref());
+    retain(&mut compat, "tool_choice", tool_choice.as_ref());
+    retain(&mut compat, "response_format", response_format.as_ref());
+    retain(&mut compat, "reasoning_effort", reasoning_effort.as_ref());
+
     types::ChatRequest {
         model: model.to_string(),
         messages: messages.into_iter().map(ingest_message).collect(),
+        tools: tools
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(ingest_tool)
+            .collect(),
+        tool_choice: tool_choice.as_ref().and_then(ingest_tool_choice),
         params: types::GenerationParams {
             max_tokens,
             temperature,
             top_p,
-            stop: stop.unwrap_or_default(),
+            // Both wire spellings mean the same list of sequences; the one
+            // that arrived is retained above so rendering can restore it.
+            stop: stop
+                .as_ref()
+                .and_then(Option::as_ref)
+                .map(ChatCompletionStop::sequences)
+                .unwrap_or_default(),
         },
+        response_format: response_format.as_ref().and_then(ingest_response_format),
+        // Only the effort half: chat completions has no token budget to read,
+        // and inventing one from a word would be a number nobody wrote.
+        reasoning: reasoning_effort
+            .flatten()
+            .map(|effort| types::ReasoningConfig {
+                effort: Some(effort),
+                ..Default::default()
+            }),
         stream: stream.unwrap_or(false),
-        ext: namespaced(unknown_fields),
+        stream_include_usage: stream_options
+            .flatten()
+            .and_then(|options| options.include_usage),
+        ext: namespaced(compat),
         source: Some(IngestSource {
             protocol: Protocol::OpenAiCompat,
             body,
@@ -56,10 +134,21 @@ pub(crate) fn ingest_request(
     }
 }
 
+/// Keeps a typed field's wire value under this protocol's namespace, so
+/// [`render_request`] can hand back exactly what arrived. See this module's
+/// docs for why the promoted form is not enough on its own.
+fn retain<T: serde::Serialize>(compat: &mut UnknownFields, key: &str, value: Option<&T>) {
+    if let Some(value) = value {
+        compat.insert(key.to_string(), plain(value));
+    }
+}
+
 fn ingest_message(message: ChatCompletionRequestMessage) -> types::Message {
     let ChatCompletionRequestMessage {
         role,
         content,
+        tool_calls,
+        tool_call_id,
         unknown_fields,
     } = message;
     let (role, raw_role) = role_from_wire(role);
@@ -69,13 +158,207 @@ fn ingest_message(message: ChatCompletionRequestMessage) -> types::Message {
         // render restores the raw spelling from ext.
         compat.insert("role".into(), Value::String(raw));
     }
-    types::Message {
-        role,
-        content: vec![ContentBlock::Text {
-            text: content,
+    retain(&mut compat, "content", content.as_ref());
+    retain(&mut compat, "tool_calls", tool_calls.as_ref());
+    retain(&mut compat, "tool_call_id", tool_call_id.as_ref());
+
+    // An absent `content` and an explicit `null` both carry no blocks; which
+    // one it was rides the residue above, so rendering restores the right one.
+    let mut blocks: Vec<ContentBlock> = match content.as_ref().and_then(Option::as_ref) {
+        Some(ChatCompletionRequestMessageContent::Text(text)) => vec![ContentBlock::Text {
+            text: text.clone(),
             cache: None,
         }],
+        Some(ChatCompletionRequestMessageContent::Parts(parts)) => {
+            parts.iter().map(ingest_part).collect()
+        }
+        None => Vec::new(),
+    };
+    // A tool result is one block carrying the id of the call it answers,
+    // which is what lets a protocol that groups results into a single turn
+    // (Anthropic) reassemble them. `tool_call_id` is what says this is one.
+    if let Some(call_id) = tool_call_id {
+        blocks = vec![ContentBlock::ToolResult {
+            call_id,
+            content: blocks,
+            // Chat completions has no way to mark a result as failed; the
+            // model reads the text. Only a protocol that flags it can set this.
+            is_error: false,
+        }];
+    }
+    blocks.extend(tool_calls.into_iter().flatten().map(ingest_tool_call));
+
+    types::Message {
+        role,
+        content: blocks,
         ext: namespaced(compat),
+    }
+}
+
+fn ingest_part(part: &ChatCompletionRequestMessageContentPart) -> ContentBlock {
+    match part {
+        ChatCompletionRequestMessageContentPart::Text(part) => ContentBlock::Text {
+            text: part.text.clone(),
+            cache: None,
+        },
+        ChatCompletionRequestMessageContentPart::Image(part) => ContentBlock::Image {
+            source: media_source(&part.image_url.url),
+            detail: part.image_url.detail.clone(),
+            cache: None,
+        },
+        ChatCompletionRequestMessageContentPart::Audio(part) => ContentBlock::Audio {
+            // The format IS the subtype for every container OpenAI documents,
+            // and it is the only thing on the wire that could name a media
+            // type — so it is composed rather than guessed at.
+            source: MediaSource::Base64 {
+                media_type: format!("audio/{}", part.input_audio.format),
+                data: part.input_audio.data.clone(),
+            },
+            format: Some(part.input_audio.format.clone()),
+        },
+        ChatCompletionRequestMessageContentPart::File(part) => match &part.file {
+            FileContent {
+                file_id: Some(id), ..
+            } => ContentBlock::Document {
+                source: MediaSource::ProviderFile { id: id.clone() },
+                title: part.file.filename.clone(),
+                cache: None,
+            },
+            FileContent {
+                file_data: Some(data),
+                ..
+            } => ContentBlock::Document {
+                // RAW base64, not a `data:` URL. The vendor documents this
+                // field as "the base64 encoded file data" flat out, where
+                // `image_url.url` is "either a URL of the image OR the base64
+                // encoded image data" — so the two fields take different
+                // things and only the image one is worth parsing.
+                //
+                // The media type is empty because the file part has no field
+                // for one. A target that requires it (Anthropic wants
+                // `application/pdf`) has to say so rather than be handed a
+                // guess made from the filename.
+                source: MediaSource::Base64 {
+                    media_type: String::new(),
+                    data: data.clone(),
+                },
+                title: part.file.filename.clone(),
+                cache: None,
+            },
+            // Neither a reference nor bytes: nothing to point a renderer at.
+            _ => ContentBlock::Unknown(plain(part)),
+        },
+        // A refusal is the model declining, not content the caller sent. The
+        // gateway form has no block for it, and inventing one would put it in
+        // front of a renderer as if it were something to say.
+        ChatCompletionRequestMessageContentPart::Refusal(part) => {
+            ContentBlock::Unknown(plain(part))
+        }
+        ChatCompletionRequestMessageContentPart::Unknown(value) => {
+            ContentBlock::Unknown(value.clone())
+        }
+    }
+}
+
+/// Splits a `data:` URL into its media type and payload, so a protocol that
+/// wants them apart (Anthropic) does not have to re-parse a string. Anything
+/// else is a plain URL, which is the other thing OpenAI accepts here.
+fn media_source(url: &str) -> MediaSource {
+    match url
+        .strip_prefix("data:")
+        .and_then(|rest| rest.split_once(";base64,"))
+    {
+        Some((media_type, data)) => MediaSource::Base64 {
+            media_type: media_type.to_string(),
+            data: data.to_string(),
+        },
+        None => MediaSource::Url {
+            url: url.to_string(),
+        },
+    }
+}
+
+fn ingest_tool_call(call: ChatCompletionMessageToolCallUnion) -> ContentBlock {
+    match call {
+        ChatCompletionMessageToolCallUnion::Function(call) => ContentBlock::ToolCall {
+            id: call.id,
+            name: call.function.name,
+            // Model-generated, so not necessarily valid JSON. `RawJson` holds
+            // the exact text either way; whoever renders it decides what to do
+            // about that.
+            arguments: RawJson::new(&call.function.arguments),
+        },
+        // A custom tool's `input` is free text against a grammar, not JSON
+        // arguments, so it is not a `ToolCall` — calling it one would put text
+        // where every renderer expects an object.
+        ChatCompletionMessageToolCallUnion::Custom(call) => ContentBlock::Unknown(plain(&call)),
+    }
+}
+
+fn ingest_tool(tool: &ChatCompletionTool) -> types::ToolDef {
+    let mut ext = UnknownFields::new();
+    ext.insert("type".into(), Value::String(tool.r#type.clone()));
+    match &tool.function {
+        Some(function) => types::ToolDef {
+            name: function.name.clone(),
+            description: function.description.clone(),
+            // Verbatim: providers that reject some JSON Schema keywords prune
+            // in their own renderer, never here.
+            input_schema: function.parameters.clone().unwrap_or(Value::Null),
+            strict: function.strict.flatten(),
+            cache: None,
+            ext: namespaced(ext),
+        },
+        // A hosted tool (`{"type": "web_search"}`) or a custom one: no
+        // arguments schema exists to translate. It keeps its `type` as a name
+        // and carries the whole wire object in ext, which is what lets a
+        // renderer for another protocol refuse it by name instead of sending
+        // something invented. A neutral representation for these is #47's.
+        None => types::ToolDef {
+            name: tool.r#type.clone(),
+            description: None,
+            input_schema: Value::Null,
+            strict: None,
+            cache: None,
+            ext: namespaced(object(plain(tool))),
+        },
+    }
+}
+
+fn ingest_tool_choice(choice: &ChatCompletionToolChoiceOption) -> Option<types::ToolChoice> {
+    match choice {
+        ChatCompletionToolChoiceOption::Named(named) => Some(types::ToolChoice::Tool {
+            name: named.function.name.clone(),
+        }),
+        ChatCompletionToolChoiceOption::Mode(mode) => match mode.as_str() {
+            "auto" => Some(types::ToolChoice::Auto),
+            "none" => Some(types::ToolChoice::None),
+            "required" => Some(types::ToolChoice::Required),
+            // A mode this gateway has no word for. It still reaches an
+            // OpenAI-compatible target through the retained residue; there is
+            // just nothing to tell another protocol.
+            _ => None,
+        },
+        // A choice shape with no gateway word either — `allowed_tools`, or a
+        // custom tool. Same deal as an unrecognized mode.
+        ChatCompletionToolChoiceOption::Unknown(_) => None,
+    }
+}
+
+fn ingest_response_format(format: &ChatCompletionResponseFormat) -> Option<types::ResponseFormat> {
+    match format {
+        ChatCompletionResponseFormat::JsonSchema(format) => {
+            Some(types::ResponseFormat::JsonSchema {
+                name: format.json_schema.name.clone(),
+                schema: format.json_schema.schema.clone().unwrap_or(Value::Null),
+                strict: format.json_schema.strict.flatten(),
+            })
+        }
+        ChatCompletionResponseFormat::Simple(format) => match format.r#type.as_str() {
+            "text" => Some(types::ResponseFormat::Text),
+            "json_object" => Some(types::ResponseFormat::JsonObject),
+            _ => None,
+        },
     }
 }
 
@@ -95,72 +378,465 @@ pub(crate) fn render_request(
     request: &types::ChatRequest,
     provider: &'static str,
 ) -> Result<CreateChatCompletionRequest> {
-    ensure_no_staged_features(request)?;
-    let unknown_fields = merged_ext(&request.ext, provider);
+    ensure_renderable(request)?;
+    let mut unknown_fields = merged_ext(&request.ext, provider);
     let params = &request.params;
+    // One gateway message can be several wire ones; see [`render_message`].
+    let mut messages = Vec::with_capacity(request.messages.len());
+    for message in &request.messages {
+        messages.extend(render_message(message, provider)?);
+    }
+    // Hoisted rather than inlined below: rendering a tool can fail, and `?`
+    // has nowhere to go inside an `or_else` closure returning `Option`.
+    let tools = match take_typed(&mut unknown_fields, "tools") {
+        Some(tools) => Some(tools),
+        None if request.tools.is_empty() => None,
+        None => Some(
+            request
+                .tools
+                .iter()
+                .map(render_tool)
+                .collect::<Result<Vec<_>>>()?,
+        ),
+    };
     Ok(CreateChatCompletionRequest {
         model: request.model.clone(),
-        messages: request
-            .messages
-            .iter()
-            .map(|m| render_message(m, provider))
-            .collect::<Result<_>>()?,
+        messages,
         temperature: params.temperature,
         max_tokens: params.max_tokens,
         top_p: params.top_p,
-        stop: (!params.stop.is_empty()).then(|| params.stop.clone()),
+        stop: take_typed(&mut unknown_fields, "stop").or_else(|| {
+            (!params.stop.is_empty()).then(|| Some(ChatCompletionStop::Many(params.stop.clone())))
+        }),
         stream: request.stream.then_some(true),
+        // Each of these prefers what arrived over what the gateway form can
+        // reconstruct; see this module's docs.
+        stream_options: take_typed(&mut unknown_fields, "stream_options").or_else(|| {
+            request.stream_include_usage.map(|include_usage| {
+                Some(ChatCompletionStreamOptions {
+                    include_usage: Some(include_usage),
+                    unknown_fields: UnknownFields::new(),
+                })
+            })
+        }),
+        tools,
+        tool_choice: take_typed(&mut unknown_fields, "tool_choice")
+            .or_else(|| request.tool_choice.as_ref().map(render_tool_choice)),
+        response_format: take_typed(&mut unknown_fields, "response_format")
+            .or_else(|| request.response_format.as_ref().map(render_response_format)),
+        reasoning_effort: take_nullable_string(&mut unknown_fields, "reasoning_effort").or_else(
+            || {
+                request
+                    .reasoning
+                    .as_ref()
+                    .and_then(|reasoning| reasoning.effort.clone())
+                    .map(Some)
+            },
+        ),
         unknown_fields,
     })
 }
 
-/// The compat wire types don't model these yet (they arrive via
-/// `ext["openai_compat"]` passthrough instead); a typed rendering is the
-/// documented follow-up before the first translated protocol.
-fn ensure_no_staged_features(request: &types::ChatRequest) -> Result<()> {
-    if !request.tools.is_empty()
-        || request.tool_choice.is_some()
-        || request.response_format.is_some()
-        || request.reasoning.is_some()
-        || request.cache.is_some()
-        || request.stream_include_usage.is_some()
+/// What the gateway form can hold and this protocol cannot say.
+///
+/// Narrower than the gate it replaces, because tools, a tool choice and a
+/// response format all became renderable — but not empty, and the remainder is
+/// not a staging list. Chat completions has no cache-breakpoint vocabulary
+/// warpllm models, and its only reasoning control is `reasoning_effort`, so a
+/// token budget or a "reason but do not return it" flag has nowhere to go.
+///
+/// Rendering these as silence would CHANGE the request rather than translate
+/// it: a caller who asked for a 4k thinking budget would get an ordinary
+/// completion back with nothing saying the budget was ignored. Refusing names
+/// the field instead.
+///
+/// Nothing on this protocol's own ingest path sets any of them, so this can
+/// only fire on a request that arrived somewhere else.
+fn ensure_renderable(request: &types::ChatRequest) -> Result<()> {
+    if request.cache.is_some()
+        || request.tools.iter().any(|tool| tool.cache.is_some())
+        || request
+            .messages
+            .iter()
+            .flat_map(|message| &message.content)
+            .any(has_cache_hint)
     {
         return Err(Error::NotImplemented(
-            "typed tools/response_format on the openai_compat renderer",
+            "cache hints on the openai_compat renderer",
         ));
+    }
+    // A failed tool result is a fact about the conversation, not a detail of
+    // it: the model reads it as "that call did not work" and behaves
+    // differently. Chat completions has no bit for it — a tool message is
+    // `{content, role, tool_call_id}` and nothing else — and the only way to
+    // convey it would be to edit the content, which puts words in the tool's
+    // mouth that its author never wrote.
+    //
+    // `is_error: false` is the ordinary case and carries no information, so it
+    // renders normally; only a result that says it FAILED has nowhere to go.
+    if request
+        .messages
+        .iter()
+        .flat_map(|message| &message.content)
+        .any(has_failed_result)
+    {
+        return Err(Error::NotImplemented(
+            "a failed tool result on the openai_compat renderer",
+        ));
+    }
+    if let Some(reasoning) = &request.reasoning {
+        if reasoning.budget_tokens.is_some() || reasoning.exclude.is_some() {
+            return Err(Error::NotImplemented(
+                "a reasoning budget or exclusion on the openai_compat renderer",
+            ));
+        }
+        // `effort` is the whole vocabulary, so asking for reasoning without
+        // one leaves nothing to emit.
+        if reasoning.enabled.is_some() && reasoning.effort.is_none() {
+            return Err(Error::NotImplemented(
+                "reasoning without an effort on the openai_compat renderer",
+            ));
+        }
     }
     Ok(())
 }
 
+fn has_cache_hint(block: &ContentBlock) -> bool {
+    match block {
+        ContentBlock::Text { cache, .. }
+        | ContentBlock::Image { cache, .. }
+        | ContentBlock::Document { cache, .. } => cache.is_some(),
+        ContentBlock::ToolResult { content, .. } => content.iter().any(has_cache_hint),
+        _ => false,
+    }
+}
+
+fn has_failed_result(block: &ContentBlock) -> bool {
+    match block {
+        ContentBlock::ToolResult {
+            is_error, content, ..
+        } => *is_error || content.iter().any(has_failed_result),
+        _ => false,
+    }
+}
+
+/// One gateway message, rendered as the one OR MORE wire messages this
+/// protocol needs to say it.
+///
+/// The count is not always one because tool results group differently per
+/// protocol. Chat completions carries exactly one result per message, keyed by
+/// `tool_call_id`; Anthropic merges a run of consecutive results into a single
+/// `user` turn holding several `tool_result` blocks. So a message arriving from
+/// there splits back into one message per result here, which is the inverse of
+/// the merge [`ingest_message`] undoes. Rendering only the first would leave
+/// every other call the model made looking unanswered — and a model told its
+/// tool never replied does not fail, it guesses.
 fn render_message(
     message: &types::Message,
     provider: &str,
-) -> Result<ChatCompletionRequestMessage> {
+) -> Result<Vec<ChatCompletionRequestMessage>> {
     let mut unknown_fields = merged_ext(&message.ext, provider);
     let role = match unknown_fields.remove("role") {
         Some(Value::String(raw)) => raw,
         _ => role_to_wire(message.role).to_string(),
     };
-    let mut texts = Vec::new();
-    for block in &message.content {
-        match block {
-            ContentBlock::Text { text, .. } => texts.push(text.as_str()),
-            // Only reachable cross-protocol; typed rendering is the
-            // documented follow-up alongside the wire-type expansion.
-            _ => {
-                return Err(Error::NotImplemented(
-                    "typed content blocks on the openai_compat renderer",
-                ));
-            }
+    let retained_content = take_typed(&mut unknown_fields, "content");
+    let retained_calls = take_typed(&mut unknown_fields, "tool_calls");
+    let retained_id = take_string(&mut unknown_fields, "tool_call_id");
+
+    let results = results_of(&message.content);
+    if results.len() > 1 {
+        // Only reachable from another protocol — this one's ingest never
+        // builds a message with two results, so there is no retained residue
+        // to divide and `unknown_fields` is empty. It rides the first message
+        // rather than being copied onto every one, which would duplicate any
+        // vendor field a future path did put there.
+        return Ok(results
+            .into_iter()
+            .enumerate()
+            .map(
+                |(position, (call_id, content))| ChatCompletionRequestMessage {
+                    role: role.clone(),
+                    content: render_content(content).map(Some),
+                    tool_calls: None,
+                    tool_call_id: Some(call_id.clone()),
+                    unknown_fields: if position == 0 {
+                        std::mem::take(&mut unknown_fields)
+                    } else {
+                        UnknownFields::new()
+                    },
+                },
+            )
+            .collect());
+    }
+
+    Ok(vec![ChatCompletionRequestMessage {
+        role,
+        content: match retained_content {
+            Some(content) => Some(content),
+            // A message built on another protocol always has content to say,
+            // so there is no explicit null to restore — only a value or
+            // nothing.
+            None => render_content(&message.content).map(Some),
+        },
+        tool_calls: match retained_calls {
+            Some(calls) => Some(calls),
+            None => render_tool_calls(&message.content),
+        },
+        // Chat completions puts the answered call's id on the message; the
+        // gateway form puts it on the block, so it is read back off the one
+        // result this message carries.
+        tool_call_id: retained_id.or_else(|| results.first().map(|(id, _)| (*id).clone())),
+        unknown_fields,
+    }])
+}
+
+/// Every tool result in a message, as the call it answers and its payload.
+///
+/// `is_error` is deliberately not returned: [`ensure_renderable`] has already
+/// refused any result that sets it, so every result reaching here is a
+/// successful one and there is no flag left to carry.
+fn results_of(blocks: &[ContentBlock]) -> Vec<(&String, &[ContentBlock])> {
+    blocks
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::ToolResult {
+                call_id, content, ..
+            } => Some((call_id, content.as_slice())),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Blocks → a message's `content`. A single text block renders as a bare
+/// string, which is what the overwhelming majority of messages are and what
+/// every provider's own examples show; anything else renders as parts.
+fn render_content(blocks: &[ContentBlock]) -> Option<ChatCompletionRequestMessageContent> {
+    // A tool result's payload is its inner blocks, and chat completions has
+    // nowhere else to put them: the result IS the message.
+    if let Some(ContentBlock::ToolResult { content, .. }) = blocks
+        .iter()
+        .find(|b| matches!(b, ContentBlock::ToolResult { .. }))
+    {
+        return render_content(content);
+    }
+    let parts: Vec<_> = blocks.iter().filter_map(render_part).collect();
+    match parts.as_slice() {
+        [] => None,
+        [ChatCompletionRequestMessageContentPart::Text(part)] if part.unknown_fields.is_empty() => {
+            Some(ChatCompletionRequestMessageContent::Text(part.text.clone()))
+        }
+        _ => Some(ChatCompletionRequestMessageContent::Parts(parts)),
+    }
+}
+
+/// `None` for a block that is not message content: a tool CALL rides
+/// `tool_calls`, and reasoning has no request-side home on this protocol at
+/// all — a provider that returned thinking cannot be told about it here.
+fn render_part(block: &ContentBlock) -> Option<ChatCompletionRequestMessageContentPart> {
+    match block {
+        ContentBlock::Text { text, .. } => Some(ChatCompletionRequestMessageContentPart::Text(
+            ChatCompletionRequestMessageContentPartText {
+                r#type: "text".into(),
+                text: text.clone(),
+                unknown_fields: UnknownFields::new(),
+            },
+        )),
+        ContentBlock::Image { source, detail, .. } => {
+            Some(ChatCompletionRequestMessageContentPart::Image(
+                ChatCompletionRequestMessageContentPartImage {
+                    r#type: "image_url".into(),
+                    image_url: ImageUrl {
+                        url: media_url(source),
+                        detail: detail.clone(),
+                        unknown_fields: UnknownFields::new(),
+                    },
+                    unknown_fields: UnknownFields::new(),
+                },
+            ))
+        }
+        ContentBlock::Audio { source, format } => {
+            let (media_type, data) = match source {
+                MediaSource::Base64 { media_type, data } => (media_type.as_str(), data.clone()),
+                // A URL or a provider file cannot become inline audio bytes,
+                // which is the only audio form this protocol takes.
+                _ => return Some(unknown_part(block)),
+            };
+            Some(ChatCompletionRequestMessageContentPart::Audio(
+                ChatCompletionRequestMessageContentPartAudio {
+                    r#type: "input_audio".into(),
+                    input_audio: InputAudio {
+                        data,
+                        format: format
+                            .clone()
+                            .unwrap_or_else(|| subtype(media_type).to_string()),
+                        unknown_fields: UnknownFields::new(),
+                    },
+                    unknown_fields: UnknownFields::new(),
+                },
+            ))
+        }
+        ContentBlock::Document { source, title, .. } => {
+            let file = match source {
+                MediaSource::ProviderFile { id } => FileContent {
+                    file_data: None,
+                    file_id: Some(id.clone()),
+                    filename: title.clone(),
+                    unknown_fields: UnknownFields::new(),
+                },
+                // Raw base64 back out, matching what the field takes. The
+                // media type has nowhere to go — the file part declares none —
+                // so a document that carried one loses it here.
+                MediaSource::Base64 { data, .. } => FileContent {
+                    file_data: Some(data.clone()),
+                    file_id: None,
+                    filename: title.clone(),
+                    unknown_fields: UnknownFields::new(),
+                },
+                // A file part takes bytes or an uploaded id, never a URL.
+                MediaSource::Url { .. } => return Some(unknown_part(block)),
+            };
+            Some(ChatCompletionRequestMessageContentPart::File(
+                ChatCompletionRequestMessageContentPartFile {
+                    r#type: "file".into(),
+                    file,
+                    unknown_fields: UnknownFields::new(),
+                },
+            ))
+        }
+        ContentBlock::Unknown(value) => Some(ChatCompletionRequestMessageContentPart::Unknown(
+            value.clone(),
+        )),
+        // Handled elsewhere, or not representable in a request on this
+        // protocol. See this function's doc.
+        ContentBlock::ToolCall { .. }
+        | ContentBlock::ToolResult { .. }
+        | ContentBlock::Reasoning { .. } => None,
+    }
+}
+
+fn unknown_part(block: &ContentBlock) -> ChatCompletionRequestMessageContentPart {
+    ChatCompletionRequestMessageContentPart::Unknown(plain(block))
+}
+
+/// The inverse of [`media_source`]: inline bytes become a `data:` URL, which
+/// is the single string field this protocol has for them.
+fn media_url(source: &MediaSource) -> String {
+    match source {
+        MediaSource::Url { url } => url.clone(),
+        MediaSource::Base64 { media_type, data } => format!("data:{media_type};base64,{data}"),
+        MediaSource::ProviderFile { id } => id.clone(),
+    }
+}
+
+fn subtype(media_type: &str) -> &str {
+    media_type
+        .split_once('/')
+        .map_or(media_type, |(_, sub)| sub)
+}
+
+fn render_tool_calls(blocks: &[ContentBlock]) -> Option<Vec<ChatCompletionMessageToolCallUnion>> {
+    let calls: Vec<_> = blocks
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::ToolCall {
+                id,
+                name,
+                arguments,
+            } => Some(ChatCompletionMessageToolCallUnion::Function(
+                ChatCompletionMessageToolCall {
+                    id: id.clone(),
+                    r#type: "function".into(),
+                    function: Function {
+                        arguments: arguments.as_str().to_string(),
+                        name: name.clone(),
+                        unknown_fields: UnknownFields::new(),
+                    },
+                    unknown_fields: UnknownFields::new(),
+                },
+            )),
+            _ => None,
+        })
+        .collect();
+    (!calls.is_empty()).then_some(calls)
+}
+
+fn render_tool(tool: &types::ToolDef) -> Result<ChatCompletionTool> {
+    // A tool with no arguments schema is a hosted or custom one, and this
+    // protocol has no shape for one it did not itself ingest. Refusing names
+    // it; sending a function tool with an empty schema would have the model
+    // call something that does not exist.
+    if tool.input_schema.is_null() {
+        return Err(Error::NotImplemented(
+            "a tool with no arguments schema on the openai_compat renderer",
+        ));
+    }
+    Ok(ChatCompletionTool {
+        r#type: "function".into(),
+        function: Some(FunctionObject {
+            name: tool.name.clone(),
+            description: tool.description.clone(),
+            parameters: Some(tool.input_schema.clone()),
+            strict: tool.strict.map(Some),
+            unknown_fields: UnknownFields::new(),
+        }),
+        unknown_fields: UnknownFields::new(),
+    })
+}
+
+fn render_tool_choice(choice: &types::ToolChoice) -> ChatCompletionToolChoiceOption {
+    match choice {
+        types::ToolChoice::Auto => ChatCompletionToolChoiceOption::Mode("auto".into()),
+        types::ToolChoice::None => ChatCompletionToolChoiceOption::Mode("none".into()),
+        types::ToolChoice::Required => ChatCompletionToolChoiceOption::Mode("required".into()),
+        types::ToolChoice::Tool { name } => {
+            ChatCompletionToolChoiceOption::Named(ChatCompletionNamedToolChoice {
+                r#type: "function".into(),
+                function: ToolChoiceFunction {
+                    name: name.clone(),
+                    unknown_fields: UnknownFields::new(),
+                },
+                unknown_fields: UnknownFields::new(),
+            })
         }
     }
-    Ok(ChatCompletionRequestMessage {
-        role,
-        // Same-protocol messages carry exactly one text block, so the join
-        // is exact; joining >1 only occurs cross-protocol.
-        content: texts.join("\n"),
-        unknown_fields,
-    })
+}
+
+fn render_response_format(format: &types::ResponseFormat) -> ChatCompletionResponseFormat {
+    match format {
+        types::ResponseFormat::Text => ChatCompletionResponseFormat::Simple(ResponseFormatSimple {
+            r#type: "text".into(),
+            unknown_fields: UnknownFields::new(),
+        }),
+        types::ResponseFormat::JsonObject => {
+            ChatCompletionResponseFormat::Simple(ResponseFormatSimple {
+                r#type: "json_object".into(),
+                unknown_fields: UnknownFields::new(),
+            })
+        }
+        types::ResponseFormat::JsonSchema {
+            name,
+            schema,
+            strict,
+        } => ChatCompletionResponseFormat::JsonSchema(ResponseFormatJsonSchema {
+            r#type: "json_schema".into(),
+            json_schema: JsonSchemaDefinition {
+                name: name.clone(),
+                description: None,
+                schema: Some(schema.clone()),
+                strict: strict.map(Some),
+                unknown_fields: UnknownFields::new(),
+            },
+            unknown_fields: UnknownFields::new(),
+        }),
+    }
+}
+
+fn object(value: Value) -> UnknownFields {
+    match value {
+        Value::Object(fields) => fields,
+        _ => UnknownFields::new(),
+    }
 }
 
 #[cfg(test)]
@@ -168,7 +844,11 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::gateway::types::ProviderExt;
+    use crate::gateway::types::{ProviderExt, Role};
+
+    fn wire(value: Value) -> CreateChatCompletionRequest {
+        serde_json::from_value(value).unwrap()
+    }
 
     fn full_wire_request() -> CreateChatCompletionRequest {
         let mut request = CreateChatCompletionRequest {
@@ -176,19 +856,22 @@ mod tests {
             messages: vec![
                 ChatCompletionRequestMessage {
                     role: "developer".into(),
-                    content: "be brief".into(),
+                    content: Some(Some("be brief".into())),
                     ..Default::default()
                 },
                 ChatCompletionRequestMessage {
                     role: "user".into(),
-                    content: "hi".into(),
+                    content: Some(Some("hi".into())),
                     ..Default::default()
                 },
             ],
             temperature: Some(0.7),
             max_tokens: Some(256),
             top_p: Some(0.9),
-            stop: Some(vec!["END".into(), "STOP".into()]),
+            stop: Some(Some(ChatCompletionStop::Many(vec![
+                "END".into(),
+                "STOP".into(),
+            ]))),
             stream: Some(false),
             ..Default::default()
         };
@@ -220,17 +903,15 @@ mod tests {
         assert_eq!(wire.messages.len(), 2);
         // The unrecognized "developer" role survives verbatim.
         assert_eq!(wire.messages[0].role, "developer");
-        assert_eq!(wire.messages[0].content, "be brief");
         assert!(wire.messages[0].unknown_fields.is_empty());
         assert_eq!(wire.messages[1].role, "user");
-        assert_eq!(wire.messages[1].content, "hi");
         // Message-level passthrough fields ride ext and come back verbatim.
         assert_eq!(wire.messages[1].unknown_fields["name"], json!("alice"));
         assert_eq!(wire.messages[1].unknown_fields["vendor_tag"], json!("vt"));
         assert_eq!(wire.temperature, Some(0.7));
         assert_eq!(wire.max_tokens, Some(256));
         assert_eq!(wire.top_p, Some(0.9));
-        assert_eq!(wire.stop, Some(vec!["END".to_string(), "STOP".to_string()]));
+        assert_eq!(plain(&wire.stop), json!(["END", "STOP"]));
         assert_eq!(wire.stream, None);
         // Request-level passthrough fields ride ext and come back verbatim.
         assert_eq!(wire.unknown_fields["top_k"], json!(40));
@@ -243,6 +924,289 @@ mod tests {
         expected["model"] = json!("gpt-5.6");
         expected.as_object_mut().unwrap().remove("stream");
         assert_eq!(serde_json::to_value(&wire).unwrap(), expected);
+    }
+
+    /// THE claim the retain half of this module exists for. Tools, a tool
+    /// choice, a multimodal parts list, an assistant turn that called a tool
+    /// and the tool message answering it all carry residue the gateway shapes
+    /// have no field for — a part's `type` spelling, a vendor extension on a
+    /// function, the difference between a bare string and a one-part list.
+    /// All of it has to come back byte for byte.
+    #[test]
+    fn a_tool_calling_request_round_trips_byte_for_byte() {
+        let original = wire(json!({
+            "model": "openai/gpt-5.6",
+            "messages": [
+                {"role": "user", "content": [
+                    {"type": "text", "text": "what is the weather"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/a.png", "detail": "high"}},
+                    {"type": "input_audio", "input_audio": {"data": "aGk=", "format": "wav"}}
+                ]},
+                {"role": "assistant", "content": null, "tool_calls": [
+                    {"id": "call_1", "type": "function",
+                     "function": {"name": "get_weather", "arguments": "{\"city\": \"Seoul\"}"},
+                     "vendor_call_field": 1}
+                ]},
+                {"role": "tool", "tool_call_id": "call_1", "content": "18C"}
+            ],
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Look up the weather",
+                    "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                    "strict": true,
+                    "vendor_function_field": "x"
+                }
+            }],
+            "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+            "response_format": {"type": "json_schema", "json_schema": {
+                "name": "weather", "schema": {"type": "object"}, "strict": true
+            }},
+            "stream_options": {"include_usage": true},
+            "reasoning_effort": "high"
+        }));
+
+        let normalized = ingest_request(original.clone(), "gpt-5.6");
+        let rendered = render_request(&normalized, "openai").unwrap();
+
+        let mut expected = serde_json::to_value(&original).unwrap();
+        expected["model"] = json!("gpt-5.6");
+        // Nothing else is permitted to differ — including the `content: null`
+        // on the tool-calling assistant turn, and the `strict` nested inside
+        // the tool, both of which are explicit values rather than absences.
+        assert_eq!(serde_json::to_value(&rendered).unwrap(), expected);
+    }
+
+    /// ...and the same request must ALSO be readable as gateway types, which
+    /// is the half that makes another protocol reachable. The retained
+    /// residue above is invisible here.
+    #[test]
+    fn ingest_promotes_tools_and_content_into_the_gateway_form() {
+        let normalized = ingest_request(
+            wire(json!({
+                "model": "openai/gpt-5.6",
+                "messages": [
+                    {"role": "user", "content": [
+                        {"type": "text", "text": "what is the weather"},
+                        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+                    ]},
+                    {"role": "assistant", "content": null, "tool_calls": [
+                        {"id": "call_1", "type": "function",
+                         "function": {"name": "get_weather", "arguments": "{\"city\":\"Seoul\"}"}}
+                    ]},
+                    {"role": "tool", "tool_call_id": "call_1", "content": "18C"}
+                ],
+                "tools": [{"type": "function", "function": {
+                    "name": "get_weather", "parameters": {"type": "object"}, "strict": true
+                }}],
+                "tool_choice": "required",
+                "response_format": {"type": "json_object"},
+                "stream_options": {"include_usage": true},
+                "reasoning_effort": "high"
+            })),
+            "gpt-5.6",
+        );
+
+        assert_eq!(normalized.tools.len(), 1);
+        assert_eq!(normalized.tools[0].name, "get_weather");
+        assert_eq!(normalized.tools[0].input_schema, json!({"type": "object"}));
+        assert_eq!(normalized.tools[0].strict, Some(true));
+        assert!(matches!(
+            normalized.tool_choice,
+            Some(types::ToolChoice::Required)
+        ));
+        assert!(matches!(
+            normalized.response_format,
+            Some(types::ResponseFormat::JsonObject)
+        ));
+        assert_eq!(normalized.stream_include_usage, Some(true));
+        assert_eq!(
+            normalized.reasoning.as_ref().unwrap().effort.as_deref(),
+            Some("high")
+        );
+
+        // A parts list becomes real blocks, and a `data:` URL is split so a
+        // protocol that wants the media type apart does not re-parse it.
+        match &normalized.messages[0].content[..] {
+            [
+                ContentBlock::Text { text, .. },
+                ContentBlock::Image { source, .. },
+            ] => {
+                assert_eq!(text, "what is the weather");
+                assert!(matches!(
+                    source,
+                    MediaSource::Base64 { media_type, data }
+                        if media_type == "image/png" && data == "AAAA"
+                ));
+            }
+            other => panic!("expected a text and an image block, got {other:?}"),
+        }
+
+        // The assistant's call, and the tool message answering it, both land
+        // as blocks carrying the id that correlates them.
+        match &normalized.messages[1].content[..] {
+            [
+                ContentBlock::ToolCall {
+                    id,
+                    name,
+                    arguments,
+                },
+            ] => {
+                assert_eq!(id, "call_1");
+                assert_eq!(name, "get_weather");
+                assert_eq!(arguments.as_str(), r#"{"city":"Seoul"}"#);
+            }
+            other => panic!("expected one tool call, got {other:?}"),
+        }
+        assert_eq!(normalized.messages[2].role, Role::Tool);
+        match &normalized.messages[2].content[..] {
+            [
+                ContentBlock::ToolResult {
+                    call_id,
+                    content,
+                    is_error,
+                },
+            ] => {
+                assert_eq!(call_id, "call_1");
+                assert!(!is_error);
+                assert!(
+                    matches!(&content[..], [ContentBlock::Text { text, .. }] if text == "18C"),
+                    "{content:?}"
+                );
+            }
+            other => panic!("expected one tool result, got {other:?}"),
+        }
+    }
+
+    /// The cross-protocol direction: a gateway request built somewhere else
+    /// carries no `openai_compat` residue, so every field has to be rendered
+    /// from the gateway form alone. This is the path a second protocol's
+    /// ingest feeds, and nothing but this test exercises it today.
+    #[test]
+    fn a_request_with_no_residue_renders_from_the_gateway_form() {
+        let request = types::ChatRequest {
+            model: "gpt-5.6".into(),
+            messages: vec![
+                types::Message {
+                    role: Role::User,
+                    content: vec![
+                        ContentBlock::Text {
+                            text: "what is the weather".into(),
+                            cache: None,
+                        },
+                        ContentBlock::Image {
+                            source: MediaSource::Base64 {
+                                media_type: "image/png".into(),
+                                data: "AAAA".into(),
+                            },
+                            detail: Some("high".into()),
+                            cache: None,
+                        },
+                    ],
+                    ext: ProviderExt::new(),
+                },
+                types::Message {
+                    role: Role::Assistant,
+                    content: vec![ContentBlock::ToolCall {
+                        id: "toolu_01".into(),
+                        name: "get_weather".into(),
+                        arguments: RawJson::new(r#"{"city":"Seoul"}"#),
+                    }],
+                    ext: ProviderExt::new(),
+                },
+                types::Message {
+                    role: Role::Tool,
+                    content: vec![ContentBlock::ToolResult {
+                        call_id: "toolu_01".into(),
+                        content: vec![ContentBlock::Text {
+                            text: "18C".into(),
+                            cache: None,
+                        }],
+                        is_error: false,
+                    }],
+                    ext: ProviderExt::new(),
+                },
+            ],
+            tools: vec![types::ToolDef {
+                name: "get_weather".into(),
+                description: Some("Look up the weather".into()),
+                input_schema: json!({"type": "object"}),
+                strict: None,
+                cache: None,
+                ext: ProviderExt::new(),
+            }],
+            tool_choice: Some(types::ToolChoice::Tool {
+                name: "get_weather".into(),
+            }),
+            stream_include_usage: Some(true),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            serde_json::to_value(render_request(&request, "openai").unwrap()).unwrap(),
+            json!({
+                "model": "gpt-5.6",
+                "messages": [
+                    {"role": "user", "content": [
+                        {"type": "text", "text": "what is the weather"},
+                        {"type": "image_url",
+                         "image_url": {"url": "data:image/png;base64,AAAA", "detail": "high"}}
+                    ]},
+                    {"role": "assistant", "tool_calls": [
+                        {"id": "toolu_01", "type": "function",
+                         "function": {"arguments": "{\"city\":\"Seoul\"}", "name": "get_weather"}}
+                    ]},
+                    // The result's payload IS the message on this protocol,
+                    // and the call id moves from the block onto the message.
+                    {"role": "tool", "content": "18C", "tool_call_id": "toolu_01"}
+                ],
+                "stream_options": {"include_usage": true},
+                "tools": [{"type": "function", "function": {
+                    "name": "get_weather",
+                    "description": "Look up the weather",
+                    "parameters": {"type": "object"}
+                }}],
+                "tool_choice": {"type": "function", "function": {"name": "get_weather"}}
+            })
+        );
+    }
+
+    /// A hosted tool has no arguments schema, so there is nothing to render a
+    /// function tool FROM. Refusing names it; emitting one with an empty
+    /// schema would have the model call something that does not exist. A
+    /// neutral representation for these is #47's to settle.
+    #[test]
+    fn a_tool_with_no_schema_is_refused_cross_protocol() {
+        let request = types::ChatRequest {
+            model: "gpt-5.6".into(),
+            tools: vec![types::ToolDef {
+                name: "web_search".into(),
+                description: None,
+                input_schema: Value::Null,
+                strict: None,
+                cache: None,
+                ext: ProviderExt::new(),
+            }],
+            ..Default::default()
+        };
+        let err = render_request(&request, "openai").unwrap_err();
+        assert!(matches!(err, Error::NotImplemented(_)), "{err:?}");
+
+        // ...but the same tool arriving ON this protocol still reaches the
+        // provider, because the residue renders it without this path.
+        let same_protocol = ingest_request(
+            wire(json!({
+                "model": "openai/gpt-5.6",
+                "messages": [],
+                "tools": [{"type": "web_search"}]
+            })),
+            "gpt-5.6",
+        );
+        assert_eq!(
+            plain(&render_request(&same_protocol, "openai").unwrap().tools),
+            json!([{"type": "web_search"}])
+        );
     }
 
     #[test]
@@ -322,28 +1286,427 @@ mod tests {
     }
 
     #[test]
-    fn render_rejects_staged_features() {
-        let mut normalized = ingest_request(full_wire_request(), "gpt-5.6");
-        normalized.tools.push(types::ToolDef {
-            name: "search".into(),
-            description: None,
-            input_schema: json!({"type": "object"}),
-            strict: None,
-            cache: None,
-            ext: ProviderExt::new(),
-        });
-        let err = render_request(&normalized, "openai").unwrap_err();
-        assert!(matches!(err, Error::NotImplemented(_)), "{err:?}");
-    }
-
-    #[test]
     fn empty_stop_is_omitted_and_stream_never_rendered() {
         let mut wire_request = full_wire_request();
         wire_request.stop = None;
         wire_request.stream = Some(false);
         let normalized = ingest_request(wire_request, "gpt-5.6");
         let wire = render_request(&normalized, "openai").unwrap();
-        assert_eq!(wire.stop, None);
+        assert!(wire.stop.is_none());
         assert_eq!(wire.stream, None);
+    }
+
+    /// `file_data` is raw base64, flatly — the vendor documents it as "the
+    /// base64 encoded file data", where `image_url.url` is "either a URL of
+    /// the image OR the base64 encoded image data". Reading a file's bytes as
+    /// a URL would hand the next protocol a `MediaSource::Url` pointing at
+    /// `"aGk="`, and no residue saves that once the request came from
+    /// somewhere else.
+    #[test]
+    fn a_files_bytes_are_raw_base64_in_both_directions() {
+        let normalized = ingest_request(
+            wire(json!({
+                "model": "openai/gpt-5.6",
+                "messages": [{"role": "user", "content": [
+                    {"type": "file", "file": {"file_data": "aGk=", "filename": "a.pdf"}},
+                    {"type": "file", "file": {"file_id": "file-1"}},
+                    // ...while the IMAGE part's data URL is still split, since
+                    // that field really does take both.
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+                ]}]
+            })),
+            "gpt-5.6",
+        );
+        match &normalized.messages[0].content[..] {
+            [
+                ContentBlock::Document {
+                    source: bytes,
+                    title,
+                    ..
+                },
+                ContentBlock::Document {
+                    source: uploaded, ..
+                },
+                ContentBlock::Image { source: image, .. },
+            ] => {
+                assert!(
+                    matches!(bytes, MediaSource::Base64 { media_type, data }
+                        if media_type.is_empty() && data == "aGk="),
+                    "{bytes:?}"
+                );
+                assert_eq!(title.as_deref(), Some("a.pdf"));
+                assert!(matches!(uploaded, MediaSource::ProviderFile { id } if id == "file-1"));
+                assert!(
+                    matches!(image, MediaSource::Base64 { media_type, data }
+                        if media_type == "image/png" && data == "AAAA"),
+                    "{image:?}"
+                );
+            }
+            other => panic!("expected two documents and an image, got {other:?}"),
+        }
+
+        // ...and back out, from a request with no residue to restore from.
+        let cross_protocol = types::ChatRequest {
+            model: "gpt-5.6".into(),
+            messages: vec![types::Message {
+                role: Role::User,
+                content: vec![ContentBlock::Document {
+                    source: MediaSource::Base64 {
+                        media_type: "application/pdf".into(),
+                        data: "aGk=".into(),
+                    },
+                    title: Some("a.pdf".into()),
+                    cache: None,
+                }],
+                ext: ProviderExt::new(),
+            }],
+            ..Default::default()
+        };
+        assert_eq!(
+            plain(&render_request(&cross_protocol, "openai").unwrap().messages),
+            json!([{"role": "user", "content": [
+                // Raw, not `data:application/pdf;base64,aGk=`. The media type
+                // is dropped because the file part declares no field for one.
+                {"type": "file", "file": {"file_data": "aGk=", "filename": "a.pdf"}}
+            ]}])
+        );
+    }
+
+    /// Anthropic merges a run of consecutive tool results into ONE `user`
+    /// turn; this protocol carries exactly one result per message. So a
+    /// grouped turn has to split back into one message each, and the count of
+    /// wire messages stops matching the count of gateway ones.
+    ///
+    /// Rendering only the first result would leave the model's other calls
+    /// looking unanswered — and a model told its tool never replied does not
+    /// fail, it guesses.
+    #[test]
+    fn a_grouped_turn_splits_into_one_message_per_tool_result() {
+        let result = |call_id: &str, text: &str| ContentBlock::ToolResult {
+            call_id: call_id.into(),
+            content: vec![ContentBlock::Text {
+                text: text.into(),
+                cache: None,
+            }],
+            is_error: false,
+        };
+        let request = types::ChatRequest {
+            model: "gpt-5.6".into(),
+            messages: vec![
+                types::Message {
+                    role: Role::Assistant,
+                    content: vec![
+                        ContentBlock::ToolCall {
+                            id: "toolu_01".into(),
+                            name: "weather".into(),
+                            arguments: RawJson::new(r#"{"city":"Seoul"}"#),
+                        },
+                        ContentBlock::ToolCall {
+                            id: "toolu_02".into(),
+                            name: "weather".into(),
+                            arguments: RawJson::new(r#"{"city":"Tokyo"}"#),
+                        },
+                    ],
+                    ext: ProviderExt::new(),
+                },
+                // The merged turn: two results, one message.
+                types::Message {
+                    role: Role::Tool,
+                    content: vec![result("toolu_01", "18C"), result("toolu_02", "24C")],
+                    ext: ProviderExt::new(),
+                },
+            ],
+            ..Default::default()
+        };
+
+        let rendered = render_request(&request, "openai").unwrap();
+        assert_eq!(
+            plain(&rendered.messages),
+            json!([
+                {"role": "assistant", "tool_calls": [
+                    {"id": "toolu_01", "type": "function",
+                     "function": {"arguments": "{\"city\":\"Seoul\"}", "name": "weather"}},
+                    {"id": "toolu_02", "type": "function",
+                     "function": {"arguments": "{\"city\":\"Tokyo\"}", "name": "weather"}}
+                ]},
+                {"role": "tool", "content": "18C", "tool_call_id": "toolu_01"},
+                {"role": "tool", "content": "24C", "tool_call_id": "toolu_02"}
+            ]),
+            "every call the assistant made must have an answer"
+        );
+
+        // Two gateway messages became three wire ones, which is the point.
+        assert_eq!(rendered.messages.len(), 3);
+    }
+
+    /// A tool that FAILED is a different fact than a tool that returned an
+    /// unhelpful answer, and the model acts on the difference. Chat
+    /// completions has no bit for it, and the only way to convey it would be
+    /// to edit the content — putting words in the tool's mouth its author
+    /// never wrote.
+    ///
+    /// The ordinary case has to keep working, which is the other half of this:
+    /// `is_error: false` carries no information and must not be refused, or
+    /// every tool result crossing protocols would be.
+    #[test]
+    fn a_failed_tool_result_is_refused_rather_than_flattened() {
+        let answered = |is_error| types::ChatRequest {
+            model: "gpt-5.6".into(),
+            messages: vec![types::Message {
+                role: Role::Tool,
+                content: vec![ContentBlock::ToolResult {
+                    call_id: "toolu_01".into(),
+                    content: vec![ContentBlock::Text {
+                        text: "the city was not found".into(),
+                        cache: None,
+                    }],
+                    is_error,
+                }],
+                ext: ProviderExt::new(),
+            }],
+            ..Default::default()
+        };
+
+        let err = render_request(&answered(true), "openai").unwrap_err();
+        assert!(matches!(err, Error::NotImplemented(_)), "{err:?}");
+        assert!(err.to_string().contains("failed tool result"), "{err}");
+
+        // The same text, not marked as a failure, is an ordinary result.
+        assert_eq!(
+            plain(&render_request(&answered(false), "openai").unwrap().messages),
+            json!([{
+                "role": "tool",
+                "content": "the city was not found",
+                "tool_call_id": "toolu_01"
+            }])
+        );
+    }
+
+    /// A cache hint has no spelling on this protocol, so rendering it as
+    /// silence would change the request rather than translate it — the caller
+    /// asked for a breakpoint and would get an ordinary completion with
+    /// nothing saying otherwise. Every level that can carry one is checked,
+    /// because widening the renderer removed the gate that used to cover them.
+    #[test]
+    fn a_cache_hint_is_refused_rather_than_dropped() {
+        let hint = || {
+            Some(types::CacheHint {
+                ttl: Some("5m".into()),
+            })
+        };
+        let text = |cache| types::Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text {
+                text: "hi".into(),
+                cache,
+            }],
+            ext: ProviderExt::new(),
+        };
+        let tool = |cache| types::ToolDef {
+            name: "f".into(),
+            description: None,
+            input_schema: json!({"type": "object"}),
+            strict: None,
+            cache,
+            ext: ProviderExt::new(),
+        };
+
+        for request in [
+            // On the request...
+            types::ChatRequest {
+                cache: hint(),
+                ..Default::default()
+            },
+            // ...on a block...
+            types::ChatRequest {
+                messages: vec![text(hint())],
+                ..Default::default()
+            },
+            // ...on a block nested inside a tool result...
+            types::ChatRequest {
+                messages: vec![types::Message {
+                    role: Role::Tool,
+                    content: vec![ContentBlock::ToolResult {
+                        call_id: "c".into(),
+                        content: vec![ContentBlock::Text {
+                            text: "18C".into(),
+                            cache: hint(),
+                        }],
+                        is_error: false,
+                    }],
+                    ext: ProviderExt::new(),
+                }],
+                ..Default::default()
+            },
+            // ...and on a tool.
+            types::ChatRequest {
+                tools: vec![tool(hint())],
+                ..Default::default()
+            },
+        ] {
+            let err = render_request(&request, "openai").unwrap_err();
+            assert!(matches!(err, Error::NotImplemented(_)), "{err:?}");
+            assert!(err.to_string().contains("cache"), "{err}");
+        }
+
+        // The same shapes without hints still render, so the check is not one
+        // that refuses everything.
+        render_request(
+            &types::ChatRequest {
+                messages: vec![text(None)],
+                tools: vec![tool(None)],
+                ..Default::default()
+            },
+            "openai",
+        )
+        .unwrap();
+    }
+
+    /// `reasoning_effort` is the whole of this protocol's reasoning
+    /// vocabulary. A budget, an exclusion, or a bare "reason" with no effort
+    /// to render has nowhere to go, and dropping them would answer a request
+    /// nobody made.
+    #[test]
+    fn an_unrenderable_reasoning_field_is_refused() {
+        let with = |reasoning| types::ChatRequest {
+            reasoning: Some(reasoning),
+            ..Default::default()
+        };
+        for reasoning in [
+            types::ReasoningConfig {
+                budget_tokens: Some(4096),
+                ..Default::default()
+            },
+            types::ReasoningConfig {
+                exclude: Some(true),
+                ..Default::default()
+            },
+            types::ReasoningConfig {
+                enabled: Some(true),
+                ..Default::default()
+            },
+            // Even alongside an effort, a budget is a number this protocol
+            // cannot state.
+            types::ReasoningConfig {
+                enabled: Some(true),
+                effort: Some("high".into()),
+                budget_tokens: Some(4096),
+                ..Default::default()
+            },
+        ] {
+            let err = render_request(&with(reasoning), "openai").unwrap_err();
+            assert!(matches!(err, Error::NotImplemented(_)), "{err:?}");
+            assert!(err.to_string().contains("reasoning"), "{err}");
+        }
+
+        // An effort alone is exactly what this protocol says, with or without
+        // the enablement that effort already implies.
+        for reasoning in [
+            types::ReasoningConfig {
+                effort: Some("high".into()),
+                ..Default::default()
+            },
+            types::ReasoningConfig {
+                enabled: Some(true),
+                effort: Some("high".into()),
+                ..Default::default()
+            },
+        ] {
+            assert_eq!(
+                render_request(&with(reasoning), "openai")
+                    .unwrap()
+                    .reasoning_effort,
+                Some(Some("high".into()))
+            );
+        }
+    }
+
+    /// The legacy `role: "function"` message is where absent and `null`
+    /// genuinely differ: its schema is `content: string | null`, so the key is
+    /// REQUIRED and may hold null. A form that read the null as an absence
+    /// would forward `{"role": "function", "name": "f"}` with the key gone,
+    /// and a provider holding OpenAI to its own schema may reject that.
+    #[test]
+    fn a_null_content_on_a_function_message_keeps_its_key() {
+        let normalized = ingest_request(
+            wire(json!({
+                "model": "openai/gpt-5.6",
+                "messages": [
+                    {"role": "function", "name": "f", "content": null},
+                    // ...while an assistant turn may legitimately omit it, and
+                    // must not gain one it never had.
+                    {"role": "assistant", "tool_calls": [
+                        {"id": "call_1", "type": "function",
+                         "function": {"name": "f", "arguments": "{}"}}
+                    ]}
+                ]
+            })),
+            "gpt-5.6",
+        );
+        let messages = plain(&render_request(&normalized, "openai").unwrap().messages);
+        assert_eq!(messages[0]["content"], Value::Null, "{messages}");
+        assert!(
+            messages[0].get("content").is_some(),
+            "the key a function message requires was dropped: {messages}"
+        );
+        assert!(
+            messages[1].get("content").is_none(),
+            "an absent content came back as a null: {messages}"
+        );
+    }
+
+    /// Typing a field is what makes it translatable, and it must not cost the
+    /// passthrough that field had while it was untyped. Every one of these
+    /// reached a provider verbatim as an `unknown_fields` entry before it had
+    /// a home; an explicit `null` still has to arrive.
+    ///
+    /// `strict` is the case that says the fix had to be in the TYPES: `retain`
+    /// stores the parsed value re-serialized, so a null the type collapsed on
+    /// the way in is gone before retention ever runs.
+    #[test]
+    fn an_explicit_null_survives_on_every_nullable_field() {
+        let body = json!({
+            "model": "openai/gpt-5.6",
+            "messages": [],
+            "stop": null,
+            "stream_options": null,
+            "reasoning_effort": null,
+            "tools": [{"type": "function", "function": {
+                "name": "f", "parameters": {"type": "object"}, "strict": null
+            }}],
+            "response_format": {"type": "json_schema", "json_schema": {
+                "name": "r", "schema": {"type": "object"}, "strict": null
+            }}
+        });
+        let normalized = ingest_request(wire(body.clone()), "gpt-5.6");
+        let rendered = plain(&render_request(&normalized, "openai").unwrap());
+
+        let mut expected = body;
+        expected["model"] = json!("gpt-5.6");
+        assert_eq!(rendered, expected);
+    }
+
+    /// `stop` is one sequence or several, and OpenAI's own examples show the
+    /// bare string. Both have to be read, both have to reach the gateway form
+    /// as the same list, and each has to render back as the form it arrived
+    /// in — a request that said `"END"` is not one that said `["END"]`.
+    #[test]
+    fn a_bare_stop_string_is_read_and_rendered_back_as_one() {
+        for (wire_stop, sequences) in [
+            (json!("END"), vec!["END".to_string()]),
+            (json!(["END", "STOP"]), vec!["END".into(), "STOP".into()]),
+        ] {
+            let original = wire(json!({
+                "model": "openai/gpt-5.6",
+                "messages": [],
+                "stop": wire_stop,
+            }));
+            let normalized = ingest_request(original, "gpt-5.6");
+            assert_eq!(normalized.params.stop, sequences);
+            assert_eq!(
+                plain(&render_request(&normalized, "openai").unwrap().stop),
+                wire_stop
+            );
+        }
     }
 }

--- a/crates/warpllm/src/lib.rs
+++ b/crates/warpllm/src/lib.rs
@@ -22,22 +22,43 @@ pub use error::{Error, Origin, Result};
 pub use gateway::types::ProviderError;
 pub use json_client::{JsonChatStream, JsonClient};
 /// Everything a caller must NAME to make a call and hold its result: the
-/// request, the message it is built from, and the response handed back by
+/// request, everything it is built from, and the response handed back by
 /// [`Client::chat_completions`].
 ///
 /// That is the whole rule, and it is why the response's insides are absent.
 /// Reading `completion.choices[0].message.content` names none of them — field
-/// access needs no import — so `Choice`, `CompletionUsage` and the tool-call
-/// forms stay at `protocol::openai_compat::chat_completions::types`, where the
-/// path states what they are: shapes of the OpenAI protocol, which warpllm
-/// speaks, rather than warpllm's own vocabulary. Requests are the asymmetric
-/// half — you cannot build one without spelling its message type.
+/// access needs no import — so `Choice` and `CompletionUsage` stay at
+/// `protocol::openai_compat::chat_completions::types`, where the path states
+/// what they are: shapes of the OpenAI protocol, which warpllm speaks, rather
+/// than warpllm's own vocabulary. Requests are the asymmetric half — you
+/// cannot build one without spelling every type it reaches.
 ///
-/// A glob here claimed all of it as warpllm's, and widened the public API
-/// every time that module gained a type.
+/// Which is why the list is long. Setting `tools`, `tool_choice`,
+/// `response_format` or a multimodal `content` means naming the type of each,
+/// and the type each of those reaches in turn; a caller who has to write
+/// `protocol::openai_compat::chat_completions::types::ImageUrl` to attach an
+/// image is being sent through a path that reads like an internal one for a
+/// thing the request cannot be built without.
+///
+/// The tool-call forms are here for the same reason and only that reason. They
+/// are still not needed to READ a reply — the rule above holds — but an
+/// assistant turn replayed back into a conversation has to be spelled out, and
+/// that is a request.
+///
+/// A glob would have claimed all of it as warpllm's, and widened the public
+/// API every time that module gained a type.
 pub use protocol::openai_compat::chat_completions::types::{
-    ChatCompletionRequestMessage, CreateChatCompletionRequest, CreateChatCompletionResponse,
-    CreateChatCompletionStreamResponse,
+    ChatCompletionMessageCustomToolCall, ChatCompletionMessageToolCall,
+    ChatCompletionMessageToolCallUnion, ChatCompletionNamedToolChoice,
+    ChatCompletionRequestMessage, ChatCompletionRequestMessageContent,
+    ChatCompletionRequestMessageContentPart, ChatCompletionRequestMessageContentPartAudio,
+    ChatCompletionRequestMessageContentPartFile, ChatCompletionRequestMessageContentPartImage,
+    ChatCompletionRequestMessageContentPartRefusal, ChatCompletionRequestMessageContentPartText,
+    ChatCompletionResponseFormat, ChatCompletionStop, ChatCompletionStreamOptions,
+    ChatCompletionTool, ChatCompletionToolChoiceOption, CreateChatCompletionRequest,
+    CreateChatCompletionResponse, CreateChatCompletionStreamResponse, Custom, FileContent,
+    Function, FunctionObject, ImageUrl, InputAudio, JsonSchemaDefinition, ResponseFormatJsonSchema,
+    ResponseFormatSimple, ToolChoiceFunction,
 };
 /// A failure rendered the way an OpenAI-compatible surface reports it, and
 /// the only error shape warpllm shows anyone who is not writing Rust.

--- a/crates/warpllm/src/protocol/openai_compat/chat_completions/types.rs
+++ b/crates/warpllm/src/protocol/openai_compat/chat_completions/types.rs
@@ -678,14 +678,47 @@ pub struct CreateChatCompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional = nullable))]
     pub top_p: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "codegen", ts(optional = nullable))]
-    pub stop: Option<Vec<String>>,
+    #[serde(
+        default,
+        deserialize_with = "present_or_null",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    #[cfg_attr(feature = "codegen", schemars(extend("x-nullable-when-present" = true)))]
+    pub stop: Option<Option<ChatCompletionStop>>,
     // The reply this asks for is CreateChatCompletionStreamResponse, above.
     // The shapes are defined; nothing reads a stream off the socket yet.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional = nullable))]
     pub stream: Option<bool>,
+    #[serde(
+        default,
+        deserialize_with = "present_or_null",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    #[cfg_attr(feature = "codegen", schemars(extend("x-nullable-when-present" = true)))]
+    pub stream_options: Option<Option<ChatCompletionStreamOptions>>,
+    /// Tools the model may call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional = nullable))]
+    pub tools: Option<Vec<ChatCompletionTool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional = nullable))]
+    pub tool_choice: Option<ChatCompletionToolChoiceOption>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional = nullable))]
+    pub response_format: Option<ChatCompletionResponseFormat>,
+    /// How much reasoning to spend; provider-defined, commonly `"low"`,
+    /// `"medium"`, `"high"`.
+    #[serde(
+        default,
+        deserialize_with = "present_or_null",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    #[cfg_attr(feature = "codegen", schemars(extend("x-nullable-when-present" = true)))]
+    pub reasoning_effort: Option<Option<String>>,
     #[serde(flatten)]
     #[cfg_attr(feature = "codegen", ts(skip))]
     pub unknown_fields: UnknownFields,
@@ -696,7 +729,389 @@ pub struct CreateChatCompletionRequest {
 pub struct ChatCompletionRequestMessage {
     /// Provider-defined role; common values include `"system"` and `"user"`.
     pub role: String,
-    pub content: String,
+    // Optional AND nullable, and the difference is load-bearing here rather
+    // than a nicety: `content` is OPTIONAL on an assistant turn that carries
+    // only `tool_calls`, and REQUIRED-but-nullable on the legacy
+    // `role: "function"` message, whose schema is `content: string | null`. A
+    // form that read `null` as absent would forward
+    // `{"role": "function", "name": "f"}` with the key gone, and a provider
+    // holding OpenAI to its own schema is entitled to reject that.
+    #[serde(
+        default,
+        deserialize_with = "present_or_null",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    #[cfg_attr(feature = "codegen", schemars(extend("x-nullable-when-present" = true)))]
+    pub content: Option<Option<ChatCompletionRequestMessageContent>>,
+    /// Set on the assistant turn that called tools; each entry is answered by
+    /// a later message with `role: "tool"` carrying the matching
+    /// `tool_call_id`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional = nullable))]
+    pub tool_calls: Option<Vec<ChatCompletionMessageToolCallUnion>>,
+    /// Which call this message answers. Set on `role: "tool"` messages.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional = nullable))]
+    pub tool_call_id: Option<String>,
+    #[serde(flatten)]
+    #[cfg_attr(feature = "codegen", ts(skip))]
+    pub unknown_fields: UnknownFields,
+}
+
+impl ChatCompletionRequestMessage {
+    /// A message with something to say — the ordinary case.
+    ///
+    /// `content` is `Option<Option<_>>` because the wire distinguishes an
+    /// absent key from an explicit `null`, and both are real: an assistant turn
+    /// carrying only `tool_calls` omits it, and the legacy `role: "function"`
+    /// message requires the key while permitting the null. A caller writing a
+    /// prompt wants neither state, and should not have to spell out the two
+    /// they are not choosing.
+    ///
+    /// The other shapes stay struct literals, because a message with no
+    /// content is exactly where those two states start to matter.
+    pub fn new(
+        role: impl Into<String>,
+        content: impl Into<ChatCompletionRequestMessageContent>,
+    ) -> Self {
+        Self {
+            role: role.into(),
+            content: Some(Some(content.into())),
+            ..Default::default()
+        }
+    }
+}
+
+/// A message's content: one string, or a list of parts.
+// Untagged for the same reason as ChatCompletionMessageToolCallUnion: the part
+// structs own their `type` field, and an internal serde tag would be captured
+// by their flattened `unknown_fields` and emitted twice. The two forms are not
+// collapsed into one — a provider is sent back what it was given, and callers
+// that pass a bare string see a bare string.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+#[serde(untagged)]
+pub enum ChatCompletionRequestMessageContent {
+    Text(String),
+    Parts(Vec<ChatCompletionRequestMessageContentPart>),
+}
+
+impl From<&str> for ChatCompletionRequestMessageContent {
+    fn from(text: &str) -> Self {
+        Self::Text(text.to_string())
+    }
+}
+
+impl From<String> for ChatCompletionRequestMessageContent {
+    fn from(text: String) -> Self {
+        Self::Text(text)
+    }
+}
+
+/// One part of a multimodal message.
+// Untagged, and each variant's required field (`text`, `image_url`,
+// `input_audio`, `file`, `refusal`) is what keeps dispatch unambiguous even
+// when a provider sends a nonstandard `type` string. `Unknown` is last so a
+// part shape warpllm does not model still reaches the provider verbatim.
+//
+// `Refusal` earns a variant despite having no gateway meaning — it round trips
+// through `Unknown` just as well. What it buys is the PUBLISHED TypeScript:
+// `Unknown` generates as `JsonValue`, whose object case is an index signature,
+// and TypeScript never assigns an interface to one of those. So a caller
+// holding OpenAI's own `ChatCompletionContentPartRefusal` could build a
+// request warpllm accepts at runtime and could not typecheck.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+#[serde(untagged)]
+pub enum ChatCompletionRequestMessageContentPart {
+    Text(ChatCompletionRequestMessageContentPartText),
+    Image(ChatCompletionRequestMessageContentPartImage),
+    Audio(ChatCompletionRequestMessageContentPartAudio),
+    File(ChatCompletionRequestMessageContentPartFile),
+    Refusal(ChatCompletionRequestMessageContentPartRefusal),
+    Unknown(serde_json::Value),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+pub struct ChatCompletionRequestMessageContentPartRefusal {
+    /// Conventionally `"refusal"`; compatible providers may differ.
+    #[serde(rename = "type")]
+    pub r#type: String,
+    pub refusal: String,
+    #[serde(flatten)]
+    #[cfg_attr(feature = "codegen", ts(skip))]
+    pub unknown_fields: UnknownFields,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+pub struct ChatCompletionRequestMessageContentPartText {
+    /// Conventionally `"text"`; compatible providers may differ.
+    #[serde(rename = "type")]
+    pub r#type: String,
+    pub text: String,
+    #[serde(flatten)]
+    #[cfg_attr(feature = "codegen", ts(skip))]
+    pub unknown_fields: UnknownFields,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+pub struct ChatCompletionRequestMessageContentPartImage {
+    /// Conventionally `"image_url"`; compatible providers may differ.
+    #[serde(rename = "type")]
+    pub r#type: String,
+    pub image_url: ImageUrl,
+    #[serde(flatten)]
+    #[cfg_attr(feature = "codegen", ts(skip))]
+    pub unknown_fields: UnknownFields,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+pub struct ImageUrl {
+    /// An `https:` URL, or a `data:` URL carrying base64 image bytes.
+    pub url: String,
+    /// Provider-defined fidelity hint; commonly `"auto"`, `"low"`, `"high"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional = nullable))]
+    pub detail: Option<String>,
+    #[serde(flatten)]
+    #[cfg_attr(feature = "codegen", ts(skip))]
+    pub unknown_fields: UnknownFields,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+pub struct ChatCompletionRequestMessageContentPartAudio {
+    /// Conventionally `"input_audio"`; compatible providers may differ.
+    #[serde(rename = "type")]
+    pub r#type: String,
+    pub input_audio: InputAudio,
+    #[serde(flatten)]
+    #[cfg_attr(feature = "codegen", ts(skip))]
+    pub unknown_fields: UnknownFields,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+pub struct InputAudio {
+    /// Base64-encoded audio bytes.
+    pub data: String,
+    /// Provider-defined container; commonly `"wav"`, `"mp3"`.
+    pub format: String,
+    #[serde(flatten)]
+    #[cfg_attr(feature = "codegen", ts(skip))]
+    pub unknown_fields: UnknownFields,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+pub struct ChatCompletionRequestMessageContentPartFile {
+    /// Conventionally `"file"`; compatible providers may differ.
+    #[serde(rename = "type")]
+    pub r#type: String,
+    pub file: FileContent,
+    #[serde(flatten)]
+    #[cfg_attr(feature = "codegen", ts(skip))]
+    pub unknown_fields: UnknownFields,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+pub struct FileContent {
+    /// Base64-encoded file bytes, for a file sent inline.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional = nullable))]
+    pub file_data: Option<String>,
+    /// A file already uploaded to the provider.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional = nullable))]
+    pub file_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional = nullable))]
+    pub filename: Option<String>,
+    #[serde(flatten)]
+    #[cfg_attr(feature = "codegen", ts(skip))]
+    pub unknown_fields: UnknownFields,
+}
+
+/// One tool the model may call.
+// `function` is optional rather than required so that a tool shape warpllm
+// does not model — a hosted tool like `{"type": "web_search"}`, or a custom
+// tool — parses and reaches the provider instead of failing the whole request.
+// Its payload rides `unknown_fields`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+pub struct ChatCompletionTool {
+    /// Conventionally `"function"`; compatible providers may differ.
+    #[serde(rename = "type")]
+    pub r#type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional = nullable))]
+    pub function: Option<FunctionObject>,
+    #[serde(flatten)]
+    #[cfg_attr(feature = "codegen", ts(skip))]
+    pub unknown_fields: UnknownFields,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+pub struct FunctionObject {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional = nullable))]
+    pub description: Option<String>,
+    /// JSON Schema for the arguments, passed through verbatim.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional = nullable))]
+    pub parameters: Option<serde_json::Value>,
+    /// Whether the provider must adhere exactly to the schema.
+    #[serde(
+        default,
+        deserialize_with = "present_or_null",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    #[cfg_attr(feature = "codegen", schemars(extend("x-nullable-when-present" = true)))]
+    pub strict: Option<Option<bool>>,
+    #[serde(flatten)]
+    #[cfg_attr(feature = "codegen", ts(skip))]
+    pub unknown_fields: UnknownFields,
+}
+
+/// Whether, and which, tool the model must call.
+// Untagged, and `Mode` stays a plain string per this module's codegen policy:
+// providers extend the vocabulary past OpenAI's `"none"`/`"auto"`/`"required"`
+// independently.
+//
+// `Unknown` is last and is what makes this a superset rather than a reading of
+// one vocabulary: OpenAI alone already sends shapes that are neither a mode
+// nor a named function — `{"type": "allowed_tools", ...}` and
+// `{"type": "custom", "custom": {...}}` — and a form without it would reject a
+// request the vendor's own SDK builds.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+#[serde(untagged)]
+pub enum ChatCompletionToolChoiceOption {
+    Named(ChatCompletionNamedToolChoice),
+    Mode(String),
+    Unknown(serde_json::Value),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+pub struct ChatCompletionNamedToolChoice {
+    /// Conventionally `"function"`; compatible providers may differ.
+    #[serde(rename = "type")]
+    pub r#type: String,
+    pub function: ToolChoiceFunction,
+    #[serde(flatten)]
+    #[cfg_attr(feature = "codegen", ts(skip))]
+    pub unknown_fields: UnknownFields,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+pub struct ToolChoiceFunction {
+    pub name: String,
+    #[serde(flatten)]
+    #[cfg_attr(feature = "codegen", ts(skip))]
+    pub unknown_fields: UnknownFields,
+}
+
+/// The shape the reply must take.
+// Untagged, with the schema-bearing variant first: `JsonSchema` requires a
+// `json_schema` field, and `Simple` covers `{"type": "text"}` and
+// `{"type": "json_object"}` alike without closing the vocabulary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+#[serde(untagged)]
+pub enum ChatCompletionResponseFormat {
+    JsonSchema(ResponseFormatJsonSchema),
+    Simple(ResponseFormatSimple),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+pub struct ResponseFormatSimple {
+    /// Conventionally `"text"` or `"json_object"`; compatible providers may
+    /// differ.
+    #[serde(rename = "type")]
+    pub r#type: String,
+    #[serde(flatten)]
+    #[cfg_attr(feature = "codegen", ts(skip))]
+    pub unknown_fields: UnknownFields,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+pub struct ResponseFormatJsonSchema {
+    /// Conventionally `"json_schema"`; compatible providers may differ.
+    #[serde(rename = "type")]
+    pub r#type: String,
+    pub json_schema: JsonSchemaDefinition,
+    #[serde(flatten)]
+    #[cfg_attr(feature = "codegen", ts(skip))]
+    pub unknown_fields: UnknownFields,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+pub struct JsonSchemaDefinition {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional = nullable))]
+    pub description: Option<String>,
+    /// JSON Schema for the reply, passed through verbatim.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional = nullable))]
+    pub schema: Option<serde_json::Value>,
+    #[serde(
+        default,
+        deserialize_with = "present_or_null",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    #[cfg_attr(feature = "codegen", schemars(extend("x-nullable-when-present" = true)))]
+    pub strict: Option<Option<bool>>,
+    #[serde(flatten)]
+    #[cfg_attr(feature = "codegen", ts(skip))]
+    pub unknown_fields: UnknownFields,
+}
+
+/// Where generation stops: one sequence, or several.
+// Both forms are held rather than normalized to a list, for the same reason a
+// message's content keeps its arrived-in form — and because a bare string is
+// what OpenAI's own examples show, so a form that took only a list would
+// reject an ordinary request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+#[serde(untagged)]
+pub enum ChatCompletionStop {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl ChatCompletionStop {
+    /// The sequences, however they were spelled.
+    pub(crate) fn sequences(&self) -> Vec<String> {
+        match self {
+            Self::One(stop) => vec![stop.clone()],
+            Self::Many(stops) => stops.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS, schemars::JsonSchema))]
+pub struct ChatCompletionStreamOptions {
+    /// Ask for a final chunk carrying the whole request's token totals.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional = nullable))]
+    pub include_usage: Option<bool>,
     #[serde(flatten)]
     #[cfg_attr(feature = "codegen", ts(skip))]
     pub unknown_fields: UnknownFields,

--- a/crates/warpllm/tests/live_stream.rs
+++ b/crates/warpllm/tests/live_stream.rs
@@ -63,11 +63,10 @@ async fn every_configured_provider_streams_chunks_warpllm_can_hold() {
 
         let mut request = CreateChatCompletionRequest {
             model: model_str.to_owned(),
-            messages: vec![ChatCompletionRequestMessage {
-                role: "user".into(),
-                content: "Reply with exactly: hello".into(),
-                unknown_fields: Default::default(),
-            }],
+            messages: vec![ChatCompletionRequestMessage::new(
+                "user",
+                "Reply with exactly: hello",
+            )],
             ..Default::default()
         };
         // Both go through the catch-all — the job it exists for, on a request

--- a/crates/warpllm/tests/providers/openai/common.rs
+++ b/crates/warpllm/tests/providers/openai/common.rs
@@ -61,11 +61,7 @@ pub fn with_openrouter_key<F: Future<Output = ()>>(body: F) {
 pub fn request(model: &str) -> CreateChatCompletionRequest {
     CreateChatCompletionRequest {
         model: model.into(),
-        messages: vec![ChatCompletionRequestMessage {
-            role: "user".into(),
-            content: "hi".into(),
-            ..Default::default()
-        }],
+        messages: vec![ChatCompletionRequestMessage::new("user", "hi")],
         ..Default::default()
     }
 }

--- a/crates/warpllm/tests/public_api.rs
+++ b/crates/warpllm/tests/public_api.rs
@@ -1,0 +1,136 @@
+//! What a caller can reach, using only what the crate root hands them.
+//!
+//! An integration test compiles against the PUBLIC surface, which is the only
+//! place the facade's claim can be checked: `lib.rs` says it re-exports
+//! everything a caller must name to make a call, and unit tests cannot notice
+//! when that stops being true — they see the whole crate.
+//!
+//! So the check is the import list below. Every type a fully-loaded request
+//! reaches is named through `warpllm::`, and a field whose type is only
+//! reachable at `protocol::openai_compat::chat_completions::types` fails to
+//! compile here rather than in someone's editor.
+
+use warpllm::{
+    ChatCompletionMessageToolCall, ChatCompletionMessageToolCallUnion,
+    ChatCompletionNamedToolChoice, ChatCompletionRequestMessage,
+    ChatCompletionRequestMessageContent, ChatCompletionRequestMessageContentPart,
+    ChatCompletionRequestMessageContentPartImage, ChatCompletionRequestMessageContentPartText,
+    ChatCompletionResponseFormat, ChatCompletionStop, ChatCompletionStreamOptions,
+    ChatCompletionTool, ChatCompletionToolChoiceOption, CreateChatCompletionRequest, Function,
+    FunctionObject, ImageUrl, JsonSchemaDefinition, ResponseFormatJsonSchema, ToolChoiceFunction,
+};
+
+/// Every typed request feature at once, built the way a caller would.
+///
+/// Deliberately exhaustive rather than minimal: the point is not that this
+/// request is useful, it is that none of it needed an import from a module
+/// path that reads as internal.
+#[test]
+fn a_fully_loaded_request_is_buildable_from_the_crate_root() {
+    let request = CreateChatCompletionRequest {
+        model: "openai/gpt-5.6".into(),
+        messages: vec![
+            // A multimodal user turn.
+            ChatCompletionRequestMessage {
+                role: "user".into(),
+                content: Some(Some(ChatCompletionRequestMessageContent::Parts(vec![
+                    ChatCompletionRequestMessageContentPart::Text(
+                        ChatCompletionRequestMessageContentPartText {
+                            r#type: "text".into(),
+                            text: "what is in this image, and what is the weather there".into(),
+                            unknown_fields: Default::default(),
+                        },
+                    ),
+                    ChatCompletionRequestMessageContentPart::Image(
+                        ChatCompletionRequestMessageContentPartImage {
+                            r#type: "image_url".into(),
+                            image_url: ImageUrl {
+                                url: "https://example.com/a.png".into(),
+                                detail: Some("high".into()),
+                                unknown_fields: Default::default(),
+                            },
+                            unknown_fields: Default::default(),
+                        },
+                    ),
+                ]))),
+                ..Default::default()
+            },
+            // The assistant turn that called a tool, replayed back in.
+            ChatCompletionRequestMessage {
+                role: "assistant".into(),
+                content: Some(None),
+                tool_calls: Some(vec![ChatCompletionMessageToolCallUnion::Function(
+                    ChatCompletionMessageToolCall {
+                        id: "call_1".into(),
+                        r#type: "function".into(),
+                        function: Function {
+                            arguments: r#"{"city":"Seoul"}"#.into(),
+                            name: "get_weather".into(),
+                            unknown_fields: Default::default(),
+                        },
+                        unknown_fields: Default::default(),
+                    },
+                )]),
+                ..Default::default()
+            },
+            // ...and the answer to it.
+            ChatCompletionRequestMessage {
+                role: "tool".into(),
+                content: Some(Some("18C".into())),
+                tool_call_id: Some("call_1".into()),
+                ..Default::default()
+            },
+        ],
+        stop: Some(Some(ChatCompletionStop::One("END".into()))),
+        stream_options: Some(Some(ChatCompletionStreamOptions {
+            include_usage: Some(true),
+            unknown_fields: Default::default(),
+        })),
+        tools: Some(vec![ChatCompletionTool {
+            r#type: "function".into(),
+            function: Some(FunctionObject {
+                name: "get_weather".into(),
+                description: Some("Look up the weather".into()),
+                parameters: Some(serde_json::json!({"type": "object"})),
+                strict: Some(Some(true)),
+                unknown_fields: Default::default(),
+            }),
+            unknown_fields: Default::default(),
+        }]),
+        tool_choice: Some(ChatCompletionToolChoiceOption::Named(
+            ChatCompletionNamedToolChoice {
+                r#type: "function".into(),
+                function: ToolChoiceFunction {
+                    name: "get_weather".into(),
+                    unknown_fields: Default::default(),
+                },
+                unknown_fields: Default::default(),
+            },
+        )),
+        response_format: Some(ChatCompletionResponseFormat::JsonSchema(
+            ResponseFormatJsonSchema {
+                r#type: "json_schema".into(),
+                json_schema: JsonSchemaDefinition {
+                    name: "weather".into(),
+                    description: None,
+                    schema: Some(serde_json::json!({"type": "object"})),
+                    strict: Some(Some(true)),
+                    unknown_fields: Default::default(),
+                },
+                unknown_fields: Default::default(),
+            },
+        )),
+        reasoning_effort: Some(Some("high".into())),
+        ..Default::default()
+    };
+
+    // Serializing is not the claim — building it was. This only pins that the
+    // shapes reached above are the ones that go on the wire.
+    let wire = serde_json::to_value(&request).unwrap();
+    assert_eq!(wire["messages"].as_array().unwrap().len(), 3);
+    assert_eq!(wire["tools"][0]["function"]["name"], "get_weather");
+    assert_eq!(wire["stop"], "END");
+    // The assistant turn's explicit null survives to the wire, where the
+    // legacy `function` role needs it and an assistant turn is entitled to it.
+    assert!(wire["messages"][1]["content"].is_null());
+}

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -26,16 +26,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .chat_completions(CreateChatCompletionRequest {
             model: "openai/gpt-5-nano".to_string(),
             messages: vec![
-                ChatCompletionRequestMessage {
-                    role: "system".to_string(),
-                    content: "You are a helpful assistant.".to_string(),
-                    ..Default::default()
-                },
-                ChatCompletionRequestMessage {
-                    role: "user".to_string(),
-                    content: "Hello!".to_string(),
-                    ..Default::default()
-                },
+                ChatCompletionRequestMessage::new("system", "You are a helpful assistant."),
+                ChatCompletionRequestMessage::new("user", "Hello!"),
             ],
             ..Default::default()
         })


### PR DESCRIPTION
Stage 0 of #23. Tool calling did not work on the OpenAI path and could not, because
`CreateChatCompletionRequest` modelled only `model`/`messages`/`temperature`/
`max_tokens`/`top_p`/`stop`/`stream`, and `ChatCompletionRequestMessage.content` was a
plain `String`. `render_request` refused the moment the gateway form carried tools —
`ensure_no_staged_features`, whose comment called a typed rendering *"the documented
follow-up before the first translated protocol"*. This is that follow-up, and it is a
prerequisite for the Anthropic work rather than part of it, which is why it is its own
PR.

Nothing changes for an existing caller. The request is a superset of what it modelled
before, and the byte-exact round trip is checked.

## Why the neutral path, and not a shortcut

The Anthropic renderer could have read `ext["openai_compat"]["tools"]` and translated
OpenAI's tool shape inline. That would have been smaller and wrong: it violates the rule
`merged_ext` already enforces (a renderer reads only the gateway form and its own
namespace), and Responses — which flattens the function wrapper, `{"type":"function",
"name":…}` against `{"type":"function","function":{"name":…}}` — would need a *second*
special case in the same file, then Google's, then Bedrock's. N protocols each carrying
N−1 translations.

With every protocol ingesting into `ToolDef`/`ToolChoice` and rendering back out, each
writes one conversion and every pairing works. #41 and #47 then add Responses without
touching a line of Anthropic code.

## What is modelled

Request: `tools`, `tool_choice`, `response_format`, `stream_options`, `reasoning_effort`.
Message: string-or-parts `content`, `tool_calls`, `tool_call_id`.

Only what the gateway form can hold. `n`, `seed`, `presence_penalty` and the rest still
reach the provider through the catch-all, which is where they belong.

## Promote but retain

Ingest lifts a field into the gateway form **and** keeps the wire value under
`ext["openai_compat"]`; render prefers the retained value. `reasoning_content` in
`response.rs` already works this way.

It matters more here, because content parts and tools carry residue the gateway shapes
have no field for — a part's `type` spelling, a vendor extension on a function, the
difference between `"hi"` and `[{"type":"text","text":"hi"}]`. So a request that arrives
and leaves on this protocol is byte-exact, and one from another protocol has no residue
and renders from the gateway form. Both paths are tested.

## What is still refused, and why

`ensure_no_staged_features` is **replaced, not deleted**. Tools, a tool choice and a
response format became renderable; three things did not, and `ensure_renderable` refuses
each by name:

| refused | why |
|---|---|
| cache hints (request, block, nested block, tool) | no vocabulary on this protocol |
| a reasoning budget or exclusion, or `enabled` with no `effort` | `reasoning_effort` is the whole vocabulary |
| a failed tool result (`is_error: true`) | a tool message is `{content, role, tool_call_id}` and nothing else |

Rendering these as silence would *change* the request rather than translate it — a
caller who asked for a 4k thinking budget would get an ordinary completion with nothing
saying otherwise. Each has a follow-up issue; the tests assert both halves, so the check
cannot be one that refuses everything.

## One gateway message, several wire messages

A protocol that groups a run of tool results into one turn (Anthropic merges consecutive
tool messages into a single `user` turn) hands over one message carrying several. This
protocol takes exactly one result per message, so `render_message` returns a `Vec` and
the group splits back apart — the inverse of the merge ingest performs.

Rendering only the first would leave every other call the model made looking unanswered,
and a model told its tool never replied does not fail, it guesses.

## Three bugs the oracle caught

`bindings/node/__test__/openai-oracle.ts` covered only replies, because there was nothing
on the request worth checking. Extending it to the request found:

1. **`stop` rejected a bare string.** OpenAI's `stop` is `string | string[]` and its own
   examples pass the string; warpllm modelled only the list, so `{"stop": "END"}` failed
   to deserialize. Now a union, and each form renders back as the form it arrived in.
2. **`tool_choice` was not a superset.** OpenAI 7.4.0 also sends
   `{"type":"allowed_tools",…}` and `{"type":"custom",…}`.
3. **`refusal` parts had no typed home.** They round trip through the catch-all in Rust,
   but the catch-all generates as `JsonValue` — whose object case is an index signature —
   and TypeScript never assigns an *interface* to one of those. A caller holding OpenAI's
   own `ChatCompletionContentPartRefusal` could build a request warpllm accepts at
   runtime and cannot typecheck.

That third one generalises: wherever warpllm types a field as arbitrary JSON, the
published `.d.ts` cannot prove the vendor's looser type fits. It is named once in the
oracle with the two fields it still affects, rather than the assertion being dropped.

## Nullability follows the vendor

`content` is **required-but-nullable** on the legacy `role: "function"` message
(`content: string | null`), so reading its null as an absence would forward
`{"role":"function","name":"f"}` with a required key gone. That and every other field
OpenAI documents as nullable — `stop`, `stream_options`, `reasoning_effort`, both
`strict`s — is `Option<Option<T>>` behind `present_or_null`.

This had to be fixed in the *types*, not the retention: `retain` stores the parsed value
re-serialized, not the original bytes, so a null the type collapsed is gone before
retention ever runs. `temperature`/`max_tokens`/`top_p` have the same latent issue and
predate this change — #51.

## Public surface

The crate root already claimed to re-export everything a caller must name to make a call,
while a caller attaching an image had to write
`protocol::openai_compat::chat_completions::types::ImageUrl`. The list went from 4 names
to 28. The tool-call forms moved too: still not needed to *read* a reply, but replaying an
assistant turn back into a conversation is a *request*.

`crates/warpllm/tests/public_api.rs` is the check — an integration test compiles against
the public surface only, which is the one place that claim can be verified. Unit tests see
the whole crate and cannot notice.

## Verification

`./scripts/test-all.sh` green: fmt, clippy `-D warnings`, workspace, Node, Python, and the
codegen drift gate. 234 lib + 1 public_api + 7 protocol + 24 provider + 9 server, Node 20
incl. the TS oracle, Python 28.

## Follow-ups filed

#51 nulls on `temperature`/`max_tokens`/`top_p` · #52 cache hints · #53 reasoning fields ·
#54 hosted tools · #55 per-protocol generated types · #56 the `developer` role · #57 failed
tool results

🤖 Generated with [Claude Code](https://claude.com/claude-code)
