### PR TITLE
Translate between Anthropic's Messages shapes and the gateway forms

### DIFF
--- a/crates/warpllm/src/gateway/anthropic/api/messages/exchange.rs
+++ b/crates/warpllm/src/gateway/anthropic/api/messages/exchange.rs
@@ -1,0 +1,51 @@
+//! The upstream half of a message exchange: gateway types in, gateway types
+//! out.
+
+use crate::error::Result;
+use crate::gateway::anthropic::error::error_from_body;
+use crate::gateway::types;
+use crate::protocol::anthropic::messages::transport::{self, Outcome};
+
+use super::{ingest_response, render_request};
+
+/// Renders the gateway request for this protocol, posts it, and ingests the
+/// reply — the one place this protocol's order is stated.
+///
+/// Gateway types on both ends, which is what lets every protocol implement this
+/// same shape so `client.rs` gains one match arm per protocol and nothing else.
+/// The argument LIST is not part of that invariant: `max_output_tokens` is here
+/// because Anthropic requires a `max_tokens` and the gateway form's is optional,
+/// so a ceiling has to reach the renderer from the roster when the caller named
+/// none.
+///
+/// Stateless, taking the transport context loose rather than borrowing a
+/// client: nothing here needs to outlive the call.
+///
+/// Error mapping happens here rather than in the transport because which
+/// [`crate::Error`] a status becomes is a protocol-and-provider decision, while
+/// reading the socket is not.
+pub(crate) async fn exchange(
+    request: &types::ChatRequest,
+    http: &reqwest::Client,
+    provider: &'static str,
+    base_url: &str,
+    api_key: &str,
+    max_output_tokens: Option<u32>,
+) -> Result<types::ChatResponse> {
+    let wire = render_request(request, provider, max_output_tokens)?;
+    match transport::post(http, provider, base_url, api_key, &wire).await? {
+        Outcome::Ok(response) => Ok(ingest_response(response)),
+        Outcome::Status {
+            status,
+            body,
+            retry_after,
+            request_id,
+        } => Err(error_from_body(
+            provider,
+            status,
+            &body,
+            retry_after,
+            request_id,
+        )),
+    }
+}

--- a/crates/warpllm/src/gateway/anthropic/api/messages/mod.rs
+++ b/crates/warpllm/src/gateway/anthropic/api/messages/mod.rs
@@ -1,0 +1,26 @@
+//! `Api::AnthropicMessages` ↔ the gateway forms.
+//!
+//! Split the way its openai_compat sibling is: [`request`] and [`response`] are
+//! the conversions, [`exchange`] is the one place this protocol's order —
+//! render, post, ingest — is stated.
+//!
+//! The streaming half — the named-event mapping and the chunk stream carrying
+//! it — lands separately. It is the harder piece and earns its own review
+//! rather than being buried in this one.
+
+mod exchange;
+mod request;
+mod response;
+
+// Nothing calls these yet. warpllm is CALLED in another protocol and only
+// SPEAKS this one, so `ingest_request` and `render_response` wait on an
+// Anthropic-shaped ingress, and `exchange` waits on the client dispatch. The
+// barrel names the surface's whole vocabulary regardless — a re-export list
+// tracking today's callers would churn on every wiring change, and the two
+// unused halves are what the round-trip tests are written against.
+#[allow(unused_imports)]
+pub(crate) use self::{
+    exchange::exchange,
+    request::{ingest_request, render_request},
+    response::{ingest_response, render_response},
+};

--- a/crates/warpllm/src/gateway/anthropic/api/messages/request.rs
+++ b/crates/warpllm/src/gateway/anthropic/api/messages/request.rs
@@ -1,0 +1,1871 @@
+//! Request conversions: Anthropic's wire request → gateway (ingest) and
+//! gateway → wire (render).
+//!
+//! # Promote but retain
+//!
+//! Every typed field lifted into the gateway form is ALSO kept in
+//! `ext["anthropic"]` exactly as it arrived, and [`render_request`] prefers the
+//! retained value over re-rendering. The reason is the same as its
+//! openai_compat counterpart's and bites harder here, because the gateway
+//! blocks have no `ext` of their own: a block's `cache_control` type, a
+//! source's unknown fields, the difference between `"hi"` and
+//! `[{"type":"text",…}]` — none has anywhere to go except the retained
+//! `content` of the message that held it.
+//!
+//! So a request that arrives on this protocol and leaves on it is byte-exact,
+//! and one that arrives on ANOTHER protocol has no residue and is rendered from
+//! the gateway form. The second path is the one that matters today: warpllm is
+//! called in OpenAI's protocol and speaks this one to the provider.
+//!
+//! # What this protocol arranges differently, and where each is handled
+//!
+//! | | chat completions | Anthropic | handled by |
+//! |---|---|---|---|
+//! | system prompt | a message with `role: "system"` | a top-level `system` | [`render_messages`] hoists it |
+//! | tool result | one message per result | `tool_result` blocks in a user turn | [`render_messages`] merges a run |
+//! | tool arguments | a string of JSON | a decoded object | [`render_block`], which can fail |
+//! | reasoning depth | `reasoning_effort` | `output_config.effort` | [`render_output_config`] |
+//! | structured output | `response_format` | `output_config.format` | [`render_output_format`] |
+//! | `max_tokens` | optional | REQUIRED | [`resolve_max_tokens`] |
+
+use serde_json::Value;
+
+use crate::error::{Error, Result};
+use crate::gateway::anthropic::{
+    cache_control, merged_ext, namespaced, role_from_wire, role_to_wire,
+};
+use crate::gateway::types::{self, ContentBlock, IngestSource, MediaSource, RawJson, Role};
+use crate::protocol::UnknownFields;
+use crate::protocol::anthropic::messages::types::{
+    Base64Source, ContentBlock as WireBlock, CreateMessageRequest, CustomTool, DocumentBlock,
+    ImageBlock, InputMessage, MessageContent, OutputConfig, OutputFormat, Source, SystemPrompt,
+    TextBlock, ThinkingAdaptive, ThinkingConfig, ThinkingDisabled, ThinkingEnabled, Tool,
+    ToolChoice, ToolChoiceMode, ToolChoiceTool, ToolResultBlock, ToolResultContent, ToolUseBlock,
+    UrlSource,
+};
+use crate::types::Protocol;
+
+// `render_source` and `render_result_content` are deliberately NOT imported.
+// The reply has its own infallible pair and this module has a fallible one; the
+// two are not interchangeable, and borrowing the reply's is what let a foreign
+// file id and a nested unknown block past this module's refusals. See
+// [`render_block`].
+use super::response::{control_of, ingest_block, object, plain, render_reasoning, take_typed};
+
+/// Permissive and infallible: capture, don't validate. `model` is the
+/// prefix-stripped name.
+///
+/// The destructuring is exhaustive (no `..`) so that adding a typed field to
+/// the wire request without mapping it here is a compile error. Everything
+/// without a typed wire field — `top_k`, `metadata`, `service_tier` — rides
+/// `ext["anthropic"]` verbatim.
+pub(crate) fn ingest_request(request: CreateMessageRequest, model: &str) -> types::ChatRequest {
+    // Wire structs are plain serde data; serialization cannot fail.
+    let body = plain(&request);
+    let CreateMessageRequest {
+        model: _,
+        messages,
+        max_tokens,
+        system,
+        temperature,
+        top_p,
+        stop_sequences,
+        stream,
+        tools,
+        tool_choice,
+        thinking,
+        output_config,
+        unknown_fields,
+    } = request;
+
+    let mut anthropic = unknown_fields;
+    retain(&mut anthropic, "system", system.as_ref());
+    retain(&mut anthropic, "stop_sequences", stop_sequences.as_ref());
+    retain(&mut anthropic, "tools", tools.as_ref());
+    retain(&mut anthropic, "tool_choice", tool_choice.as_ref());
+    retain(&mut anthropic, "thinking", thinking.as_ref());
+    retain(&mut anthropic, "output_config", output_config.as_ref());
+
+    let effort = output_config
+        .as_ref()
+        .and_then(|config| config.effort.as_deref());
+    types::ChatRequest {
+        model: model.to_string(),
+        // The system prompt becomes a LEADING message, which is the gateway's
+        // arrangement — `ChatRequest::messages` documents system messages as
+        // included and hoisted per target. Rendering hoists it back out.
+        messages: system
+            .iter()
+            .map(ingest_system)
+            .chain(messages.into_iter().map(ingest_message))
+            .collect(),
+        tools: tools
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(ingest_tool)
+            .collect(),
+        tool_choice: tool_choice.as_ref().and_then(ingest_tool_choice),
+        params: types::GenerationParams {
+            max_tokens: Some(max_tokens),
+            temperature,
+            top_p,
+            stop: stop_sequences.unwrap_or_default(),
+        },
+        response_format: output_config
+            .as_ref()
+            .and_then(|config| config.format.as_ref())
+            .and_then(ingest_output_format),
+        reasoning: ingest_reasoning(thinking.as_ref(), effort),
+        // Anthropic's cache breakpoints are POSITIONAL — each sits on the block
+        // it marks — so there is no request-level hint to lift. The hints ride
+        // the blocks, where `ingest_block` puts them.
+        cache: None,
+        stream: stream.unwrap_or(false),
+        // No counterpart: Anthropic reports usage on every stream
+        // unconditionally, so there is no opt-in to record.
+        stream_include_usage: None,
+        ext: namespaced(anthropic),
+        source: Some(IngestSource {
+            protocol: Protocol::Anthropic,
+            body,
+        }),
+    }
+}
+
+/// Keeps a typed field's wire value under this protocol's namespace, so
+/// [`render_request`] can hand back exactly what arrived.
+fn retain<T: serde::Serialize>(fields: &mut UnknownFields, key: &str, value: Option<&T>) {
+    if let Some(value) = value {
+        fields.insert(key.to_string(), plain(value));
+    }
+}
+
+/// The top-level `system` as the gateway's leading system message. Which of the
+/// two wire forms it arrived in is retained at request level, so nothing is
+/// decided here that render cannot undo.
+fn ingest_system(prompt: &SystemPrompt) -> types::Message {
+    types::Message {
+        role: Role::System,
+        content: match prompt {
+            SystemPrompt::Text(text) => vec![ContentBlock::Text {
+                text: text.clone(),
+                cache: None,
+            }],
+            SystemPrompt::Blocks(blocks) => blocks.iter().map(ingest_block).collect(),
+        },
+        ext: types::ProviderExt::new(),
+    }
+}
+
+/// A wire turn as a gateway message.
+///
+/// The one judgement here is [`Role::Tool`]. Anthropic has no tool role — a
+/// result is a `tool_result` block inside a USER turn — so a turn carrying
+/// nothing but results is exactly what the gateway calls a tool message, and
+/// reading it as an ordinary user turn would leave a renderer for a protocol
+/// with a tool role unable to find one. A MIXED turn stays `User`: its results
+/// are blocks among others, and `Role::Tool`'s contract is results only.
+fn ingest_message(message: InputMessage) -> types::Message {
+    let InputMessage {
+        role,
+        content,
+        unknown_fields,
+    } = message;
+    let (role, raw_role) = role_from_wire(role);
+    let mut anthropic = unknown_fields;
+    if let Some(raw) = raw_role {
+        anthropic.insert("role".into(), Value::String(raw));
+    }
+    anthropic.insert("content".into(), plain(&content));
+
+    let blocks: Vec<ContentBlock> = match &content {
+        MessageContent::Text(text) => vec![ContentBlock::Text {
+            text: text.clone(),
+            cache: None,
+        }],
+        MessageContent::Blocks(blocks) => blocks.iter().map(ingest_block).collect(),
+    };
+    let only_results = !blocks.is_empty()
+        && blocks
+            .iter()
+            .all(|block| matches!(block, ContentBlock::ToolResult { .. }));
+    types::Message {
+        role: if role == Role::User && only_results {
+            Role::Tool
+        } else {
+            role
+        },
+        content: blocks,
+        ext: namespaced(anthropic),
+    }
+}
+
+fn ingest_tool(tool: &Tool) -> types::ToolDef {
+    match tool {
+        Tool::Custom(custom) => types::ToolDef {
+            name: custom.name.clone(),
+            description: custom.description.clone(),
+            // Verbatim: Anthropic spells this `input_schema` where chat
+            // completions spells it `parameters`, and the name is the only
+            // difference.
+            input_schema: custom.input_schema.clone(),
+            strict: custom.strict,
+            cache: custom
+                .cache_control
+                .as_ref()
+                .and_then(Option::as_ref)
+                .map(crate::gateway::anthropic::cache_hint),
+            ext: namespaced(custom.unknown_fields.clone()),
+        },
+        // A server tool: no arguments schema exists to translate, so it keeps
+        // its name and carries the whole wire object in ext. That is what lets
+        // a renderer for another protocol refuse it BY NAME rather than send
+        // something invented. #54 owns a neutral representation.
+        Tool::Other(value) => types::ToolDef {
+            name: value["name"]
+                .as_str()
+                .or_else(|| value["type"].as_str())
+                .unwrap_or_default()
+                .to_string(),
+            description: None,
+            input_schema: Value::Null,
+            strict: None,
+            cache: None,
+            ext: namespaced(object(value.clone())),
+        },
+    }
+}
+
+fn ingest_tool_choice(choice: &ToolChoice) -> Option<types::ToolChoice> {
+    match choice {
+        ToolChoice::Auto(_) => Some(types::ToolChoice::Auto),
+        ToolChoice::None(_) => Some(types::ToolChoice::None),
+        // "any tool" is Anthropic's spelling of "required".
+        ToolChoice::Any(_) => Some(types::ToolChoice::Required),
+        ToolChoice::Tool(tool) => Some(types::ToolChoice::Tool {
+            name: tool.name.clone(),
+        }),
+        // A shape this gateway has no word for. It still reaches an Anthropic
+        // target through the retained residue; there is just nothing to tell
+        // another protocol.
+        ToolChoice::Unknown(_) => None,
+    }
+}
+
+fn ingest_output_format(format: &OutputFormat) -> Option<types::ResponseFormat> {
+    // `name` and `strict` are chat-completions labels with no Anthropic
+    // counterpart; a schema is the whole of what this protocol says.
+    (format.r#type == "json_schema").then(|| types::ResponseFormat::JsonSchema {
+        name: String::new(),
+        schema: format.schema.clone().unwrap_or(Value::Null),
+        strict: None,
+    })
+}
+
+/// `thinking` and `output_config.effort` are ONE gateway concept split across
+/// two Anthropic parameters, which is why this reads both.
+fn ingest_reasoning(
+    thinking: Option<&ThinkingConfig>,
+    effort: Option<&str>,
+) -> Option<types::ReasoningConfig> {
+    let mut config = types::ReasoningConfig {
+        effort: effort.map(str::to_string),
+        ..Default::default()
+    };
+    match thinking {
+        Some(ThinkingConfig::Enabled(enabled)) => {
+            config.enabled = Some(true);
+            config.budget_tokens = Some(enabled.budget_tokens);
+            config.exclude = exclusion(enabled.display.as_deref());
+        }
+        Some(ThinkingConfig::Adaptive(adaptive)) => {
+            config.enabled = Some(true);
+            config.exclude = exclusion(adaptive.display.as_deref());
+        }
+        Some(ThinkingConfig::Disabled(_)) => config.enabled = Some(false),
+        // A thinking mode warpllm does not model reaches Anthropic through the
+        // retained residue; there is nothing to promote.
+        Some(ThinkingConfig::Unknown(_)) | None => {}
+    }
+    (config.enabled.is_some() || config.effort.is_some()).then_some(config)
+}
+
+/// `display` as the gateway's "reason but don't return it".
+///
+/// Anthropic's field says what the CALLER sees, not whether the model thinks:
+/// `"omitted"` still bills the thinking and still requires the blocks back
+/// unchanged next turn. That is exactly `ReasoningConfig::exclude`.
+fn exclusion(display: Option<&str>) -> Option<bool> {
+    match display {
+        Some("omitted") => Some(true),
+        Some("summarized") => Some(false),
+        _ => None,
+    }
+}
+
+/// Renders the gateway request onto this protocol's wire.
+///
+/// Takes a third argument its openai_compat counterpart does not, and this is
+/// the reason: `max_tokens` is REQUIRED here and optional in the gateway form,
+/// so a ceiling has to come from somewhere — see [`resolve_max_tokens`]. The
+/// invariant every protocol shares is gateway types on both ends, not an
+/// identical argument list.
+///
+/// Mechanical otherwise: nothing is filtered against what the target documents.
+/// The provider is the authority on its own parameters and rejects what it does
+/// not accept — including the two thinking arms, which are mutually exclusive
+/// PER MODEL rather than per protocol. Guessing which one the routed model
+/// takes would mean either inventing a token budget for a model that wants none
+/// or discarding one the caller wrote; Anthropic's own 400 says which, by name.
+///
+/// `stream` is emitted only when true, matching the transport's contract: it
+/// CHECKS the flag rather than setting it, so a streamed exchange must render
+/// `Some(true)` and a whole-reply exchange must not.
+pub(crate) fn render_request(
+    request: &types::ChatRequest,
+    provider: &'static str,
+    max_output_tokens: Option<u32>,
+) -> Result<CreateMessageRequest> {
+    ensure_renderable(request)?;
+    let mut unknown_fields = merged_ext(&request.ext, provider);
+    let params = &request.params;
+    let (system, messages) = render_messages(&request.messages, provider)?;
+    // Hoisted rather than inlined below: rendering a tool can fail, and `?` has
+    // nowhere to go inside an `or_else` closure returning `Option`.
+    let tools = match take_typed(&mut unknown_fields, "tools") {
+        Some(tools) => Some(tools),
+        None if request.tools.is_empty() => None,
+        None => Some(
+            request
+                .tools
+                .iter()
+                .map(render_tool)
+                .collect::<Result<Vec<_>>>()?,
+        ),
+    };
+    Ok(CreateMessageRequest {
+        model: request.model.clone(),
+        max_tokens: resolve_max_tokens(request, max_output_tokens)?,
+        messages,
+        // Each of these prefers what arrived over what the gateway form can
+        // reconstruct; see this module's docs.
+        system: take_typed(&mut unknown_fields, "system").or(system),
+        temperature: params.temperature,
+        top_p: params.top_p,
+        stop_sequences: take_typed(&mut unknown_fields, "stop_sequences")
+            .or_else(|| (!params.stop.is_empty()).then(|| params.stop.clone())),
+        stream: request.stream.then_some(true),
+        tools,
+        tool_choice: take_typed(&mut unknown_fields, "tool_choice")
+            .or_else(|| request.tool_choice.as_ref().map(render_tool_choice)),
+        thinking: take_typed(&mut unknown_fields, "thinking")
+            .or_else(|| request.reasoning.as_ref().and_then(render_thinking)),
+        output_config: render_output_config(request, &mut unknown_fields)?,
+        unknown_fields,
+    })
+}
+
+/// The ceiling Anthropic requires, from the caller or from the roster.
+///
+/// Never an invented default. A number picked here would silently truncate
+/// replies at a length nobody asked for, and the failure would look like the
+/// model stopping early rather than like a missing parameter — so an
+/// unresolvable ceiling names the model and refuses.
+fn resolve_max_tokens(request: &types::ChatRequest, max_output_tokens: Option<u32>) -> Result<u32> {
+    request
+        .params
+        .max_tokens
+        .or(max_output_tokens)
+        .ok_or_else(|| {
+            Error::InvalidInput(format!(
+                "'{}' needs a max_tokens: Anthropic requires one and the roster \
+                 documents no output ceiling for this model",
+                request.model
+            ))
+        })
+}
+
+/// What the gateway form can hold and this protocol cannot say.
+///
+/// Short, because Anthropic says most of it: tools, tool choices, structured
+/// output, cache breakpoints and a FAILED tool result all render. That last one
+/// is the mirror image of the openai_compat gate, which refuses `is_error`
+/// because chat completions has no bit for it.
+///
+/// Rendering any of these as silence would CHANGE the request rather than
+/// translate it, which is the one thing a renderer must not do.
+///
+/// Per-value refusals are not here — a tool with no schema, an unparseable
+/// argument string, a JSON mode with no schema — because each is decided where
+/// the value is converted and would have to be found twice to be checked here.
+fn ensure_renderable(request: &types::ChatRequest) -> Result<()> {
+    // No audio block exists on this protocol, in any shape. Dropping one would
+    // send a request that reads as if the caller never attached the audio, and
+    // the model would answer confidently about nothing.
+    if blocks(request).any(|block| matches!(block, ContentBlock::Audio { .. })) {
+        return Err(Error::NotImplemented(
+            "an audio block on the anthropic renderer",
+        ));
+    }
+    // Anthropic's breakpoints are positional and BLOCK-level, which the gateway
+    // models directly; a request-level hint means "put one on the last
+    // cacheable block", and choosing that block is a policy nothing has asked
+    // for yet. Block-level hints render normally.
+    if request.cache.is_some() {
+        return Err(Error::NotImplemented(
+            "a request-level cache hint on the anthropic renderer",
+        ));
+    }
+    // Anthropic's base64 source REQUIRES a media type — `application/pdf`,
+    // `image/png` — and the gateway form can arrive without one: chat
+    // completions' `file` part carries raw bytes and a filename and declares no
+    // MIME type at all, so its ingest fills an empty string rather than a
+    // guess. `openai_compat`'s own comment says a target that requires one "has
+    // to say so"; this is it saying so. Sending the empty string builds a
+    // request Anthropic is certain to reject, and the caller would read that
+    // 400 as being about their document rather than about the conversion.
+    if blocks(request).any(|block| matches!(source_of(block), Some(MediaSource::Base64 { media_type, .. }) if media_type.is_empty()))
+    {
+        return Err(Error::NotImplemented(
+            "inline bytes with no media type on the anthropic renderer",
+        ));
+    }
+    if let Some(reasoning) = &request.reasoning {
+        // `display` is the only way to say "reason but do not return it", and
+        // it is invalid without a mode to attach to — Anthropic rejects it on
+        // `disabled`, and nothing is emitted at all when neither a budget nor
+        // `enabled` was asked for.
+        if reasoning.exclude.is_some()
+            && !matches!(
+                thinking_arm(reasoning),
+                Some(Arm::Enabled(_) | Arm::Adaptive)
+            )
+        {
+            return Err(Error::NotImplemented(
+                "a reasoning exclusion with no thinking mode on the anthropic renderer",
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Where a block's bytes come from, for the blocks that have bytes.
+fn source_of(block: &ContentBlock) -> Option<&MediaSource> {
+    match block {
+        ContentBlock::Image { source, .. }
+        | ContentBlock::Document { source, .. }
+        | ContentBlock::Audio { source, .. } => Some(source),
+        _ => None,
+    }
+}
+
+/// Every block in a request, tool-result payloads included — a nested block is
+/// as unrenderable as a top-level one.
+fn blocks(request: &types::ChatRequest) -> impl Iterator<Item = &ContentBlock> {
+    request
+        .messages
+        .iter()
+        .flat_map(|message| &message.content)
+        .flat_map(|block| {
+            let nested = match block {
+                ContentBlock::ToolResult { content, .. } => content.as_slice(),
+                _ => &[],
+            };
+            std::iter::once(block).chain(nested)
+        })
+}
+
+/// Splits the gateway's one message list into this protocol's two: the
+/// top-level `system` parameter and the turns.
+///
+/// A system message AFTER the conversation has started is refused rather than
+/// moved. Anthropic has one system slot and it is read before everything else,
+/// so hoisting a later instruction to the front would silently reorder the
+/// conversation — the model would see mid-conversation guidance as if it had
+/// been there from the start — and rendering it as a user turn would fabricate
+/// a turn the caller never sent. Neither is a translation.
+fn render_messages(
+    messages: &[types::Message],
+    provider: &str,
+) -> Result<(Option<SystemPrompt>, Vec<InputMessage>)> {
+    let leading = messages
+        .iter()
+        .take_while(|message| message.role == Role::System)
+        .count();
+    if messages[leading..]
+        .iter()
+        .any(|message| message.role == Role::System)
+    {
+        return Err(Error::NotImplemented(
+            "a system message after the conversation has started on the anthropic renderer",
+        ));
+    }
+
+    let mut turns = Vec::with_capacity(messages.len() - leading);
+    let mut rest = &messages[leading..];
+    while let Some(first) = rest.first() {
+        // Consecutive tool results become ONE user turn holding all of them —
+        // the merge that `Role::Tool`'s own doc describes. Rendering them as
+        // separate turns would leave a protocol that sends one result per
+        // message unable to answer more than one call, and rendering only the
+        // first would leave every other call the model made looking unanswered.
+        //
+        // ...but only for messages that do NOT already describe a turn of their
+        // own. A tool message ingested from THIS protocol was a whole wire turn
+        // and retained it; merging two of those would rewrite boundaries the
+        // caller drew and drop the residue of every turn after the first. What
+        // arrived as two turns goes back as two turns, and whether Anthropic
+        // likes that arrangement is Anthropic's to say — warpllm's job is not
+        // to quietly redraw it.
+        //
+        // The retained content IS the provenance test, and exactly the right
+        // one: `merged_ext` reads only this protocol's namespace, so a tool
+        // message from chat completions has no `content` here however much
+        // residue it carries under its own name.
+        let run = match first.role {
+            Role::Tool if !describes_a_whole_turn(first, provider) => rest
+                .iter()
+                .take_while(|message| {
+                    message.role == Role::Tool && !describes_a_whole_turn(message, provider)
+                })
+                .count(),
+            _ => 1,
+        };
+        turns.push(render_turn(&rest[..run], provider)?);
+        rest = &rest[run..];
+    }
+    Ok((render_system(&messages[..leading])?, turns))
+}
+
+/// Whether this message already carries the wire turn it came from, which is
+/// what makes it ineligible to be merged into a neighbour's.
+fn describes_a_whole_turn(message: &types::Message, provider: &str) -> bool {
+    merged_ext(&message.ext, provider).contains_key("content")
+}
+
+/// The leading system messages as the top-level parameter. A single plain text
+/// block renders as the bare string form, which is what a system prompt almost
+/// always is; anything else renders as blocks.
+fn render_system(messages: &[types::Message]) -> Result<Option<SystemPrompt>> {
+    let blocks: Vec<&ContentBlock> = messages
+        .iter()
+        .flat_map(|message| &message.content)
+        .collect();
+    Ok(match blocks.as_slice() {
+        [] => None,
+        [ContentBlock::Text { text, cache: None }] => Some(SystemPrompt::Text(text.clone())),
+        _ => {
+            let mut rendered = Vec::with_capacity(blocks.len());
+            for block in blocks {
+                rendered.extend(render_block(block)?);
+            }
+            Some(SystemPrompt::Blocks(rendered))
+        }
+    })
+}
+
+/// One or more gateway messages as the single wire turn they make.
+///
+/// A run of length one replays its retained wire content when it has one. A
+/// longer run is a merge, and [`render_messages`] only ever builds one out of
+/// messages that carry NO retained content — so nothing is being overridden
+/// here, and the first message's other residue rides the merged turn rather
+/// than being copied onto turns that no longer exist.
+///
+/// That split is load-bearing rather than incidental: without it, two native
+/// tool-result turns would merge into one and every turn after the first would
+/// lose its residue, while still passing any test that only checked a single
+/// turn.
+fn render_turn(run: &[types::Message], provider: &str) -> Result<InputMessage> {
+    let mut unknown_fields = merged_ext(&run[0].ext, provider);
+    let role = match unknown_fields.remove("role") {
+        Some(Value::String(raw)) => raw,
+        _ => role_to_wire(run[0].role).to_string(),
+    };
+    let retained = take_typed(&mut unknown_fields, "content");
+    if let ([_], Some(content)) = (run, retained) {
+        return Ok(InputMessage {
+            role,
+            content,
+            unknown_fields,
+        });
+    }
+    let mut blocks = Vec::new();
+    for message in run {
+        for block in &message.content {
+            blocks.extend(render_block(block)?);
+        }
+    }
+    Ok(InputMessage {
+        role,
+        content: render_content(blocks),
+        unknown_fields,
+    })
+}
+
+/// A lone plain text block renders as the bare string form; anything else
+/// renders as blocks. The two must stay distinguishable — collapsing the string
+/// into a one-element list is lossless in meaning and still fails a
+/// byte-for-byte round trip.
+fn render_content(blocks: Vec<WireBlock>) -> MessageContent {
+    match blocks.as_slice() {
+        [WireBlock::Text(text)]
+            if text.cache_control.is_none() && text.unknown_fields.is_empty() =>
+        {
+            MessageContent::Text(text.text.clone())
+        }
+        _ => MessageContent::Blocks(blocks),
+    }
+}
+
+/// A gateway block as this protocol's, where one exists.
+///
+/// `None` means the block has no shape here and is dropped: reasoning another
+/// provider produced, which Anthropic could not verify. Audio is the other
+/// unrenderable block and never reaches this function — [`ensure_renderable`]
+/// refuses the whole request first, because dropping content the caller
+/// attached is not the same kind of loss as dropping a signature that would
+/// have been rejected anyway.
+fn render_block(block: &ContentBlock) -> Result<Option<WireBlock>> {
+    Ok(match block {
+        ContentBlock::Text { text, cache } => Some(WireBlock::Text(TextBlock {
+            text: text.clone(),
+            cache_control: control_of(cache),
+            unknown_fields: UnknownFields::new(),
+        })),
+        ContentBlock::Image { source, cache, .. } => Some(WireBlock::Image(ImageBlock {
+            source: render_source(source)?,
+            // `detail` is a resolution hint chat completions has and Anthropic
+            // does not. Dropping it changes nothing the model is shown — the
+            // image is sent either way — which is why it is not a refusal.
+            cache_control: control_of(cache),
+            unknown_fields: UnknownFields::new(),
+        })),
+        ContentBlock::Document {
+            source,
+            title,
+            cache,
+        } => Some(WireBlock::Document(DocumentBlock {
+            source: render_source(source)?,
+            title: title.clone().map(Some),
+            cache_control: control_of(cache),
+            unknown_fields: UnknownFields::new(),
+        })),
+        ContentBlock::ToolCall {
+            id,
+            name,
+            arguments,
+        } => Some(WireBlock::ToolUse(ToolUseBlock {
+            id: id.clone(),
+            name: name.clone(),
+            // THE lossy seam in the tool path, and the one place it can fail.
+            // Chat completions carries arguments as text that models do not
+            // always make valid JSON; this field is an object and cannot hold
+            // text that is not. There is nothing honest to send, so it names
+            // the call and the text.
+            //
+            // Parsing is not enough: `null`, `"a"`, `7` and `[1]` are all valid
+            // JSON and none is an OBJECT, which is what `input` is documented to
+            // be and what Anthropic requires. Accepting them would move the
+            // failure to a 400 that names neither the call nor the text.
+            input: render_tool_input(arguments, id, name)?,
+            cache_control: None,
+            unknown_fields: UnknownFields::new(),
+        })),
+        ContentBlock::ToolResult {
+            call_id,
+            content,
+            is_error,
+        } => Some(WireBlock::ToolResult(ToolResultBlock {
+            tool_use_id: call_id.clone(),
+            content: Some(render_result_content(content)?),
+            // The bit chat completions has no way to say. `false` carries no
+            // information and stays absent; only a result that FAILED emits it.
+            is_error: is_error.then_some(true),
+            cache_control: None,
+            unknown_fields: UnknownFields::new(),
+        })),
+        ContentBlock::Reasoning {
+            detail, provenance, ..
+        } => render_reasoning(detail, provenance.as_deref()),
+        // A block this gateway has no shape for, which is NOT the same as one
+        // Anthropic would accept. Every producer of it is another protocol
+        // saying something this one cannot: chat completions turns a `refusal`
+        // part, a `file` part carrying neither reference nor bytes, a custom
+        // tool call, and any part type it does not know into exactly this. Sent
+        // verbatim they become `{"type": "refusal"}` and `{"type": "custom"}`
+        // blocks that Anthropic rejects — the catch-all rendering as speech.
+        //
+        // A block Anthropic itself sent does not come through here: ingest
+        // retains the whole wire `content` array per message and `render_turn`
+        // replays it, so a same-protocol round trip never reaches this arm.
+        // That is what makes refusing free rather than a losslessness break.
+        ContentBlock::Unknown(value) => {
+            return Err(Error::InvalidInput(format!(
+                "a '{}' content block has no Anthropic form: it came from \
+                 another protocol and Anthropic would reject it",
+                block_type_of(value)
+            )));
+        }
+        // Refused by `ensure_renderable` before anything gets here.
+        ContentBlock::Audio { .. } => None,
+    })
+}
+
+/// A tool result's payload, for a REQUEST.
+///
+/// Mirrors the reply's renderer including its bare-string special case, and
+/// differs in the one way that matters: it goes through THIS module's fallible
+/// [`render_block`]. Blocks nested in a tool result are no more this protocol's
+/// than the blocks around them, so every refusal that holds at the top level
+/// has to hold one level down — otherwise an OpenAI `refusal` part rejected as
+/// a message block sails through as a `tool_result` block, and a tool call
+/// whose arguments will not parse becomes `null` instead of an error.
+fn render_result_content(blocks: &[ContentBlock]) -> Result<ToolResultContent> {
+    if let [ContentBlock::Text { text, cache: None }] = blocks {
+        return Ok(ToolResultContent::Text(text.clone()));
+    }
+    let mut rendered = Vec::new();
+    for block in blocks {
+        rendered.extend(render_block(block)?);
+    }
+    Ok(ToolResultContent::Blocks(rendered))
+}
+
+/// A gateway media source as this protocol's, for a REQUEST.
+///
+/// Separate from the reply's for the same reason, and it refuses the one source
+/// that cannot cross a protocol boundary: a provider file id is a handle issued
+/// by ONE provider's files API and means nothing to another, while
+/// [`MediaSource`] carries no provenance to tell an Anthropic id from an OpenAI
+/// one. Forwarding it produced a request that could only ever 404.
+///
+/// An Anthropic file the caller referenced itself never arrives here — a
+/// same-protocol turn replays its retained content — so this refuses exactly
+/// the foreign case, the same way the `Unknown` block arm does.
+fn render_source(source: &MediaSource) -> Result<Source> {
+    match source {
+        MediaSource::ProviderFile { id } => Err(Error::InvalidInput(format!(
+            "file reference '{id}' was issued by another provider's files API, \
+             which Anthropic cannot resolve"
+        ))),
+        MediaSource::Base64 { media_type, data } => Ok(Source::Base64(Base64Source {
+            media_type: media_type.clone(),
+            data: data.clone(),
+            unknown_fields: UnknownFields::new(),
+        })),
+        MediaSource::Url { url } => Ok(Source::Url(UrlSource {
+            url: url.clone(),
+            unknown_fields: UnknownFields::new(),
+        })),
+    }
+}
+
+/// A tool call's arguments as Anthropic's `input`.
+///
+/// Separate from [`render_block`] because it has two distinct refusals and both
+/// name the call: text that is not JSON at all, and JSON that is not an object.
+fn render_tool_input(arguments: &RawJson, id: &str, name: &str) -> Result<Value> {
+    let refuse = |what: &str| {
+        Error::InvalidInput(format!(
+            "tool call '{id}' to '{name}' has arguments that are {what}, \
+             which Anthropic requires: {}",
+            arguments.as_str()
+        ))
+    };
+    let input = arguments.parse().map_err(|_| refuse("not JSON"))?;
+    if !input.is_object() {
+        return Err(refuse("valid JSON but not an object"));
+    }
+    Ok(input)
+}
+
+/// The `type` of an unknown block, for a refusal that names it. Falls back to
+/// the whole value when there is no string `type` to quote — a block with none
+/// is exactly as unrenderable, and saying so beats saying nothing.
+fn block_type_of(value: &Value) -> String {
+    match value.get("type") {
+        Some(Value::String(tag)) => tag.clone(),
+        _ => value.to_string(),
+    }
+}
+
+fn render_tool(tool: &types::ToolDef) -> Result<Tool> {
+    // A tool with no arguments schema is a hosted or server one, and this
+    // protocol has no shape for one it did not itself ingest. Refusing names
+    // it; sending a custom tool with an empty schema would have the model call
+    // something that does not exist.
+    if tool.input_schema.is_null() {
+        return Err(Error::NotImplemented(
+            "a tool with no arguments schema on the anthropic renderer",
+        ));
+    }
+    Ok(Tool::Custom(CustomTool {
+        name: tool.name.clone(),
+        description: tool.description.clone(),
+        input_schema: tool.input_schema.clone(),
+        strict: tool.strict,
+        cache_control: tool.cache.as_ref().map(|hint| Some(cache_control(hint))),
+        unknown_fields: UnknownFields::new(),
+    }))
+}
+
+fn render_tool_choice(choice: &types::ToolChoice) -> ToolChoice {
+    match choice {
+        types::ToolChoice::Auto => ToolChoice::Auto(ToolChoiceMode::default()),
+        types::ToolChoice::None => ToolChoice::None(ToolChoiceMode::default()),
+        types::ToolChoice::Required => ToolChoice::Any(ToolChoiceMode::default()),
+        types::ToolChoice::Tool { name } => ToolChoice::Tool(ToolChoiceTool {
+            name: name.clone(),
+            disable_parallel_tool_use: None,
+            unknown_fields: UnknownFields::new(),
+        }),
+    }
+}
+
+/// Which thinking arm a reasoning config asks for, before `display` is attached.
+///
+/// One function so that [`ensure_renderable`] and [`render_thinking`] cannot
+/// disagree about whether a block will be emitted.
+enum Arm {
+    Enabled(u32),
+    Adaptive,
+    Disabled,
+}
+
+fn thinking_arm(reasoning: &types::ReasoningConfig) -> Option<Arm> {
+    // An explicit off wins over a budget: a budget says how MUCH to think, and
+    // this says not to.
+    if reasoning.enabled == Some(false) {
+        return Some(Arm::Disabled);
+    }
+    match (reasoning.budget_tokens, reasoning.enabled) {
+        // A budget is unambiguous — `enabled` is the only arm that takes one.
+        (Some(budget), _) => Some(Arm::Enabled(budget)),
+        // ...and so is its absence: `adaptive` is the only arm that works
+        // without a budget, and inventing one would be a number nobody wrote.
+        (None, Some(true)) => Some(Arm::Adaptive),
+        (None, _) => None,
+    }
+}
+
+fn render_thinking(reasoning: &types::ReasoningConfig) -> Option<ThinkingConfig> {
+    let display = reasoning
+        .exclude
+        .map(|exclude| if exclude { "omitted" } else { "summarized" }.to_string());
+    Some(match thinking_arm(reasoning)? {
+        Arm::Enabled(budget_tokens) => ThinkingConfig::Enabled(ThinkingEnabled {
+            budget_tokens,
+            display,
+            unknown_fields: UnknownFields::new(),
+        }),
+        Arm::Adaptive => ThinkingConfig::Adaptive(ThinkingAdaptive {
+            display,
+            unknown_fields: UnknownFields::new(),
+        }),
+        // `display` is invalid here — there is nothing to display — and
+        // `ensure_renderable` has already refused a request that asked for one.
+        Arm::Disabled => ThinkingConfig::Disabled(ThinkingDisabled::default()),
+    })
+}
+
+/// The two unrelated controls Anthropic files under one key.
+///
+/// Emitted only when one of them has something to say, so a request that asked
+/// for neither does not grow an empty object.
+fn render_output_config(
+    request: &types::ChatRequest,
+    unknown_fields: &mut UnknownFields,
+) -> Result<Option<OutputConfig>> {
+    if let Some(retained) = take_typed(unknown_fields, "output_config") {
+        return Ok(Some(retained));
+    }
+    let config = OutputConfig {
+        format: request
+            .response_format
+            .as_ref()
+            .map(render_output_format)
+            .transpose()?
+            .flatten(),
+        // Passed through verbatim rather than checked against Anthropic's set.
+        // The two vocabularies overlap but are not equal — chat completions has
+        // `minimal`, Anthropic has `max` — and the provider is the authority on
+        // its own values, by name, where a table here would go stale silently.
+        effort: request
+            .reasoning
+            .as_ref()
+            .and_then(|reasoning| reasoning.effort.clone()),
+        unknown_fields: UnknownFields::new(),
+    };
+    Ok((config.format.is_some() || config.effort.is_some()).then_some(config))
+}
+
+/// The gateway's `response_format` as Anthropic's structured output.
+///
+/// Anthropic gained this after the plan for this work was written, which had it
+/// down as untranslatable. It is not: a schema is a schema. What does NOT cross
+/// is a schema-less JSON mode — Anthropic requires the schema — so that one is
+/// named and refused rather than sent as a request for free-form text, which is
+/// what dropping it would silently produce.
+fn render_output_format(format: &types::ResponseFormat) -> Result<Option<OutputFormat>> {
+    match format {
+        // Anthropic's default and the meaning of an absent `format`. Emitting
+        // nothing asks for exactly what this asks for.
+        types::ResponseFormat::Text => Ok(None),
+        types::ResponseFormat::JsonObject => Err(Error::NotImplemented(
+            "a schema-less json_object response format on the anthropic renderer",
+        )),
+        // `name` and `strict` are dropped: Anthropic's format object has
+        // neither, its structured output is strict by construction, and the
+        // name is a caller-side label with no effect on the reply.
+        types::ResponseFormat::JsonSchema { schema, .. } => Ok(Some(OutputFormat {
+            r#type: "json_schema".into(),
+            schema: Some(schema.clone()),
+            unknown_fields: UnknownFields::new(),
+        })),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::gateway::openai_compat::api::chat_completions::{
+        ingest_request as ingest_openai, render_response as render_openai,
+    };
+    use crate::gateway::types::{MediaSource, RawJson, ReasoningDetail};
+
+    fn wire(body: Value) -> CreateMessageRequest {
+        serde_json::from_value(body).unwrap()
+    }
+
+    fn rendered(request: &types::ChatRequest) -> Value {
+        plain(&render_request(request, "anthropic", None).unwrap())
+    }
+
+    /// Every documented parameter, both `system` forms' worth of shapes, tools
+    /// of both kinds, and unknown fields at three nesting levels.
+    fn maximal_body() -> Value {
+        json!({
+            "model": "claude-opus-5",
+            "max_tokens": 1024,
+            "system": [{
+                "type": "text",
+                "text": "Be brief.",
+                "cache_control": {"type": "ephemeral", "ttl": "1h"}
+            }],
+            "temperature": 0.7,
+            "top_p": 0.95,
+            "top_k": 40,
+            "stop_sequences": ["END"],
+            "stream": true,
+            "metadata": {"user_id": "u1"},
+            "service_tier": "auto",
+            "tools": [
+                {
+                    "name": "counter",
+                    "description": "counts",
+                    "input_schema": {"type": "object", "properties": {"z": {"type": "number"}}},
+                    "cache_control": {"type": "ephemeral"},
+                    "vendor_hint": true
+                },
+                {"type": "web_search_20250305", "name": "web_search", "max_uses": 3}
+            ],
+            "tool_choice": {"type": "any", "disable_parallel_tool_use": true},
+            "thinking": {"type": "adaptive", "display": "summarized"},
+            "output_config": {
+                "effort": "xhigh",
+                "format": {"type": "json_schema", "schema": {"type": "object"}}
+            },
+            "messages": [
+                {"role": "user", "content": "count them"},
+                {"role": "assistant", "content": [
+                    {"type": "thinking", "thinking": "counting", "signature": "sig"},
+                    {"type": "tool_use", "id": "toolu_01", "name": "counter", "input": {"z": 1}}
+                ]},
+                {"role": "user", "content": [
+                    {"type": "tool_result", "tool_use_id": "toolu_01", "content": "3"}
+                ]},
+                {"role": "user", "content": [
+                    {"type": "image", "source": {"type": "url", "url": "https://e.com/a.png"}},
+                    {"type": "text", "text": "and this?"}
+                ], "vendor_tag": "vt"}
+            ]
+        })
+    }
+
+    /// An Anthropic request must survive normalization and come back out with
+    /// zero data loss — including the block-level residue the gateway blocks
+    /// have no field for, which only the retained `content` preserves.
+    #[test]
+    fn an_anthropic_request_round_trips_byte_for_byte() {
+        let body = maximal_body();
+        let normalized = ingest_request(wire(body.clone()), "claude-opus-5");
+        assert_eq!(rendered(&normalized), body);
+    }
+
+    /// The gateway view, so a change to the mapping fails on the mapping rather
+    /// than only inside a round trip that both halves could change together.
+    #[test]
+    fn the_gateway_view_of_a_maximal_request() {
+        let request = ingest_request(wire(maximal_body()), "claude-opus-5");
+        assert_eq!(request.model, "claude-opus-5");
+        assert_eq!(request.params.max_tokens, Some(1024));
+        assert_eq!(request.params.stop, vec!["END".to_string()]);
+        assert!(request.stream);
+
+        // The system prompt becomes a LEADING message, and the tool-result turn
+        // becomes the gateway's tool role.
+        let roles: Vec<_> = request.messages.iter().map(|m| m.role).collect();
+        assert_eq!(
+            roles,
+            vec![
+                Role::System,
+                Role::User,
+                Role::Assistant,
+                Role::Tool,
+                Role::User
+            ]
+        );
+
+        // A server tool keeps its name and carries a null schema, which is what
+        // lets another protocol's renderer refuse it BY NAME.
+        assert_eq!(request.tools.len(), 2);
+        assert_eq!(request.tools[0].name, "counter");
+        assert_eq!(request.tools[1].name, "web_search");
+        assert!(request.tools[1].input_schema.is_null());
+        assert!(matches!(
+            request.tool_choice,
+            Some(types::ToolChoice::Required)
+        ));
+
+        // `thinking` and `output_config.effort` are one gateway concept.
+        let reasoning = request.reasoning.as_ref().unwrap();
+        assert_eq!(reasoning.enabled, Some(true));
+        assert_eq!(reasoning.budget_tokens, None, "adaptive carries no budget");
+        assert_eq!(reasoning.effort.as_deref(), Some("xhigh"));
+        assert_eq!(reasoning.exclude, Some(false), "summarized means returned");
+        assert!(matches!(
+            request.response_format,
+            Some(types::ResponseFormat::JsonSchema { .. })
+        ));
+    }
+
+    // -----------------------------------------------------------------------
+    // The cross-protocol path: an OpenAI-shaped conversation reaching Claude.
+    // -----------------------------------------------------------------------
+
+    fn openai_tool_conversation() -> types::ChatRequest {
+        ingest_openai(
+            serde_json::from_value(json!({
+                "model": "anthropic/claude-opus-5",
+                "max_tokens": 512,
+                "messages": [
+                    {"role": "system", "content": "Be brief."},
+                    {"role": "user", "content": "weather in SF and NYC?"},
+                    {"role": "assistant", "content": null, "tool_calls": [
+                        {"id": "call_a", "type": "function",
+                         "function": {"name": "weather", "arguments": "{\"city\":\"SF\"}"}},
+                        {"id": "call_b", "type": "function",
+                         "function": {"name": "weather", "arguments": "{\"city\":\"NYC\"}"}}
+                    ]},
+                    {"role": "tool", "tool_call_id": "call_a", "content": "18C"},
+                    {"role": "tool", "tool_call_id": "call_b", "content": "3C"}
+                ],
+                "tools": [{
+                    "type": "function",
+                    "function": {
+                        "name": "weather",
+                        "description": "current weather",
+                        "parameters": {"type": "object", "properties": {"city": {"type": "string"}}}
+                    }
+                }],
+                "tool_choice": "auto",
+                "reasoning_effort": "medium"
+            }))
+            .unwrap(),
+            "claude-opus-5",
+        )
+    }
+
+    /// THE test the neutral tool path exists for, and the one Responses will
+    /// copy: an OpenAI-shaped request with tools, a two-call assistant turn and
+    /// two consecutive tool results becomes a valid Anthropic body — tools
+    /// translated, system hoisted, results merged into ONE user turn.
+    ///
+    /// Rendering the results as two turns would have Anthropic reject the
+    /// conversation; rendering only the first would leave the model's second
+    /// call looking unanswered, and a model told its tool never replied does
+    /// not fail, it guesses.
+    #[test]
+    fn an_openai_tool_conversation_renders_as_a_valid_anthropic_body() {
+        assert_eq!(
+            rendered(&openai_tool_conversation()),
+            json!({
+                "model": "claude-opus-5",
+                "max_tokens": 512,
+                "system": "Be brief.",
+                "messages": [
+                    {"role": "user", "content": "weather in SF and NYC?"},
+                    {"role": "assistant", "content": [
+                        {"type": "tool_use", "id": "call_a", "name": "weather",
+                         "input": {"city": "SF"}},
+                        {"type": "tool_use", "id": "call_b", "name": "weather",
+                         "input": {"city": "NYC"}}
+                    ]},
+                    {"role": "user", "content": [
+                        {"type": "tool_result", "tool_use_id": "call_a", "content": "18C"},
+                        {"type": "tool_result", "tool_use_id": "call_b", "content": "3C"}
+                    ]}
+                ],
+                "tools": [{
+                    "name": "weather",
+                    "description": "current weather",
+                    "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}}
+                }],
+                "tool_choice": {"type": "auto"},
+                "output_config": {"effort": "medium"}
+            })
+        );
+    }
+
+    /// The other direction, closing the loop: Anthropic's reply renders back as
+    /// OpenAI-shaped `tool_calls`. Together with the test above this is the
+    /// whole round trip a caller actually makes.
+    #[test]
+    fn an_anthropic_reply_renders_back_as_openai_tool_calls() {
+        let reply = super::super::ingest_response(
+            serde_json::from_value(json!({
+                "id": "msg_1", "type": "message", "role": "assistant",
+                "model": "claude-opus-5",
+                "content": [{"type": "tool_use", "id": "toolu_9", "name": "weather",
+                             "input": {"city": "SF"}}],
+                "stop_reason": "tool_use", "stop_sequence": null,
+                "usage": {"input_tokens": 10, "output_tokens": 5}
+            }))
+            .unwrap(),
+        );
+        let openai = plain(&render_openai(&reply, "anthropic"));
+        assert_eq!(openai["choices"][0]["finish_reason"], "tool_calls");
+        assert_eq!(
+            openai["choices"][0]["message"]["tool_calls"][0],
+            json!({
+                "id": "toolu_9",
+                "type": "function",
+                "function": {"name": "weather", "arguments": "{\"city\":\"SF\"}"}
+            })
+        );
+    }
+
+    /// Two NATIVE tool-result turns must come back as two turns.
+    ///
+    /// Each already was a whole wire turn, so merging them would redraw
+    /// boundaries the caller drew and — because a merged turn replays only the
+    /// first message's residue — silently drop every later turn's. The merge
+    /// exists to serve protocols that must split results across messages, not
+    /// to normalize a conversation that already arrived in this one's shape.
+    #[test]
+    fn consecutive_native_tool_result_turns_are_not_merged() {
+        let body = json!({
+            "model": "claude-opus-5",
+            "max_tokens": 512,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "tool_use_id": "a", "content": "18C"}],
+                    "vendor_tag": "first"
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "tool_use_id": "b", "content": "3C"}],
+                    "vendor_tag": "second"
+                }
+            ]
+        });
+        let normalized = ingest_request(wire(body.clone()), "claude-opus-5");
+        // Both are tool messages, which is what makes them merge candidates...
+        assert_eq!(
+            normalized
+                .messages
+                .iter()
+                .map(|m| m.role)
+                .collect::<Vec<_>>(),
+            vec![Role::Tool, Role::Tool]
+        );
+        // ...and both come back whole, residue included.
+        assert_eq!(rendered(&normalized), body);
+    }
+
+    /// The merge still happens where it is the ONLY way to answer more than one
+    /// call: messages from a protocol that sends one result each, which carry no
+    /// turn of their own under this protocol's namespace. Pinned beside the test
+    /// above because the fix for one could trivially break the other.
+    #[test]
+    fn tool_results_from_another_protocol_still_merge_into_one_turn() {
+        let turns = rendered(&openai_tool_conversation())["messages"]
+            .as_array()
+            .unwrap()
+            .len();
+        assert_eq!(turns, 3, "the two tool results must share one user turn");
+    }
+
+    /// A run that mixes the two: the native turn stands alone and the foreign
+    /// ones merge around it, rather than one rule winning for the whole run.
+    #[test]
+    fn a_native_turn_does_not_absorb_its_foreign_neighbours() {
+        let mut request = bare_request();
+        request.params.max_tokens = Some(64);
+        let foreign = |call_id: &str| types::Message {
+            role: Role::Tool,
+            content: vec![ContentBlock::ToolResult {
+                call_id: call_id.into(),
+                content: vec![ContentBlock::Text {
+                    text: "ok".into(),
+                    cache: None,
+                }],
+                is_error: false,
+            }],
+            ext: types::ProviderExt::new(),
+        };
+        let mut native = foreign("native");
+        native.ext.insert(
+            "anthropic".into(),
+            json!({"content": [{"type": "tool_result", "tool_use_id": "native", "content": "kept"}]}),
+        );
+        request.messages = vec![native, foreign("a"), foreign("b")];
+
+        let turns = rendered(&request);
+        let turns = turns["messages"].as_array().unwrap();
+        assert_eq!(turns.len(), 2, "{turns:?}");
+        assert_eq!(turns[0]["content"][0]["content"], json!("kept"));
+        assert_eq!(turns[1]["content"].as_array().unwrap().len(), 2);
+    }
+
+    /// A field addressed to one protocol must not reach another's body. The
+    /// merge is unit-tested next door; this pins it at the layer a leak would
+    /// actually be observed — a request rendered onto the wire.
+    #[test]
+    fn another_protocols_ext_never_reaches_an_anthropic_body() {
+        let mut request = openai_tool_conversation();
+        request
+            .ext
+            .insert("openai_compat".into(), json!({"seed": 7, "logit_bias": {}}));
+        request.ext.insert("anthropic".into(), json!({"top_k": 40}));
+
+        let body = rendered(&request);
+        assert_eq!(body["top_k"], json!(40));
+        assert!(body.get("seed").is_none(), "{body}");
+        assert!(body.get("logit_bias").is_none(), "{body}");
+    }
+
+    // -----------------------------------------------------------------------
+    // max_tokens: required upstream, optional in the gateway form.
+    // -----------------------------------------------------------------------
+
+    fn bare_request() -> types::ChatRequest {
+        types::ChatRequest {
+            model: "claude-opus-5".into(),
+            messages: vec![types::Message {
+                role: Role::User,
+                content: vec![ContentBlock::Text {
+                    text: "hi".into(),
+                    cache: None,
+                }],
+                ext: types::ProviderExt::new(),
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn max_tokens_prefers_the_caller_over_the_roster() {
+        let mut request = bare_request();
+        request.params.max_tokens = Some(64);
+        let body = plain(&render_request(&request, "anthropic", Some(8192)).unwrap());
+        assert_eq!(body["max_tokens"], json!(64));
+    }
+
+    #[test]
+    fn max_tokens_falls_back_to_the_models_documented_ceiling() {
+        let body = plain(&render_request(&bare_request(), "anthropic", Some(8192)).unwrap());
+        assert_eq!(body["max_tokens"], json!(8192));
+    }
+
+    /// Never an invented default: a number picked here would truncate replies
+    /// at a length nobody asked for, and would look like the model stopping
+    /// early rather than like a missing parameter.
+    #[test]
+    fn an_unresolvable_max_tokens_refuses_and_names_the_model() {
+        let error = render_request(&bare_request(), "anthropic", None).unwrap_err();
+        assert!(matches!(error, Error::InvalidInput(_)), "{error}");
+        assert!(error.to_string().contains("claude-opus-5"), "{error}");
+        assert!(error.to_string().contains("max_tokens"), "{error}");
+    }
+
+    // -----------------------------------------------------------------------
+    // What this protocol cannot say.
+    // -----------------------------------------------------------------------
+
+    fn refusal_of(mutate: impl FnOnce(&mut types::ChatRequest)) -> Error {
+        let mut request = bare_request();
+        request.params.max_tokens = Some(64);
+        mutate(&mut request);
+        render_request(&request, "anthropic", None).unwrap_err()
+    }
+
+    /// Model-generated arguments are not always valid JSON, and this protocol's
+    /// field is an OBJECT — there is nothing honest to send, so the failure
+    /// names the call and the text rather than shipping an empty object the
+    /// model never wrote.
+    #[test]
+    fn unparseable_tool_arguments_refuse_and_name_the_call() {
+        let error = refusal_of(|request| {
+            request.messages[0].role = Role::Assistant;
+            request.messages[0].content = vec![ContentBlock::ToolCall {
+                id: "call_a".into(),
+                name: "weather".into(),
+                arguments: RawJson::new(r#"{"city": "S"#),
+            }];
+        });
+        assert!(matches!(error, Error::InvalidInput(_)), "{error}");
+        for expected in ["call_a", "weather", r#"{"city": "S"#] {
+            assert!(error.to_string().contains(expected), "{error}");
+        }
+    }
+
+    /// Parsing is not the whole check. Anthropic's `input` is an OBJECT, and
+    /// every one of these is valid JSON that is not one — so a parse-only gate
+    /// would forward them and let the provider answer with a 400 that names
+    /// neither the call nor the text.
+    #[test]
+    fn tool_arguments_that_are_json_but_not_an_object_refuse() {
+        for arguments in ["null", "[1]", "7", r#""a string""#, "true"] {
+            let error = refusal_of(|request| {
+                request.messages[0].role = Role::Assistant;
+                request.messages[0].content = vec![ContentBlock::ToolCall {
+                    id: "call_a".into(),
+                    name: "weather".into(),
+                    arguments: RawJson::new(arguments),
+                }];
+            });
+            assert!(
+                matches!(error, Error::InvalidInput(_)),
+                "{arguments}: {error}"
+            );
+            for expected in ["call_a", "weather", arguments, "not an object"] {
+                assert!(error.to_string().contains(expected), "{arguments}: {error}");
+            }
+        }
+    }
+
+    /// An empty argument string is the one non-object that is NOT a refusal:
+    /// `RawJson::parse` reads it as `{}`, which is what a no-argument call
+    /// means and what every protocol here spells differently.
+    #[test]
+    fn empty_tool_arguments_stay_an_empty_object() {
+        let mut request = bare_request();
+        request.params.max_tokens = Some(64);
+        request.messages[0].role = Role::Assistant;
+        request.messages[0].content = vec![ContentBlock::ToolCall {
+            id: "call_a".into(),
+            name: "ping".into(),
+            arguments: RawJson::new(""),
+        }];
+        let body = plain(&render_request(&request, "anthropic", None).unwrap());
+        assert_eq!(body["messages"][0]["content"][0]["input"], json!({}));
+    }
+
+    /// The catch-all that would otherwise render as speech. Chat completions
+    /// turns a `refusal` part, a bytes-less `file` part, a custom tool call and
+    /// any unrecognized part into `ContentBlock::Unknown`; forwarding those
+    /// verbatim sends Anthropic block types it does not define.
+    #[test]
+    fn an_unknown_block_from_another_protocol_refuses_and_names_its_type() {
+        let error = refusal_of(|request| {
+            request.messages[0].content = vec![ContentBlock::Unknown(
+                json!({"type": "refusal", "refusal": "I cannot help with that"}),
+            )];
+        });
+        assert!(matches!(error, Error::InvalidInput(_)), "{error}");
+        assert!(error.to_string().contains("refusal"), "{error}");
+    }
+
+    /// A block with no string `type` is exactly as unrenderable, and the
+    /// refusal still has to say WHICH block — so it quotes the value.
+    #[test]
+    fn an_unknown_block_without_a_type_still_names_itself() {
+        let error = refusal_of(|request| {
+            request.messages[0].content = vec![ContentBlock::Unknown(json!({"odd": 1}))];
+        });
+        assert!(error.to_string().contains(r#"{"odd":1}"#), "{error}");
+    }
+
+    /// The refusal above is free ONLY because a block Anthropic itself sent
+    /// never reaches that arm: ingest retains the whole wire `content` array
+    /// and `render_turn` replays it. Without this test the refusal would look
+    /// like it broke same-protocol losslessness for any block type Anthropic
+    /// adds tomorrow — the case the `Unknown` arm was built for.
+    #[test]
+    fn an_anthropic_native_unknown_block_still_round_trips() {
+        let body = json!({
+            "model": "claude-opus-5",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": [
+                {"type": "web_search_tool_result_20991231", "payload": {"q": "rust"}}
+            ]}]
+        });
+        let normalized = ingest_request(wire(body.clone()), "claude-opus-5");
+        assert!(
+            matches!(
+                normalized.messages[0].content.as_slice(),
+                [ContentBlock::Unknown(_)]
+            ),
+            "the block must land in the arm the refusal guards, or this proves nothing"
+        );
+        assert_eq!(rendered(&normalized), body);
+    }
+
+    /// The refusals above have to survive one level of nesting. A tool result
+    /// carries blocks, and borrowing the REPLY's infallible renderer for them
+    /// let exactly the values rejected at the top level through underneath —
+    /// so this is the same input as
+    /// `an_unknown_block_from_another_protocol_refuses_and_names_its_type`,
+    /// moved inside a `tool_result`.
+    #[test]
+    fn an_unknown_block_nested_in_a_tool_result_refuses() {
+        let error = refusal_of(|request| {
+            request.messages[0].role = Role::Tool;
+            request.messages[0].content = vec![ContentBlock::ToolResult {
+                call_id: "call_a".into(),
+                content: vec![ContentBlock::Unknown(json!({"type": "refusal"}))],
+                is_error: false,
+            }];
+        });
+        assert!(matches!(error, Error::InvalidInput(_)), "{error}");
+        assert!(error.to_string().contains("refusal"), "{error}");
+    }
+
+    /// The other half of the same hole: nested arguments went through the
+    /// reply's `unwrap_or(Value::Null)` rather than this module's refusal, so a
+    /// malformed tool call became a silent `null` input.
+    #[test]
+    fn unparseable_arguments_nested_in_a_tool_result_refuse() {
+        let error = refusal_of(|request| {
+            request.messages[0].role = Role::Tool;
+            request.messages[0].content = vec![ContentBlock::ToolResult {
+                call_id: "call_a".into(),
+                content: vec![ContentBlock::ToolCall {
+                    id: "call_b".into(),
+                    name: "weather".into(),
+                    arguments: RawJson::new("{oops"),
+                }],
+                is_error: false,
+            }];
+        });
+        assert!(matches!(error, Error::InvalidInput(_)), "{error}");
+        assert!(error.to_string().contains("call_b"), "{error}");
+    }
+
+    /// A file id is a handle into ONE provider's files API. `MediaSource` has
+    /// no provenance, so an OpenAI `file-…` and an Anthropic one are the same
+    /// shape here — and forwarding the foreign one builds a request that can
+    /// only 404.
+    #[test]
+    fn a_foreign_provider_file_reference_refuses_and_names_the_id() {
+        for block in [
+            ContentBlock::Document {
+                source: MediaSource::ProviderFile {
+                    id: "file-abc123".into(),
+                },
+                title: None,
+                cache: None,
+            },
+            ContentBlock::Image {
+                source: MediaSource::ProviderFile {
+                    id: "file-abc123".into(),
+                },
+                detail: None,
+                cache: None,
+            },
+        ] {
+            let error = refusal_of(|request| request.messages[0].content = vec![block]);
+            assert!(matches!(error, Error::InvalidInput(_)), "{error}");
+            assert!(error.to_string().contains("file-abc123"), "{error}");
+        }
+    }
+
+    /// And the refusal above stays free: Anthropic's own file reference comes
+    /// back through the retained content, never through the renderer that
+    /// refuses. Without this the fix would have broken a documented native
+    /// request shape.
+    #[test]
+    fn an_anthropic_native_file_reference_still_round_trips() {
+        let body = json!({
+            "model": "claude-opus-5",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": [
+                {"type": "document", "source": {"type": "file", "file_id": "file_011CNha8iCJcU1wXNR6q4V8w"}}
+            ]}]
+        });
+        let normalized = ingest_request(wire(body.clone()), "claude-opus-5");
+        assert!(
+            matches!(
+                normalized.messages[0].content.as_slice(),
+                [ContentBlock::Document {
+                    source: MediaSource::ProviderFile { .. },
+                    ..
+                }]
+            ),
+            "the source must land in the arm the refusal guards, or this proves nothing"
+        );
+        assert_eq!(rendered(&normalized), body);
+    }
+
+    /// A system message the caller placed mid-conversation cannot be hoisted
+    /// without reordering what the model sees, and cannot be rendered as a user
+    /// turn without fabricating one. Neither is a translation.
+    #[test]
+    fn a_system_message_after_the_first_turn_refuses() {
+        let error = refusal_of(|request| {
+            request.messages.push(types::Message {
+                role: Role::System,
+                content: vec![ContentBlock::Text {
+                    text: "now be terse".into(),
+                    cache: None,
+                }],
+                ext: types::ProviderExt::new(),
+            });
+        });
+        assert!(matches!(error, Error::NotImplemented(_)), "{error}");
+        assert!(error.to_string().contains("system message"), "{error}");
+    }
+
+    /// Dropping audio would send a request that reads as if the caller never
+    /// attached it, and the model would answer confidently about nothing.
+    #[test]
+    fn an_audio_block_refuses() {
+        let error = refusal_of(|request| {
+            request.messages[0].content.push(ContentBlock::Audio {
+                source: MediaSource::Base64 {
+                    media_type: "audio/wav".into(),
+                    data: "aGk=".into(),
+                },
+                format: Some("wav".into()),
+            });
+        });
+        assert!(error.to_string().contains("audio"), "{error}");
+    }
+
+    /// Nested as well as top-level: a block inside a tool result is as
+    /// unrenderable as one beside it.
+    #[test]
+    fn an_audio_block_inside_a_tool_result_refuses() {
+        let error = refusal_of(|request| {
+            request.messages[0].content = vec![ContentBlock::ToolResult {
+                call_id: "call_a".into(),
+                content: vec![ContentBlock::Audio {
+                    source: MediaSource::Url {
+                        url: "https://e.com/a.wav".into(),
+                    },
+                    format: None,
+                }],
+                is_error: false,
+            }];
+        });
+        assert!(error.to_string().contains("audio"), "{error}");
+    }
+
+    /// Chat completions' `file` part carries bytes and a filename and declares
+    /// no MIME type, so its ingest fills an empty string rather than guessing
+    /// from the extension. Anthropic REQUIRES one, so forwarding the empty
+    /// string would build a request certain to be rejected — and the caller
+    /// would read that 400 as being about their document rather than about the
+    /// conversion. Refusing here says which.
+    #[test]
+    fn inline_bytes_with_no_media_type_refuse() {
+        let error = refusal_of(|request| {
+            request.messages[0].content.push(ContentBlock::Document {
+                source: MediaSource::Base64 {
+                    media_type: String::new(),
+                    data: "JVBERi0=".into(),
+                },
+                title: Some("report.pdf".into()),
+                cache: None,
+            });
+        });
+        assert!(matches!(error, Error::NotImplemented(_)), "{error}");
+        assert!(error.to_string().contains("media type"), "{error}");
+    }
+
+    /// The end-to-end shape of that refusal: an OpenAI request carrying a
+    /// `file` part is what actually produces it, and it must be named rather
+    /// than sent.
+    #[test]
+    fn an_openai_file_part_refuses_rather_than_being_sent_invalid() {
+        let request = ingest_openai(
+            serde_json::from_value(json!({
+                "model": "anthropic/claude-opus-5",
+                "max_tokens": 512,
+                "messages": [{"role": "user", "content": [
+                    {"type": "text", "text": "summarize this"},
+                    {"type": "file", "file": {"file_data": "JVBERi0=", "filename": "r.pdf"}}
+                ]}]
+            }))
+            .unwrap(),
+            "claude-opus-5",
+        );
+        let error = render_request(&request, "anthropic", None).unwrap_err();
+        assert!(error.to_string().contains("media type"), "{error}");
+    }
+
+    /// ...while a document that DOES name its type renders normally. The gate
+    /// must refuse the missing media type, not inline bytes in general.
+    #[test]
+    fn inline_bytes_with_a_media_type_render() {
+        let mut request = bare_request();
+        request.params.max_tokens = Some(64);
+        request.messages[0].content = vec![ContentBlock::Document {
+            source: MediaSource::Base64 {
+                media_type: "application/pdf".into(),
+                data: "JVBERi0=".into(),
+            },
+            title: None,
+            cache: None,
+        }];
+        assert_eq!(
+            rendered(&request)["messages"][0]["content"],
+            json!([{
+                "type": "document",
+                "source": {
+                    "type": "base64",
+                    "media_type": "application/pdf",
+                    "data": "JVBERi0="
+                }
+            }])
+        );
+    }
+
+    #[test]
+    fn a_tool_with_no_schema_refuses_by_name() {
+        let error = refusal_of(|request| {
+            request.tools.push(types::ToolDef {
+                name: "web_search".into(),
+                description: None,
+                input_schema: Value::Null,
+                strict: None,
+                cache: None,
+                ext: types::ProviderExt::new(),
+            });
+        });
+        assert!(error.to_string().contains("arguments schema"), "{error}");
+    }
+
+    /// Anthropic requires a schema, so a schema-less JSON mode has no wire
+    /// form. Dropping it would silently ask for free-form text instead.
+    #[test]
+    fn a_schema_less_json_mode_refuses() {
+        let error = refusal_of(|request| {
+            request.response_format = Some(types::ResponseFormat::JsonObject);
+        });
+        assert!(error.to_string().contains("json_object"), "{error}");
+    }
+
+    #[test]
+    fn a_request_level_cache_hint_refuses() {
+        let error = refusal_of(|request| {
+            request.cache = Some(types::CacheHint { ttl: None });
+        });
+        assert!(error.to_string().contains("cache hint"), "{error}");
+    }
+
+    // -----------------------------------------------------------------------
+    // Thinking and effort, the two parameters that are one gateway concept.
+    // -----------------------------------------------------------------------
+
+    fn with_reasoning(reasoning: types::ReasoningConfig) -> Value {
+        let mut request = bare_request();
+        request.params.max_tokens = Some(64);
+        request.reasoning = Some(reasoning);
+        rendered(&request)
+    }
+
+    /// A budget is unambiguous — `enabled` is the only arm that takes one — and
+    /// its absence is equally so, since `adaptive` is the only arm that works
+    /// without. Neither needs to know which model is routed to: a model that
+    /// rejects the arm says so by name, where warpllm guessing would have to
+    /// invent a budget or discard the caller's.
+    #[test]
+    fn the_thinking_arm_follows_the_budget_not_the_model() {
+        assert_eq!(
+            with_reasoning(types::ReasoningConfig {
+                enabled: Some(true),
+                budget_tokens: Some(4096),
+                ..Default::default()
+            })["thinking"],
+            json!({"type": "enabled", "budget_tokens": 4096})
+        );
+        assert_eq!(
+            with_reasoning(types::ReasoningConfig {
+                enabled: Some(true),
+                ..Default::default()
+            })["thinking"],
+            json!({"type": "adaptive"})
+        );
+        assert_eq!(
+            with_reasoning(types::ReasoningConfig {
+                enabled: Some(false),
+                ..Default::default()
+            })["thinking"],
+            json!({"type": "disabled"})
+        );
+    }
+
+    /// An explicit off beats a budget: a budget says how MUCH to think, and
+    /// this says not to.
+    #[test]
+    fn an_explicit_off_outranks_a_budget() {
+        assert_eq!(
+            with_reasoning(types::ReasoningConfig {
+                enabled: Some(false),
+                budget_tokens: Some(4096),
+                ..Default::default()
+            })["thinking"],
+            json!({"type": "disabled"})
+        );
+    }
+
+    /// "Reason but do not return it" is `display`, which rides whichever arm is
+    /// being emitted rather than being a mode of its own.
+    #[test]
+    fn an_exclusion_becomes_the_display_field() {
+        assert_eq!(
+            with_reasoning(types::ReasoningConfig {
+                enabled: Some(true),
+                budget_tokens: Some(4096),
+                exclude: Some(true),
+                ..Default::default()
+            })["thinking"],
+            json!({"type": "enabled", "budget_tokens": 4096, "display": "omitted"})
+        );
+    }
+
+    /// ...and has nowhere to go without one, so it is named rather than
+    /// dropped. A caller who asked not to be shown reasoning would otherwise
+    /// get a request that never mentioned it.
+    #[test]
+    fn an_exclusion_with_no_thinking_mode_refuses() {
+        let error = refusal_of(|request| {
+            request.reasoning = Some(types::ReasoningConfig {
+                exclude: Some(true),
+                ..Default::default()
+            });
+        });
+        assert!(error.to_string().contains("exclusion"), "{error}");
+    }
+
+    /// The effort word crosses verbatim into the parameter Anthropic now has
+    /// for it — this is the mapping the plan for this work had down as
+    /// impossible, before `output_config` existed.
+    #[test]
+    fn an_effort_renders_into_output_config_and_not_into_thinking() {
+        let body = with_reasoning(types::ReasoningConfig {
+            effort: Some("low".into()),
+            ..Default::default()
+        });
+        assert_eq!(body["output_config"], json!({"effort": "low"}));
+        assert!(body.get("thinking").is_none(), "{body}");
+    }
+
+    /// The two vocabularies overlap without being equal — chat completions has
+    /// `minimal`, Anthropic has `max` — and the provider is the authority on
+    /// its own values. A table here would go stale silently.
+    #[test]
+    fn an_effort_anthropic_does_not_define_is_passed_through_not_filtered() {
+        assert_eq!(
+            with_reasoning(types::ReasoningConfig {
+                effort: Some("minimal".into()),
+                ..Default::default()
+            })["output_config"],
+            json!({"effort": "minimal"})
+        );
+    }
+
+    #[test]
+    fn a_json_schema_becomes_the_output_format() {
+        let mut request = bare_request();
+        request.params.max_tokens = Some(64);
+        request.response_format = Some(types::ResponseFormat::JsonSchema {
+            name: "answer".into(),
+            schema: json!({"type": "object"}),
+            strict: Some(true),
+        });
+        // `name` and `strict` have no Anthropic counterpart and are dropped;
+        // the schema is the whole of what this protocol says.
+        assert_eq!(
+            rendered(&request)["output_config"],
+            json!({"format": {"type": "json_schema", "schema": {"type": "object"}}})
+        );
+    }
+
+    /// `text` IS this protocol's default, so emitting nothing asks for exactly
+    /// what it asks for — and a request that wanted neither control must not
+    /// grow an empty `output_config`.
+    #[test]
+    fn a_text_response_format_emits_nothing_at_all() {
+        let mut request = bare_request();
+        request.params.max_tokens = Some(64);
+        request.response_format = Some(types::ResponseFormat::Text);
+        let body = rendered(&request);
+        assert!(body.get("output_config").is_none(), "{body}");
+    }
+
+    // -----------------------------------------------------------------------
+    // Reasoning blocks, which only replay when Anthropic produced them.
+    // -----------------------------------------------------------------------
+
+    /// Anthropic requires a run of its own thinking blocks back untouched, and
+    /// this sends exactly those. Another provider's reasoning carries no
+    /// signature Anthropic would accept, so forwarding it would reject the turn
+    /// rather than preserve anything.
+    #[test]
+    fn only_anthropics_own_reasoning_is_sent_back() {
+        let mut request = bare_request();
+        request.params.max_tokens = Some(64);
+        request.messages[0].role = Role::Assistant;
+        request.messages[0].content = vec![
+            ContentBlock::Reasoning {
+                detail: ReasoningDetail::Text {
+                    text: "mine".into(),
+                    signature: Some("sig".into()),
+                },
+                provenance: Some("anthropic".into()),
+                id: None,
+            },
+            ContentBlock::Reasoning {
+                detail: ReasoningDetail::Text {
+                    text: "theirs".into(),
+                    signature: None,
+                },
+                provenance: Some("openai_compat".into()),
+                id: None,
+            },
+        ];
+        assert_eq!(
+            rendered(&request)["messages"][0]["content"],
+            json!([{"type": "thinking", "thinking": "mine", "signature": "sig"}])
+        );
+    }
+
+    /// The transport CHECKS this flag rather than setting it, so a whole-reply
+    /// exchange must not carry one and a streamed one must.
+    #[test]
+    fn stream_is_emitted_only_when_it_is_true() {
+        let mut request = bare_request();
+        request.params.max_tokens = Some(64);
+        assert!(rendered(&request).get("stream").is_none());
+        request.stream = true;
+        assert_eq!(rendered(&request)["stream"], json!(true));
+    }
+}

--- a/crates/warpllm/src/gateway/anthropic/api/messages/response.rs
+++ b/crates/warpllm/src/gateway/anthropic/api/messages/response.rs
@@ -1,0 +1,1032 @@
+//! Response conversions: Anthropic's [`Message`] → gateway (ingest) and back
+//! (render). Round trips are lossless: fields the gateway form has no home for
+//! — `type`, `stop_sequence`, the usage breakdowns — ride `ext["anthropic"]` at
+//! their nesting level and are restored verbatim.
+//!
+//! # PROMOTE BUT RETAIN, including the whole content array
+//!
+//! The gateway's content blocks carry no `ext` of their own, so a KNOWN block's
+//! residue has nowhere to be filed one field at a time: a text block's
+//! `citations`, a source's vendor extensions, an explicit `null` where the
+//! gateway holds only present-or-absent. Promotion alone loses all of it
+//! precisely BECAUSE the block parsed — a shape warpllm does not recognize
+//! reaches the `Unknown` arm and survives whole, while one it does recognize
+//! would be rebuilt from the fields it could hold.
+//!
+//! So `ingest_response` retains the entire `content` array under the message's
+//! ext and `render_response` prefers it. What the blocks promote to is then the
+//! CROSS-protocol view, and the retained copy is the same-protocol one; the
+//! tests below check each separately, because retention alone would make a
+//! round trip pass however wrong the promotion was.
+//!
+//! # One normalization, and it is arithmetic
+//!
+//! `Usage::input_tokens` is the only value not carried across unchanged: this
+//! protocol's excludes the cached counts and the gateway's includes them. See
+//! [`ingest_usage`].
+//!
+//! # Two shapes this protocol does not have
+//!
+//! **No `created`.** Anthropic stamps no timestamp, so `ChatResponse::created`
+//! is `None` and rendering back emits nothing. A caller that needs one reads
+//! its own clock; inventing one here would be a number nobody measured.
+//!
+//! **No choices.** One request yields one reply, so `completions` always holds
+//! exactly one element. That is why nothing here has a choice-level `ext`: the
+//! reply IS the completion, and its residue is the response's.
+//!
+//! # `render_response` has no caller yet
+//!
+//! Nothing answers in this protocol — warpllm speaks Anthropic to a provider
+//! and answers its own callers in theirs — so [`render_response`] exists as the
+//! round trip's other half rather than as a code path. That is not idle
+//! symmetry: a residue that is stashed but cannot be restored looks identical
+//! to a lossless ingest from the gateway side alone, and only rendering back
+//! tells the two apart. The tests below are what it is for.
+
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::gateway::anthropic::{
+    cache_control, cache_hint, merged_ext, namespaced, role_from_wire, role_to_wire,
+};
+use crate::gateway::types::{
+    self, ContentBlock, FinishReason, IngestSource, MediaSource, RawJson, ReasoningDetail,
+};
+use crate::protocol::UnknownFields;
+use crate::protocol::anthropic::messages::types::{
+    Base64Source, CacheControl, ContentBlock as WireBlock, DocumentBlock, FileSource, ImageBlock,
+    Message, OutputTokensDetails, RedactedThinkingBlock, Source, TextBlock, ThinkingBlock,
+    ToolResultBlock, ToolResultContent, ToolUseBlock, UrlSource, Usage,
+};
+use crate::types::Protocol;
+
+/// Permissive and infallible; the exhaustive destructures at every level make
+/// dropping a newly-typed wire field a compile error.
+pub(crate) fn ingest_response(response: Message) -> types::ChatResponse {
+    // Wire structs are plain serde data; serialization cannot fail.
+    let body = plain(&response);
+    let Message {
+        id,
+        r#type,
+        role,
+        content,
+        model,
+        stop_reason,
+        stop_sequence,
+        usage,
+        unknown_fields,
+    } = response;
+    let mut anthropic = UnknownFields::new();
+    anthropic.insert("type".into(), Value::String(r#type));
+    // Required AND nullable upstream, so it is stashed either way — as a string
+    // or as the null it arrived as — and always emitted again.
+    anthropic.insert(
+        "stop_sequence".into(),
+        stop_sequence.map_or(Value::Null, Value::String),
+    );
+    anthropic.extend(unknown_fields);
+
+    let (role, raw_role) = role_from_wire(role);
+    let mut message_ext = UnknownFields::new();
+    if let Some(raw) = raw_role {
+        message_ext.insert("role".into(), Value::String(raw));
+    }
+    // PROMOTE BUT RETAIN, and here it is the ONLY way a reply round trips.
+    //
+    // The gateway's content blocks have no `ext` of their own, so anything a
+    // known block carries that they cannot hold has nowhere else to go: a text
+    // block's `citations`, a source's vendor fields, the difference between an
+    // absent `cache_control` and an explicit null. Promoting alone would let
+    // `render_response` rebuild the block with an empty residue and silently
+    // drop documented metadata, which is exactly what the losslessness claim
+    // above forbids. Retaining the whole array is what makes the claim true.
+    message_ext.insert("content".into(), plain(&content));
+    types::ChatResponse {
+        id,
+        model,
+        // See this module's docs: there is no timestamp to report.
+        created: None,
+        completions: vec![types::Completion {
+            message: types::Message {
+                role,
+                content: content.iter().map(ingest_block).collect(),
+                ext: namespaced(message_ext),
+            },
+            finish_reason: finish_reason(stop_reason.as_deref()),
+            // A null `stop_reason` means the reply is still being generated,
+            // which a whole reply never is — so the empty string here is
+            // unreachable from a completed exchange, and rendering reads it
+            // back as the null it was. Anthropic sends no empty stop reasons.
+            finish_reason_raw: stop_reason.unwrap_or_default(),
+            ext: types::ProviderExt::new(),
+        }],
+        usage: Some(ingest_usage(usage)),
+        ext: namespaced(anthropic),
+        source: Some(IngestSource {
+            protocol: Protocol::Anthropic,
+            body,
+        }),
+    }
+}
+
+/// Anthropic's `stop_reason` → the gateway's programmatic enum.
+///
+/// Its own table rather than [`FinishReason::from_raw`], which reads OpenAI's
+/// spellings and shares not one of these. `finish_reason_raw` stays
+/// authoritative on render, so this only has to be right for callers matching
+/// on the enum.
+fn finish_reason(stop_reason: Option<&str>) -> FinishReason {
+    match stop_reason {
+        Some("end_turn" | "stop_sequence") => FinishReason::Stop,
+        // Both ran out of room: one hit the caller's ceiling, the other the
+        // model's window. A caller does the same thing about either — send
+        // less — which is what this enum is for.
+        Some("max_tokens" | "model_context_window_exceeded") => FinishReason::Length,
+        Some("tool_use") => FinishReason::ToolCalls,
+        Some("refusal") => FinishReason::ContentFilter,
+        // `pause_turn` is deliberately NOT `Stop`: the turn was interrupted and
+        // is meant to be continued, which is not the claim `Stop` makes. A
+        // caller that treats it as a finished answer stops a reply mid-thought.
+        _ => FinishReason::Other,
+    }
+}
+
+/// Anthropic's blocks → the gateway's.
+///
+/// A block this protocol has and the gateway model does not — a text source, a
+/// server tool's result, whatever ships next — becomes `Unknown` carrying the
+/// WHOLE wire block rather than a lossy approximation of it. That is what makes
+/// a same-protocol round trip exact for shapes warpllm does not understand.
+pub(super) fn ingest_block(block: &WireBlock) -> ContentBlock {
+    match block {
+        WireBlock::Text(text) => ContentBlock::Text {
+            text: text.text.clone(),
+            cache: hint_of(&text.cache_control),
+        },
+        WireBlock::Image(image) => match media_source(&image.source) {
+            Some(source) => ContentBlock::Image {
+                source,
+                // Anthropic has no resolution hint on an image block, so this
+                // is only ever filled by an ingest from a protocol that does.
+                detail: None,
+                cache: hint_of(&image.cache_control),
+            },
+            None => ContentBlock::Unknown(plain(block)),
+        },
+        WireBlock::Document(document) => match media_source(&document.source) {
+            Some(source) => ContentBlock::Document {
+                source,
+                title: document.title.clone().flatten(),
+                cache: hint_of(&document.cache_control),
+            },
+            None => ContentBlock::Unknown(plain(block)),
+        },
+        WireBlock::ToolUse(call) => ContentBlock::ToolCall {
+            id: call.id.clone(),
+            name: call.name.clone(),
+            // An OBJECT here, a string of JSON on chat completions. Serializing
+            // once at the boundary is what `RawJson::from_value` is for, and
+            // `preserve_order` keeps Anthropic's key order — so the text is
+            // exact modulo whitespace, which is the one documented seam in the
+            // tool path.
+            arguments: RawJson::from_value(&call.input),
+        },
+        WireBlock::ToolResult(result) => ContentBlock::ToolResult {
+            call_id: result.tool_use_id.clone(),
+            content: match &result.content {
+                Some(ToolResultContent::Text(text)) => vec![ContentBlock::Text {
+                    text: text.clone(),
+                    cache: None,
+                }],
+                Some(ToolResultContent::Blocks(blocks)) => {
+                    blocks.iter().map(ingest_block).collect()
+                }
+                None => Vec::new(),
+            },
+            is_error: result.is_error.unwrap_or(false),
+        },
+        WireBlock::Thinking(thinking) => ContentBlock::Reasoning {
+            detail: ReasoningDetail::Text {
+                text: thinking.thinking.clone(),
+                signature: thinking.signature.clone(),
+            },
+            provenance: Some(Protocol::Anthropic.as_str().to_string()),
+            id: None,
+        },
+        WireBlock::RedactedThinking(redacted) => ContentBlock::Reasoning {
+            detail: ReasoningDetail::Encrypted {
+                data: redacted.data.clone(),
+            },
+            provenance: Some(Protocol::Anthropic.as_str().to_string()),
+            id: None,
+        },
+        WireBlock::Unknown(value) => ContentBlock::Unknown(value.clone()),
+    }
+}
+
+/// `Some` for the three sources the gateway model names; `None` for a source it
+/// does not, which makes the whole block `Unknown`.
+///
+/// Anthropic's `text` source — a document's contents inline — is the one with
+/// no counterpart: `MediaSource` is a URL, base64 bytes, or a provider file id,
+/// and none of those is "here is the text". Squeezing it into `Base64` would
+/// claim the payload was encoded when it was not.
+fn media_source(source: &Source) -> Option<MediaSource> {
+    match source {
+        Source::Base64(base64) => Some(MediaSource::Base64 {
+            media_type: base64.media_type.clone(),
+            data: base64.data.clone(),
+        }),
+        Source::Url(url) => Some(MediaSource::Url {
+            url: url.url.clone(),
+        }),
+        Source::File(file) => Some(MediaSource::ProviderFile {
+            id: file.file_id.clone(),
+        }),
+        Source::Text(_) | Source::Unknown(_) => None,
+    }
+}
+
+/// The inverse of [`media_source`]. Fallible in the other direction for the
+/// mirror reason: nothing in this protocol carries a media type for a provider
+/// file, and a bare URL is not something every block accepts — but both of
+/// those the wire DOES have shapes for, so only the media type is guessed at,
+/// never the kind.
+pub(super) fn render_source(source: &MediaSource) -> Source {
+    match source {
+        MediaSource::Base64 { media_type, data } => Source::Base64(Base64Source {
+            media_type: media_type.clone(),
+            data: data.clone(),
+            unknown_fields: UnknownFields::new(),
+        }),
+        MediaSource::Url { url } => Source::Url(UrlSource {
+            url: url.clone(),
+            unknown_fields: UnknownFields::new(),
+        }),
+        MediaSource::ProviderFile { id } => Source::File(FileSource {
+            file_id: id.clone(),
+            unknown_fields: UnknownFields::new(),
+        }),
+    }
+}
+
+/// A wire block's three-state `cache_control` as the gateway's plain
+/// `Option`. An explicit `null` and an absent key both mean no breakpoint;
+/// which one it was rides the message's retained `content`.
+fn hint_of(control: &Option<Option<CacheControl>>) -> Option<types::CacheHint> {
+    control.as_ref().and_then(Option::as_ref).map(cache_hint)
+}
+
+pub(super) fn ingest_usage(usage: Usage) -> types::Usage {
+    let Usage {
+        input_tokens,
+        output_tokens,
+        cache_creation_input_tokens,
+        cache_read_input_tokens,
+        output_tokens_details,
+        unknown_fields,
+    } = usage;
+    let mut anthropic = UnknownFields::new();
+    let cache_write_tokens = lift_count(
+        &mut anthropic,
+        "cache_creation_input_tokens",
+        cache_creation_input_tokens,
+    );
+    let cache_read_tokens = lift_count(
+        &mut anthropic,
+        "cache_read_input_tokens",
+        cache_read_input_tokens,
+    );
+    let mut reasoning_tokens = None;
+    if let Some(details) = output_tokens_details {
+        let residue = match details {
+            Some(details) => {
+                let mut residue = object(plain(&details));
+                // Only a NUMBER is lifted. An explicit `null` stays in the
+                // residue, because the gateway's `Option<u64>` cannot tell one
+                // from an absent key and rendering would turn it into one.
+                if residue.get("thinking_tokens").is_some_and(Value::is_number) {
+                    reasoning_tokens = residue.remove("thinking_tokens").and_then(|v| v.as_u64());
+                }
+                Value::Object(residue)
+            }
+            None => Value::Null,
+        };
+        anthropic.insert("output_tokens_details".into(), residue);
+    }
+    anthropic.extend(unknown_fields);
+    // NORMALIZED, and this is the one arithmetic decision in the module.
+    //
+    // Anthropic's `input_tokens` counts only the tokens after the last cache
+    // breakpoint — "not read from or used to create a cache" — where the
+    // gateway's means the WHOLE input with the cached parts included, which is
+    // what `Usage`'s own doc requires and what OpenAI's `prompt_tokens` already
+    // is. Storing Anthropic's number unchanged would make one conversation
+    // report a different prompt size depending on which backend served it, and
+    // would let `cached_tokens` come out LARGER than the prompt it is part of.
+    let cached = cache_read_tokens.unwrap_or(0) + cache_write_tokens.unwrap_or(0);
+    let input_total = u64::from(input_tokens) + cached;
+    // PROMOTE BUT RETAIN, so the normalization is reversible: the wire value
+    // rides the residue and `render_usage` prefers it over subtracting back.
+    if cached > 0 {
+        anthropic.insert("input_tokens".into(), Value::from(input_tokens));
+    }
+    types::Usage {
+        input_tokens: Some(input_total),
+        output_tokens: Some(u64::from(output_tokens)),
+        // COMPUTED, because Anthropic sends no total. Input plus output and
+        // nothing else — the cache counts are already inside `input_total`, so
+        // adding them here would double-count every cached request.
+        total_tokens: Some(input_total + u64::from(output_tokens)),
+        // Thinking tokens are likewise a BREAKDOWN of `output_tokens`, already
+        // counted in it.
+        reasoning_tokens,
+        cache_read_tokens,
+        cache_write_tokens,
+        ext: namespaced(anthropic),
+    }
+}
+
+/// Lifts an optional-and-nullable count into the gateway's plain `Option<u64>`,
+/// stashing an explicit `null` so rendering can restore one.
+///
+/// Three wire states do not fit in the gateway's two. Collapsing them would
+/// turn `"cache_read_input_tokens": null` — which a cache-aware reply really
+/// does send — into an absent key on the way back out.
+fn lift_count(residue: &mut UnknownFields, key: &str, value: Option<Option<u32>>) -> Option<u64> {
+    match value {
+        Some(Some(count)) => Some(u64::from(count)),
+        Some(None) => {
+            residue.insert(key.to_string(), Value::Null);
+            None
+        }
+        None => None,
+    }
+}
+
+/// The inverse of [`lift_count`]. A stashed `null` is restored only when the
+/// gateway field is empty; a count that is set is authoritative over it.
+fn restore_count(
+    residue: &mut UnknownFields,
+    key: &str,
+    count: Option<u64>,
+) -> Option<Option<u32>> {
+    match (count, residue.remove(key)) {
+        (Some(count), _) => Some(Some(count as u32)),
+        (None, Some(Value::Null)) => Some(None),
+        (None, _) => None,
+    }
+}
+
+/// Infallible: wire fields restore from ext, and anything corrupted past its
+/// wire type falls back to dropping that field rather than failing a render.
+pub(crate) fn render_response(response: &types::ChatResponse, provider: &str) -> Message {
+    let mut unknown_fields = merged_ext(&response.ext, provider);
+    // One reply, one completion — see this module's docs. A response carrying
+    // several could only have come from a protocol with choices, and Anthropic
+    // has no shape for the others; the first is the answer, and dropping the
+    // rest is the whole of what "no multi-choice concept" costs.
+    let completion = response.completions.first();
+    let mut message_fields = completion
+        .map(|completion| merged_ext(&completion.message.ext, provider))
+        .unwrap_or_default();
+    Message {
+        id: response.id.clone(),
+        r#type: take_string(&mut unknown_fields, "type").unwrap_or_else(|| "message".into()),
+        role: match message_fields.remove("role") {
+            Some(Value::String(raw)) => raw,
+            _ => completion
+                .map_or("assistant", |completion| {
+                    role_to_wire(completion.message.role)
+                })
+                .to_string(),
+        },
+        // What arrived wins over what the blocks can be rebuilt into; see
+        // `ingest_response`. A reply from ANOTHER protocol has no residue here
+        // and is rebuilt, which is the only path `render_blocks` serves.
+        content: take_typed(&mut message_fields, "content").unwrap_or_else(|| {
+            completion
+                .map(|completion| render_blocks(&completion.message.content))
+                .unwrap_or_default()
+        }),
+        model: response.model.clone(),
+        stop_reason: completion
+            .map(|completion| completion.finish_reason_raw.clone())
+            .filter(|raw| !raw.is_empty()),
+        stop_sequence: match unknown_fields.remove("stop_sequence") {
+            Some(Value::String(sequence)) => Some(sequence),
+            _ => None,
+        },
+        usage: response
+            .usage
+            .as_ref()
+            .map_or_else(zero_usage, |usage| render_usage(usage, provider)),
+        unknown_fields,
+    }
+}
+
+/// Blocks that have no wire shape are DROPPED rather than approximated. Only
+/// two can be: reasoning that did not come from Anthropic (see
+/// [`render_reasoning`]) and audio, which `request::ensure_renderable` refuses
+/// before anything reaches here.
+fn render_blocks(blocks: &[ContentBlock]) -> Vec<WireBlock> {
+    blocks.iter().filter_map(render_block).collect()
+}
+
+/// The inverse of [`ingest_block`] for the blocks a REPLY carries.
+///
+/// Deliberately not shared with the request renderer: a request's blocks can
+/// fail to render (a tool call whose arguments will not parse) and a reply's
+/// cannot, because everything in a reply came off this protocol's own wire.
+fn render_block(block: &ContentBlock) -> Option<WireBlock> {
+    match block {
+        ContentBlock::Text { text, cache } => Some(WireBlock::Text(TextBlock {
+            text: text.clone(),
+            cache_control: control_of(cache),
+            unknown_fields: UnknownFields::new(),
+        })),
+        ContentBlock::Image { source, cache, .. } => Some(WireBlock::Image(ImageBlock {
+            source: render_source(source),
+            cache_control: control_of(cache),
+            unknown_fields: UnknownFields::new(),
+        })),
+        ContentBlock::Document {
+            source,
+            title,
+            cache,
+        } => Some(WireBlock::Document(DocumentBlock {
+            source: render_source(source),
+            title: title.clone().map(Some),
+            cache_control: control_of(cache),
+            unknown_fields: UnknownFields::new(),
+        })),
+        ContentBlock::ToolCall {
+            id,
+            name,
+            arguments,
+        } => Some(WireBlock::ToolUse(ToolUseBlock {
+            id: id.clone(),
+            name: name.clone(),
+            // A reply's arguments came from this protocol as an object, so
+            // they parse. A REQUEST's may not, which is why that renderer
+            // reports the failure instead of falling back — here the fallback
+            // is unreachable and an empty object is the inert value.
+            input: arguments.parse().unwrap_or(Value::Null),
+            cache_control: None,
+            unknown_fields: UnknownFields::new(),
+        })),
+        ContentBlock::ToolResult {
+            call_id,
+            content,
+            is_error,
+        } => Some(WireBlock::ToolResult(ToolResultBlock {
+            tool_use_id: call_id.clone(),
+            content: Some(render_result_content(content)),
+            is_error: is_error.then_some(true),
+            cache_control: None,
+            unknown_fields: UnknownFields::new(),
+        })),
+        ContentBlock::Reasoning {
+            detail, provenance, ..
+        } => render_reasoning(detail, provenance.as_deref()),
+        ContentBlock::Unknown(value) => Some(WireBlock::Unknown(value.clone())),
+        // No audio block exists on this protocol. Reaching here would mean the
+        // request gate let one through; a reply cannot contain one.
+        ContentBlock::Audio { .. } => None,
+    }
+}
+
+/// Reasoning back onto the wire, but only reasoning THIS protocol produced.
+///
+/// `provenance` is what makes that decision possible, and it is what the
+/// field's own doc says it is for: "renderers can reconstitute the native shape
+/// (or know they can't)". A thinking block carries a cryptographic signature
+/// Anthropic verifies, and one produced elsewhere has none that would pass — so
+/// forwarding another provider's reasoning would not preserve it, it would
+/// reject the turn. A summary has no Anthropic shape at all.
+///
+/// Dropping is safe in a way that forwarding is not: Anthropic requires a run
+/// of its OWN thinking blocks to come back untouched, and this returns exactly
+/// those unchanged.
+pub(super) fn render_reasoning(
+    detail: &ReasoningDetail,
+    provenance: Option<&str>,
+) -> Option<WireBlock> {
+    if provenance != Some(Protocol::Anthropic.as_str()) {
+        return None;
+    }
+    match detail {
+        ReasoningDetail::Text { text, signature } => Some(WireBlock::Thinking(ThinkingBlock {
+            thinking: text.clone(),
+            signature: signature.clone(),
+            unknown_fields: UnknownFields::new(),
+        })),
+        ReasoningDetail::Encrypted { data } => {
+            Some(WireBlock::RedactedThinking(RedactedThinkingBlock {
+                data: data.clone(),
+                unknown_fields: UnknownFields::new(),
+            }))
+        }
+        // Anthropic never produces one, so this is unreachable under the
+        // provenance check above and stays a drop rather than a guess.
+        ReasoningDetail::Summary { .. } => None,
+    }
+}
+
+/// A tool result's payload. A lone text block renders as the bare string form,
+/// which is what a result almost always is and what Anthropic's own examples
+/// show; anything else renders as blocks.
+pub(super) fn render_result_content(blocks: &[ContentBlock]) -> ToolResultContent {
+    match blocks {
+        [ContentBlock::Text { text, cache: None }] => ToolResultContent::Text(text.clone()),
+        _ => ToolResultContent::Blocks(render_blocks(blocks)),
+    }
+}
+
+/// The inverse of [`hint_of`]. A hint always renders as a present breakpoint,
+/// never as an explicit `null` — the null form only ever comes back through a
+/// message's retained content.
+pub(super) fn control_of(hint: &Option<types::CacheHint>) -> Option<Option<CacheControl>> {
+    hint.as_ref().map(|hint| Some(cache_control(hint)))
+}
+
+fn zero_usage() -> Usage {
+    Usage {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: None,
+        cache_read_input_tokens: None,
+        output_tokens_details: None,
+        unknown_fields: UnknownFields::new(),
+    }
+}
+
+fn render_usage(usage: &types::Usage, provider: &str) -> Usage {
+    let mut unknown_fields = merged_ext(&usage.ext, provider);
+    let details = match unknown_fields.remove("output_tokens_details") {
+        Some(Value::Object(mut residue)) => {
+            if let Some(tokens) = usage.reasoning_tokens {
+                residue.insert("thinking_tokens".into(), Value::from(tokens));
+            }
+            Some(Some(from_fields(residue)))
+        }
+        Some(Value::Null) => Some(None),
+        // No residue: the breakdown is emitted only if there is a count to put
+        // in it, so a reply that reported none does not grow an empty object.
+        _ => usage.reasoning_tokens.map(|tokens| {
+            Some(OutputTokensDetails {
+                thinking_tokens: Some(Some(tokens as u32)),
+                unknown_fields: UnknownFields::new(),
+            })
+        }),
+    };
+    Usage {
+        // The inverse of `ingest_usage`'s normalization: the gateway count
+        // INCLUDES the cached tokens and this protocol's excludes them. The
+        // retained wire value wins where there is one; subtracting is the
+        // fallback for a reply that arrived on another protocol, and saturates
+        // rather than wrapping because nothing guarantees a hand-built `Usage`
+        // keeps the parts smaller than the whole.
+        input_tokens: match unknown_fields
+            .remove("input_tokens")
+            .and_then(|v| v.as_u64())
+        {
+            Some(retained) => retained as u32,
+            None => usage
+                .input_tokens
+                .unwrap_or(0)
+                .saturating_sub(usage.cache_read_tokens.unwrap_or(0))
+                .saturating_sub(usage.cache_write_tokens.unwrap_or(0)) as u32,
+        },
+        output_tokens: usage.output_tokens.unwrap_or(0) as u32,
+        cache_creation_input_tokens: restore_count(
+            &mut unknown_fields,
+            "cache_creation_input_tokens",
+            usage.cache_write_tokens,
+        ),
+        cache_read_input_tokens: restore_count(
+            &mut unknown_fields,
+            "cache_read_input_tokens",
+            usage.cache_read_tokens,
+        ),
+        output_tokens_details: details,
+        unknown_fields,
+    }
+}
+
+fn from_fields<T: DeserializeOwned + Default>(fields: UnknownFields) -> T {
+    serde_json::from_value(Value::Object(fields)).unwrap_or_default()
+}
+
+pub(super) fn take_string(fields: &mut UnknownFields, key: &str) -> Option<String> {
+    match fields.remove(key) {
+        Some(Value::String(value)) => Some(value),
+        _ => None,
+    }
+}
+
+pub(super) fn take_typed<T: DeserializeOwned>(fields: &mut UnknownFields, key: &str) -> Option<T> {
+    fields
+        .remove(key)
+        .and_then(|value| serde_json::from_value(value).ok())
+}
+
+/// Wire structs are plain serde data; serialization cannot fail.
+pub(super) fn plain<T: serde::Serialize>(value: &T) -> Value {
+    serde_json::to_value(value).expect("wire data serializes")
+}
+
+pub(super) fn object(value: Value) -> UnknownFields {
+    match value {
+        Value::Object(fields) => fields,
+        _ => UnknownFields::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn parse(body: Value) -> Message {
+        serde_json::from_value(body).unwrap()
+    }
+
+    fn round_trip(body: Value) -> Value {
+        plain(&render_response(&ingest_response(parse(body)), "anthropic"))
+    }
+
+    /// Every documented field, unknown fields at every nesting level, and one
+    /// block of each kind — including two the gateway model has no shape for.
+    fn maximal_body() -> Value {
+        json!({
+            "id": "msg_013Zva2CMHLNnXjNJJKqJ2EF",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-opus-5",
+            "content": [
+                {"type": "thinking", "thinking": "Let me count.", "signature": "sig_abc"},
+                {"type": "redacted_thinking", "data": "EncryptedBase64=="},
+                {"type": "text", "text": "There are 3."},
+                {"type": "tool_use", "id": "toolu_01", "name": "counter", "input": {"z": 1, "a": 2}},
+                {"type": "server_tool_use", "id": "srvtoolu_01", "name": "web_search"}
+            ],
+            "stop_reason": "tool_use",
+            "stop_sequence": null,
+            "usage": {
+                "input_tokens": 2095,
+                "output_tokens": 503,
+                "cache_creation_input_tokens": 2051,
+                "cache_read_input_tokens": null,
+                "output_tokens_details": {"thinking_tokens": 120},
+                "service_tier": "standard",
+                "cache_creation": {"ephemeral_5m_input_tokens": 2051}
+            },
+            "container": null
+        })
+    }
+
+    #[test]
+    fn a_maximal_reply_round_trips_byte_for_byte() {
+        let body = maximal_body();
+        assert_eq!(round_trip(body.clone()), body);
+    }
+
+    /// The gateway view, so a change to the mapping fails here rather than only
+    /// inside a round trip that would still pass if BOTH halves changed.
+    #[test]
+    fn the_gateway_view_of_a_maximal_reply() {
+        let response = ingest_response(parse(maximal_body()));
+        assert_eq!(response.id, "msg_013Zva2CMHLNnXjNJJKqJ2EF");
+        assert!(response.created.is_none(), "Anthropic stamps no timestamp");
+        assert_eq!(response.completions.len(), 1, "one reply, one completion");
+
+        let completion = &response.completions[0];
+        assert_eq!(completion.finish_reason, FinishReason::ToolCalls);
+        assert_eq!(completion.finish_reason_raw, "tool_use");
+        assert_eq!(completion.message.role, types::Role::Assistant);
+
+        let blocks = &completion.message.content;
+        assert!(matches!(
+            &blocks[0],
+            ContentBlock::Reasoning {
+                detail: ReasoningDetail::Text { signature: Some(sig), .. },
+                provenance: Some(p),
+                ..
+            } if sig == "sig_abc" && p == "anthropic"
+        ));
+        assert!(matches!(
+            &blocks[1],
+            ContentBlock::Reasoning {
+                detail: ReasoningDetail::Encrypted { data },
+                ..
+            } if data == "EncryptedBase64=="
+        ));
+        assert!(matches!(&blocks[2], ContentBlock::Text { text, .. } if text == "There are 3."));
+        // Key order survives the object → text conversion (preserve_order).
+        assert!(matches!(
+            &blocks[3],
+            ContentBlock::ToolCall { id, arguments, .. }
+                if id == "toolu_01" && arguments.as_str() == r#"{"z":1,"a":2}"#
+        ));
+        // A block warpllm does not model stays whole rather than being
+        // approximated as something it is not.
+        assert!(
+            matches!(&blocks[4], ContentBlock::Unknown(value) if value["type"] == "server_tool_use")
+        );
+    }
+
+    /// The arithmetic, spelled out. Anthropic's `input_tokens` counts only what
+    /// came after the last cache breakpoint; the gateway's counts the WHOLE
+    /// input with the cached parts inside it, so ingest adds them back. Storing
+    /// the wire number unchanged would make the cached counts look like a
+    /// separate pool rather than a breakdown.
+    #[test]
+    fn the_input_count_is_normalized_to_include_the_cached_tokens() {
+        let usage = ingest_usage(
+            serde_json::from_value(json!({
+                "input_tokens": 10,
+                "output_tokens": 20,
+                "cache_creation_input_tokens": 300,
+                "cache_read_input_tokens": 4000,
+                "output_tokens_details": {"thinking_tokens": 7}
+            }))
+            .unwrap(),
+        );
+        assert_eq!(usage.input_tokens, Some(4310), "10 + 300 + 4000");
+        assert_eq!(usage.output_tokens, Some(20));
+        assert_eq!(usage.cache_write_tokens, Some(300));
+        assert_eq!(usage.cache_read_tokens, Some(4000));
+        // Input plus output and nothing else: the cache counts are already
+        // inside the input, so adding them again would double-count them.
+        assert_eq!(usage.total_tokens, Some(4330));
+        // Likewise a breakdown of `output_tokens`, already inside it.
+        assert_eq!(usage.reasoning_tokens, Some(7));
+    }
+
+    /// THE reason the normalization exists, checked where it is observable: at
+    /// the OpenAI surface a caller actually reads.
+    ///
+    /// Without it a cached reply comes out self-contradicting — `cached_tokens`
+    /// larger than the `prompt_tokens` it is a subset of, and a `total_tokens`
+    /// that is not `prompt + completion` — and every one of those numbers feeds
+    /// cost accounting that has no way to notice.
+    #[test]
+    fn a_cached_reply_reports_consistent_openai_usage() {
+        let reply = ingest_response(parse(json!({
+            "id": "msg_1", "type": "message", "role": "assistant",
+            "model": "claude-opus-5", "content": [{"type": "text", "text": "hi"}],
+            "stop_reason": "end_turn", "stop_sequence": null,
+            "usage": {
+                "input_tokens": 21,
+                "output_tokens": 16,
+                "cache_creation_input_tokens": 1024,
+                "cache_read_input_tokens": 8192
+            }
+        })));
+        let openai = plain(
+            &crate::gateway::openai_compat::api::chat_completions::render_response(
+                &reply,
+                "anthropic",
+            ),
+        );
+        let usage = &openai["usage"];
+        assert_eq!(usage["prompt_tokens"], json!(9237), "21 + 1024 + 8192");
+        assert_eq!(usage["completion_tokens"], json!(16));
+        assert_eq!(
+            usage["total_tokens"],
+            json!(9253),
+            "OpenAI's total is prompt + completion"
+        );
+        assert_eq!(
+            usage["total_tokens"].as_u64().unwrap(),
+            usage["prompt_tokens"].as_u64().unwrap() + usage["completion_tokens"].as_u64().unwrap()
+        );
+        // The cached count is a SUBSET of the prompt, so it cannot exceed it.
+        let cached = usage["prompt_tokens_details"]["cached_tokens"]
+            .as_u64()
+            .unwrap();
+        assert_eq!(cached, 8192);
+        assert!(cached <= usage["prompt_tokens"].as_u64().unwrap());
+    }
+
+    /// ...and the normalization is reversible, so an Anthropic round trip still
+    /// hands back the exclusive number the protocol actually uses.
+    #[test]
+    fn the_wire_input_count_survives_the_normalization() {
+        let body = json!({
+            "id": "msg_1", "type": "message", "role": "assistant",
+            "model": "claude-opus-5", "content": [],
+            "stop_reason": "end_turn", "stop_sequence": null,
+            "usage": {
+                "input_tokens": 21, "output_tokens": 16,
+                "cache_creation_input_tokens": 1024,
+                "cache_read_input_tokens": 8192
+            }
+        });
+        assert_eq!(round_trip(body.clone()), body);
+    }
+
+    /// An explicit `null` count is not an absent one, and the gateway's plain
+    /// `Option` cannot hold the difference — so it rides the residue. Without
+    /// this the null comes back as a missing key.
+    #[test]
+    fn an_explicit_null_count_survives_the_round_trip() {
+        let body = json!({
+            "id": "msg_1", "type": "message", "role": "assistant", "model": "claude-opus-5",
+            "content": [], "stop_reason": "end_turn", "stop_sequence": null,
+            "usage": {
+                "input_tokens": 1, "output_tokens": 2,
+                "cache_creation_input_tokens": null,
+                "cache_read_input_tokens": null,
+                "output_tokens_details": {"thinking_tokens": null}
+            }
+        });
+        assert_eq!(round_trip(body.clone()), body);
+    }
+
+    /// A reply that reports no breakdown must not grow an empty one.
+    #[test]
+    fn an_absent_breakdown_stays_absent() {
+        let body = json!({
+            "id": "msg_1", "type": "message", "role": "assistant", "model": "claude-opus-5",
+            "content": [{"type": "text", "text": "hi"}],
+            "stop_reason": "end_turn", "stop_sequence": null,
+            "usage": {"input_tokens": 1, "output_tokens": 2}
+        });
+        assert_eq!(round_trip(body.clone()), body);
+    }
+
+    /// Every row of the table, including the two the plan for this work did not
+    /// have and the one that must NOT read as a finished answer.
+    #[test]
+    fn the_stop_reason_table() {
+        let rows = [
+            ("end_turn", FinishReason::Stop),
+            ("stop_sequence", FinishReason::Stop),
+            ("max_tokens", FinishReason::Length),
+            ("model_context_window_exceeded", FinishReason::Length),
+            ("tool_use", FinishReason::ToolCalls),
+            ("refusal", FinishReason::ContentFilter),
+            ("pause_turn", FinishReason::Other),
+            ("something_new", FinishReason::Other),
+        ];
+        for (raw, expected) in rows {
+            assert_eq!(finish_reason(Some(raw)), expected, "{raw}");
+        }
+        assert_eq!(finish_reason(None), FinishReason::Other);
+    }
+
+    /// `pause_turn` on its own, because the cost of getting it wrong is not a
+    /// mislabelled enum: a caller that reads it as `Stop` presents an
+    /// interrupted turn as the finished answer and never continues it.
+    #[test]
+    fn a_paused_turn_is_not_a_stop() {
+        assert_ne!(finish_reason(Some("pause_turn")), FinishReason::Stop);
+    }
+
+    /// A `stop_reason` Anthropic adds tomorrow keeps its exact spelling, which
+    /// is what `finish_reason_raw` is for — the enum is for matching, the
+    /// string is authoritative.
+    #[test]
+    fn an_unknown_stop_reason_keeps_its_spelling() {
+        let body = json!({
+            "id": "msg_1", "type": "message", "role": "assistant", "model": "claude-opus-5",
+            "content": [], "stop_reason": "model_context_window_exceeded", "stop_sequence": null,
+            "usage": {"input_tokens": 1, "output_tokens": 2}
+        });
+        let response = ingest_response(parse(body.clone()));
+        assert_eq!(
+            response.completions[0].finish_reason_raw,
+            "model_context_window_exceeded"
+        );
+        assert_eq!(round_trip(body.clone()), body);
+    }
+
+    /// Reasoning from ANOTHER provider must not be forwarded: it carries no
+    /// signature Anthropic would accept, so sending it rejects the whole turn
+    /// rather than preserving anything.
+    #[test]
+    fn only_anthropics_own_reasoning_renders_back() {
+        let detail = ReasoningDetail::Text {
+            text: "thinking".into(),
+            signature: Some("sig".into()),
+        };
+        assert!(render_reasoning(&detail, Some("anthropic")).is_some());
+        assert!(render_reasoning(&detail, Some("openai_compat")).is_none());
+        assert!(render_reasoning(&detail, None).is_none());
+        assert!(
+            render_reasoning(
+                &ReasoningDetail::Summary {
+                    summary: "s".into()
+                },
+                Some("anthropic")
+            )
+            .is_none()
+        );
+    }
+
+    /// A KNOWN block carrying residue the gateway blocks cannot hold. This is
+    /// the case promotion alone loses: the block parses, so it never reaches
+    /// the `Unknown` arm that would have kept it whole, and the gateway's
+    /// `ContentBlock` has no `ext` to put a citation or a vendor field in.
+    /// Retaining the array is what holds it — and the explicit `null` on a
+    /// three-state field is the same loss in miniature.
+    #[test]
+    fn residue_on_a_known_block_survives_the_round_trip() {
+        let body = json!({
+            "id": "msg_1", "type": "message", "role": "assistant", "model": "claude-opus-5",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "The grass is green.",
+                    "citations": [{
+                        "type": "char_location",
+                        "cited_text": "The grass is green.",
+                        "document_index": 0,
+                        "start_char_index": 0,
+                        "end_char_index": 19
+                    }]
+                },
+                {
+                    "type": "image",
+                    "source": {"type": "url", "url": "https://e.com/a.png", "vendor_hint": 1},
+                    "cache_control": null
+                },
+                {"type": "text", "text": "and more", "cache_control": null}
+            ],
+            "stop_reason": "end_turn", "stop_sequence": null,
+            "usage": {"input_tokens": 1, "output_tokens": 2}
+        });
+        assert_eq!(round_trip(body.clone()), body);
+    }
+
+    /// The other half of the retention design, and the reason the test above is
+    /// not the only one that matters: a reply with NO residue — one built by
+    /// hand, or ingested from another protocol — must still render its blocks
+    /// from the gateway form. Without this, `render_blocks` could break
+    /// entirely and every round-trip test would still pass, because retention
+    /// answers before it is ever called.
+    #[test]
+    fn a_reply_with_no_retained_content_still_renders_its_blocks() {
+        let response = types::ChatResponse {
+            id: "msg_1".into(),
+            model: "claude-opus-5".into(),
+            created: None,
+            completions: vec![types::Completion {
+                message: types::Message {
+                    role: types::Role::Assistant,
+                    content: vec![
+                        ContentBlock::Text {
+                            text: "hi".into(),
+                            cache: None,
+                        },
+                        ContentBlock::ToolCall {
+                            id: "toolu_1".into(),
+                            name: "counter".into(),
+                            arguments: RawJson::new(r#"{"z":1}"#),
+                        },
+                    ],
+                    ext: types::ProviderExt::new(),
+                },
+                finish_reason: FinishReason::ToolCalls,
+                finish_reason_raw: "tool_use".into(),
+                ext: types::ProviderExt::new(),
+            }],
+            usage: None,
+            ext: types::ProviderExt::new(),
+            source: None,
+        };
+        assert_eq!(
+            plain(&render_response(&response, "anthropic"))["content"],
+            json!([
+                {"type": "text", "text": "hi"},
+                {"type": "tool_use", "id": "toolu_1", "name": "counter", "input": {"z": 1}}
+            ])
+        );
+    }
+
+    /// A source shape the gateway model cannot name keeps its whole wire block
+    /// rather than being flattened into something it is not.
+    #[test]
+    fn a_text_source_document_stays_whole() {
+        let body = json!({
+            "id": "msg_1", "type": "message", "role": "assistant", "model": "claude-opus-5",
+            "content": [{
+                "type": "document",
+                "source": {"type": "text", "media_type": "text/plain", "data": "grass is green"},
+                "title": "notes"
+            }],
+            "stop_reason": "end_turn", "stop_sequence": null,
+            "usage": {"input_tokens": 1, "output_tokens": 2}
+        });
+        let response = ingest_response(parse(body.clone()));
+        assert!(matches!(
+            &response.completions[0].message.content[0],
+            ContentBlock::Unknown(value) if value["source"]["type"] == "text"
+        ));
+        assert_eq!(round_trip(body.clone()), body);
+    }
+}

--- a/crates/warpllm/src/gateway/anthropic/api/mod.rs
+++ b/crates/warpllm/src/gateway/anthropic/api/mod.rs
@@ -1,0 +1,4 @@
+//! One module per API surface Anthropic serves, named for its
+//! [`Api`](crate::Api) variant.
+
+pub(crate) mod messages;

--- a/crates/warpllm/src/gateway/anthropic/error.rs
+++ b/crates/warpllm/src/gateway/anthropic/error.rs
@@ -1,0 +1,359 @@
+//! What an Anthropic failure MEANS: an error envelope in, warpllm's canonical
+//! failure form out.
+//!
+//! One direction only. Its [`openai_compat`](crate::gateway::openai_compat::error)
+//! counterpart has an egress half because warpllm ANSWERS in that protocol;
+//! nothing answers in this one, so there is nothing here to render.
+//!
+//! Sibling of [`api`](super::api) rather than a child of one of its surfaces:
+//! the envelope is protocol-wide, shared by every endpoint Anthropic serves.
+//!
+//! # Two signals, not three
+//!
+//! [`ErrorMapper`] offers `from_code`, `from_status` and `from_type`, and this
+//! protocol implements only the last two. Anthropic sends **no `code`** — the
+//! envelope is `{type, message}` and nothing else — so a distinction OpenAI
+//! draws with a slug has to be drawn from the status here or not at all.
+//!
+//! That is not a gap to work around. `classify` asks the strongest signal
+//! first, and with the strongest one absent the ordering does more work than it
+//! does next door: `invalid_request_error` is Anthropic's documented catch-all
+//! for "other 4XX status codes not listed", so reading the family before the
+//! status would report a 402 billing failure as a malformed request. The status
+//! table below is deliberately the wider of the two.
+
+use std::time::Duration;
+
+use serde_json::Value;
+
+use crate::error::Error;
+use crate::gateway::error::{Classified, ErrorMapper, MatchesProtocol, classify};
+use crate::gateway::types::ProviderError;
+
+/// Anthropic error bodies look like
+/// `{"type": "error", "error": {"type": …, "message": …}, "request_id": …}`.
+/// Unparseable bodies fall back to the raw text.
+///
+/// `retry_after` comes from the response HEADERS, which is the only place it
+/// exists. `request_id` is read from the header too, but Anthropic also repeats
+/// it in the BODY — so unlike its openai_compat counterpart this one falls back
+/// to the body's copy, which is what a body read from a log still has.
+pub(crate) fn error_from_body(
+    provider: &'static str,
+    status: u16,
+    body: &str,
+    retry_after: Option<Duration>,
+    request_id: Option<String>,
+) -> Error {
+    let parsed: Option<Value> = serde_json::from_str(body).ok();
+    let error = parsed.as_ref().map(|v| &v["error"]);
+    let field = |name: &str| error.and_then(|e| e[name].as_str());
+    // No provider on this protocol has a vocabulary of its own to consult; see
+    // this module's docs on why there is no `provider_overrides` directory.
+    let classified = classify(&MatchesProtocol, &Anthropic, status, field("type"), None);
+    classified(Box::new(ProviderError {
+        provider,
+        status,
+        message: field("message")
+            .map(str::to_string)
+            .unwrap_or_else(|| body.to_string()),
+        error_type: field("type").map(str::to_string),
+        // The field this protocol does not have. Left `None` rather than
+        // filled from `type`, which is the FAMILY and is already reported as
+        // one — copying it across would invent a per-failure slug Anthropic
+        // never sent and make the two fields look like corroboration.
+        provider_code: None,
+        retry_after,
+        request_id: request_id.or_else(|| {
+            parsed
+                .as_ref()
+                .and_then(|v| v["request_id"].as_str())
+                .map(str::to_string)
+        }),
+        raw_body: ProviderError::bounded(body),
+    }))
+}
+
+/// The error vocabulary every backend speaking this protocol shares.
+///
+/// Deliberately does not sniff `message`, for the reason its openai_compat
+/// counterpart states: free text is what providers reword without notice, and a
+/// substring match on it misclassifies silently.
+pub(super) struct Anthropic;
+
+impl ErrorMapper for Anthropic {
+    /// Anthropic publishes one status per failure and a matching `type` for
+    /// each, so the status table is complete rather than the residue it is on a
+    /// protocol with per-failure codes.
+    ///
+    /// **529** is the one that has to be here. It is Anthropic's own overload
+    /// status, outside any range `classify`'s residual reads — 5xx there stops
+    /// at 599 but means [`Error::ServerError`], so a 529 left unmapped would
+    /// report a retriable overload as an unattributed server fault and lose the
+    /// one thing a caller does about it.
+    ///
+    /// **402** is [`Error::QuotaExceeded`], not [`Error::RateLimited`]: the
+    /// account has a billing problem, and backing off does not fix one. This is
+    /// the distinction OpenAI draws with an `insufficient_quota` code, and the
+    /// reason the split matters even more here — the status is the ONLY place
+    /// it can be drawn.
+    ///
+    /// **413** is [`Error::ContextLengthExceeded`]. Anthropic's is a byte limit
+    /// on the request rather than a token limit on the context, and they are
+    /// not the same measure — but they are the same PROBLEM to the caller, who
+    /// fixes both by sending less, and there is no other variant that says so.
+    ///
+    /// **400, 500 and 504 are absent**, and adding them would be wrong:
+    /// `classify`'s residual already reads them as `InvalidRequest` and
+    /// `ServerError`, and naming them here would only outrank the `type` family
+    /// for the statuses whose family is most likely to say something more
+    /// specific.
+    ///
+    /// **404 is [`Error::ModelNotFound`] because a model is the only resource
+    /// any reachable path asks Anthropic to find** — NOT because 404 means
+    /// that. Anthropic answers an inaccessible file id with the same status and
+    /// the same `not_found_error` family, and the two are separable only by the
+    /// free-text `message`, which this mapper refuses to read for the reason
+    /// stated above it. What makes the mapping true is that a file id cannot be
+    /// sent: a foreign one is refused in `request::render_source`, and a native
+    /// one needs an Anthropic-shaped ingress that does not exist. Both halves
+    /// are pinned by `a_file_reference_cannot_reach_anthropic` below, so this
+    /// comment cannot quietly become false.
+    ///
+    /// Files API support is what breaks it, and that work owes this mapping a
+    /// second look. Delineating them then means using what warpllm SENT — it
+    /// knows whether the request carried a file reference — never what
+    /// Anthropic wrote back.
+    fn from_status(&self, status: u16) -> Option<Classified> {
+        Some(match status {
+            401 => Error::Authentication,
+            402 => Error::QuotaExceeded,
+            403 => Error::PermissionDenied,
+            404 => Error::ModelNotFound,
+            413 => Error::ContextLengthExceeded,
+            429 => Error::RateLimited,
+            529 => Error::Overloaded,
+            _ => return None,
+        })
+    }
+
+    /// The `type` family — the weaker of the two signals this protocol has, and
+    /// the one that only decides a failure whose status said nothing.
+    ///
+    /// In practice that is a mid-stream `error` event, which arrives with no
+    /// status at all because the HTTP exchange already answered 200. Every
+    /// family below is reachable that way, which is why the table mirrors the
+    /// status one rather than stopping at the families a 4xx can carry.
+    fn from_type(&self, error_type: &str) -> Option<Classified> {
+        Some(match error_type {
+            "authentication_error" => Error::Authentication,
+            "billing_error" => Error::QuotaExceeded,
+            "permission_error" => Error::PermissionDenied,
+            "not_found_error" => Error::ModelNotFound,
+            "request_too_large" => Error::ContextLengthExceeded,
+            "rate_limit_error" => Error::RateLimited,
+            "overloaded_error" => Error::Overloaded,
+            // A 504 from Anthropic's own edge. NOT `Error::StreamStalled`,
+            // however closely the words match: that variant is warpllm
+            // reporting that IT stopped waiting, carries the timeout it
+            // enforced, and holds no provider evidence — so it cannot even be
+            // constructed here. An upstream that timed out and said so is an
+            // unattributed 5xx, which is what `ServerError` means.
+            "api_error" | "timeout_error" => Error::ServerError,
+            // Anthropic's catch-all, and the reason it is read LAST: it is
+            // documented as covering "other 4XX status codes not listed",
+            // which makes it the family that means least.
+            "invalid_request_error" => Error::InvalidRequest,
+            // `conflict_error` (409) is deliberately absent, and it is the one
+            // family here that falls all the way through to `Error::Unknown` —
+            // `classify`'s residual reads 400 and 422, not the whole 4xx range.
+            // That is the honest answer rather than a gap: a conflict means a
+            // resource changed underneath the request, which nothing warpllm
+            // sends to `/messages` can do, and the nearest variant
+            // (`InvalidRequest`) would tell a caller to go fix a payload that
+            // is fine. `Unknown` says nothing and keeps the status and the
+            // family intact for whoever reads it.
+            _ => return None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn envelope(error_type: &str, message: &str) -> String {
+        serde_json::json!({
+            "type": "error",
+            "error": {"type": error_type, "message": message},
+            "request_id": "req_body"
+        })
+        .to_string()
+    }
+
+    fn coded(status: u16, body: &str) -> &'static str {
+        error_from_body("anthropic", status, body, None, None).code()
+    }
+
+    /// What makes `404 => ModelNotFound` true, tested where the claim is made.
+    ///
+    /// Anthropic answers an inaccessible file id with the identical status and
+    /// family, so the mapping is honest only while a file id cannot be sent.
+    /// This pins the half that is code — the request renderer refuses a file
+    /// reference that did not arrive with this protocol's own retained content
+    /// — and it is the test that must fail when Files API support arrives, so
+    /// that work cannot inherit a mapping that has quietly become a guess.
+    ///
+    /// The other half is an absence (no Anthropic-shaped ingress exists to
+    /// produce a native reference) and is pinned next door, by
+    /// `request::tests::an_anthropic_native_file_reference_still_round_trips`.
+    #[test]
+    fn a_file_reference_cannot_reach_anthropic() {
+        use crate::gateway::anthropic::api::messages::render_request;
+        use crate::gateway::types::{self, ContentBlock, MediaSource};
+
+        let request = types::ChatRequest {
+            model: "claude-opus-5".into(),
+            messages: vec![types::Message {
+                role: crate::gateway::types::Role::User,
+                content: vec![ContentBlock::Document {
+                    source: MediaSource::ProviderFile {
+                        id: "file_011CNha8iCJcU1wXNR6q4V8w".into(),
+                    },
+                    title: None,
+                    cache: None,
+                }],
+                ext: types::ProviderExt::new(),
+            }],
+            ..Default::default()
+        };
+        let error = render_request(&request, "anthropic", Some(64)).unwrap_err();
+        assert!(
+            matches!(error, Error::InvalidInput(_)),
+            "a file reference reached the wire, so a 404 can no longer be read \
+             as a missing MODEL: {error}"
+        );
+    }
+
+    /// Every documented status, in one place, so a change to the table is a
+    /// change to this list.
+    #[test]
+    fn the_documented_status_table() {
+        let cases = [
+            (400, "invalid_request_error", "provider_invalid_request"),
+            (401, "authentication_error", "authentication"),
+            (402, "billing_error", "quota_exceeded"),
+            (403, "permission_error", "permission_denied"),
+            (404, "not_found_error", "model_not_found"),
+            // Deliberately unclassified — see `from_type`. Pinned so that
+            // giving it a meaning later is a visible decision.
+            (409, "conflict_error", "provider_unknown"),
+            (413, "request_too_large", "context_length_exceeded"),
+            (429, "rate_limit_error", "rate_limited"),
+            (500, "api_error", "provider_server_error"),
+            (504, "timeout_error", "provider_server_error"),
+            (529, "overloaded_error", "overloaded"),
+        ];
+        for (status, error_type, expected) in cases {
+            assert_eq!(
+                coded(status, &envelope(error_type, "boom")),
+                expected,
+                "{status} {error_type}"
+            );
+        }
+    }
+
+    /// 529 is outside `classify`'s 5xx residual, so an unmapped one would
+    /// report a retriable overload as an unattributed server fault. Pinned on
+    /// its own because it is the single reason `from_status` exists at all.
+    #[test]
+    fn a_529_is_an_overload_rather_than_a_server_fault() {
+        assert_eq!(coded(529, "not json at all"), "overloaded");
+    }
+
+    /// A mid-stream `error` event has no status to read — the HTTP exchange
+    /// already answered 200 — so the family is the only signal left.
+    #[test]
+    fn a_family_decides_a_failure_that_arrived_after_a_200() {
+        assert_eq!(
+            coded(200, &envelope("overloaded_error", "busy")),
+            "overloaded"
+        );
+        assert_eq!(
+            coded(200, &envelope("billing_error", "unpaid")),
+            "quota_exceeded"
+        );
+    }
+
+    /// The catch-all family must not outrank a status that says something
+    /// specific. Anthropic documents `invalid_request_error` as covering "other
+    /// 4XX status codes not listed", so a 402 carrying it is a BILLING failure
+    /// wearing the generic family — and reporting it as a malformed request
+    /// would send the caller to fix a payload that is fine.
+    #[test]
+    fn a_status_outranks_the_catch_all_family() {
+        assert_eq!(
+            coded(402, &envelope("invalid_request_error", "payment required")),
+            "quota_exceeded"
+        );
+    }
+
+    /// A family Anthropic adds tomorrow must not be guessed at: the status
+    /// answers, and the raw family survives on the error for a caller to read.
+    #[test]
+    fn an_unknown_family_falls_back_to_http_semantics() {
+        let error = error_from_body(
+            "anthropic",
+            418,
+            &envelope("quantum_error", "?"),
+            None,
+            None,
+        );
+        assert_eq!(error.code(), "provider_unknown");
+        assert!(error.to_string().contains('?'), "{error}");
+    }
+
+    /// The message is the body's when there is no envelope to read one from —
+    /// an HTML error page from a proxy in front of the API, say.
+    #[test]
+    fn an_unparseable_body_survives_as_the_message() {
+        let error = error_from_body("anthropic", 502, "<html>bad gateway</html>", None, None);
+        assert_eq!(error.code(), "provider_server_error");
+        assert!(error.to_string().contains("bad gateway"), "{error}");
+    }
+
+    /// This protocol has no `code`, and the field must stay empty rather than
+    /// be filled from the family — which is already reported as the family.
+    #[test]
+    fn no_code_is_invented_from_the_family() {
+        let Error::RateLimited(details) = error_from_body(
+            "anthropic",
+            429,
+            &envelope("rate_limit_error", "slow down"),
+            None,
+            None,
+        ) else {
+            panic!("expected a rate limit");
+        };
+        assert_eq!(details.error_type.as_deref(), Some("rate_limit_error"));
+        assert_eq!(details.provider_code, None);
+    }
+
+    /// The header is authoritative, and the body's copy is the fallback — which
+    /// is the whole reason Anthropic repeating it in the body is worth reading.
+    #[test]
+    fn the_request_id_falls_back_to_the_body() {
+        let body = envelope("not_found_error", "nope");
+        let from_body = error_from_body("anthropic", 404, &body, None, None);
+        let Error::ModelNotFound(details) = from_body else {
+            panic!("expected a model-not-found");
+        };
+        assert_eq!(details.request_id.as_deref(), Some("req_body"));
+
+        let from_header = error_from_body("anthropic", 404, &body, None, Some("req_header".into()));
+        let Error::ModelNotFound(details) = from_header else {
+            panic!("expected a model-not-found");
+        };
+        assert_eq!(details.request_id.as_deref(), Some("req_header"));
+    }
+}

--- a/crates/warpllm/src/gateway/anthropic/mod.rs
+++ b/crates/warpllm/src/gateway/anthropic/mod.rs
@@ -1,0 +1,239 @@
+//! Conversions between Anthropic's Messages wire shapes
+//! ([`crate::protocol::anthropic`]) and the gateway forms, plus the vocabulary
+//! glue both directions share.
+//!
+//! Laid out like its [`openai_compat`](super::openai_compat) sibling, and for
+//! the same reasons:
+//!
+//! * [`api`] — one module per API surface, named for its [`Api`](crate::Api)
+//!   variant.
+//! * [`error`] — the error envelope's meaning, protocol-wide rather than
+//!   per-surface.
+//!
+//! What is NOT here is a `provider_overrides` directory. `anthropic` is the
+//! only provider speaking this protocol, and it matches it by definition — a
+//! provider cannot diverge from a protocol it defines. #24 (Bedrock) and #25
+//! (Vertex) are where that grows, and both differ in transport and auth rather
+//! than in vocabulary.
+//!
+//! # The one asymmetry with openai_compat
+//!
+//! That protocol is one warpllm both SPEAKS and ANSWERS IN: callers program
+//! against an OpenAI-compatible surface, so its error module has an egress half
+//! that renders a warpllm failure as OpenAI would have reported it. Anthropic
+//! is egress-only — warpllm speaks it to a provider and answers its own callers
+//! in their protocol — so there is no counterpart here. An Anthropic-shaped
+//! INGRESS would add one; that is deliberately out of scope.
+
+pub(crate) mod api;
+pub(crate) mod error;
+
+use serde_json::Value;
+
+use crate::gateway::types::{CacheHint, ProviderExt, Role};
+use crate::protocol::UnknownFields;
+use crate::protocol::anthropic::messages::types::CacheControl;
+use crate::types::Protocol;
+
+/// Flattens the ext bags relevant to this render target: the protocol
+/// namespace first, overlaid by the provider's own. Other providers'
+/// namespaces are ignored — a field meant for one provider never leaks into
+/// another.
+///
+/// A near-copy of `openai_compat::merged_ext`, deliberately NOT a shared helper
+/// taking a [`Protocol`]. Generalizing working code to serve a second caller is
+/// a refactor of the first, and these two will diverge before they converge:
+/// this protocol has one provider today and the other has five. Revisit at the
+/// third.
+///
+/// One quirk this protocol has and that one does not: the protocol name and its
+/// only provider's name are the SAME string, so both loop passes read the same
+/// bag and the overlay is a no-op. That is what `ProviderExt`'s doc means by
+/// provider names shadowing protocol names being reserved — here the shadow is
+/// intended, since a field addressed to "anthropic" is addressed to both.
+///
+/// It is intended only HERE, though, which is why [`Protocol::may_read`] guards
+/// the loop rather than the shadow being left to the name alone: the same bag
+/// read by a renderer for another protocol is that protocol reaching into this
+/// one's residue. The guard is a no-op on this protocol's own name and stops
+/// the symmetric case, a provider named `openai_compat`.
+pub(crate) fn merged_ext(ext: &ProviderExt, provider: &str) -> UnknownFields {
+    let mut merged = UnknownFields::new();
+    for namespace in [Protocol::Anthropic.as_str(), provider] {
+        if !Protocol::Anthropic.may_read(namespace) {
+            continue;
+        }
+        if let Some(Value::Object(fields)) = ext.get(namespace) {
+            for (key, value) in fields {
+                merged.insert(key.clone(), value.clone());
+            }
+        }
+    }
+    merged
+}
+
+/// The inverse of [`merged_ext`] for this protocol's own namespace. An empty
+/// bag is omitted rather than stored as an empty object.
+pub(crate) fn namespaced(fields: UnknownFields) -> ProviderExt {
+    let mut ext = ProviderExt::new();
+    if !fields.is_empty() {
+        ext.insert(Protocol::Anthropic.as_str().into(), Value::Object(fields));
+    }
+    ext
+}
+
+/// Wire role string → gateway role, plus the raw spelling when it is one this
+/// protocol does not define.
+///
+/// Anthropic has exactly TWO roles. There is no `system` — the system prompt is
+/// a top-level parameter — and no `tool`, because a tool result is a block
+/// inside a user turn. So the gateway's four roles do not map onto this
+/// protocol's two, and the difference is handled by the request conversion
+/// rather than smuggled through a role table: see `request::ingest_message` for
+/// how a user turn carrying only tool results becomes [`Role::Tool`].
+pub(crate) fn role_from_wire(role: String) -> (Role, Option<String>) {
+    match role.as_str() {
+        "user" => (Role::User, None),
+        "assistant" => (Role::Assistant, None),
+        _ => (Role::User, Some(role)),
+    }
+}
+
+/// Gateway role → Anthropic's two-role vocabulary.
+///
+/// [`Role::Tool`] is `"user"`: Anthropic carries a tool result as a
+/// `tool_result` BLOCK inside a user turn, which is what `render_request`'s
+/// merge produces.
+///
+/// [`Role::System`] never reaches here. `render_request` hoists a leading
+/// system message into the top-level `system` parameter and REFUSES one that
+/// appears later, so by the time messages are rendered none is left — and the
+/// arm is `"user"` only because that is the one non-assistant role this
+/// protocol has, not because mapping a system prompt onto a user turn would be
+/// acceptable. That refusal is the reason this function has nothing to decide.
+pub(crate) fn role_to_wire(role: Role) -> &'static str {
+    match role {
+        Role::Assistant => "assistant",
+        Role::System | Role::User | Role::Tool => "user",
+    }
+}
+
+/// Anthropic's cache breakpoint → the gateway's.
+///
+/// Only `ttl` survives, because only `ttl` has a field: the `type`
+/// (`"ephemeral"`) and anything else on the object are residue. That is lossy
+/// in one direction and harmless in practice — a same-protocol render replays
+/// the message's retained wire content rather than rebuilding from the hint, so
+/// the residue is only unreachable when the request came from ANOTHER protocol,
+/// which had no `type` to lose.
+pub(crate) fn cache_hint(control: &CacheControl) -> CacheHint {
+    CacheHint {
+        ttl: control.ttl.clone(),
+    }
+}
+
+/// The inverse of [`cache_hint`]. `type` is `"ephemeral"` because that is the
+/// only value Anthropic documents and a breakpoint must name one.
+pub(crate) fn cache_control(hint: &CacheHint) -> CacheControl {
+    CacheControl {
+        r#type: "ephemeral".into(),
+        ttl: hint.ttl.clone(),
+        unknown_fields: UnknownFields::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    /// The isolation claim in [`merged_ext`]'s doc, at the function level: a
+    /// field addressed to one provider must not reach another.
+    #[test]
+    fn merged_ext_ignores_other_providers() {
+        let mut ext = ProviderExt::new();
+        ext.insert(
+            Protocol::Anthropic.as_str().into(),
+            json!({"top_k": 40, "metadata": {"user_id": "u1"}}),
+        );
+        ext.insert("openai_compat".into(), json!({"seed": 7}));
+        ext.insert("deepseek".into(), json!({"ds_only": 2}));
+
+        let merged = merged_ext(&ext, "anthropic");
+        assert_eq!(merged["top_k"], json!(40));
+        assert_eq!(merged["metadata"], json!({"user_id": "u1"}));
+        assert!(
+            merged.get("seed").is_none(),
+            "the openai_compat namespace leaked into an Anthropic render"
+        );
+        assert!(merged.get("ds_only").is_none());
+    }
+
+    /// The shadowing case [`merged_ext`]'s doc calls out: protocol and provider
+    /// are one string here, so reading the bag twice must be a no-op rather
+    /// than something that duplicates or drops.
+    #[test]
+    fn the_shared_protocol_and_provider_name_reads_one_bag() {
+        let mut ext = ProviderExt::new();
+        ext.insert("anthropic".into(), json!({"top_k": 40}));
+        assert_eq!(merged_ext(&ext, "anthropic"), merged_ext(&ext, "other"));
+    }
+
+    /// The mirror of the openai_compat case: this renderer must not read that
+    /// protocol's bag either, however the provider is named. Without the guard
+    /// a provider literally called `openai_compat` would pull OpenAI's residue
+    /// into an Anthropic body.
+    #[test]
+    fn a_provider_named_for_another_protocol_does_not_leak_its_bag() {
+        let mut ext = ProviderExt::new();
+        ext.insert(
+            Protocol::OpenAiCompat.as_str().into(),
+            json!({"seed": 7, "content": "a string, not blocks"}),
+        );
+        ext.insert(Protocol::Anthropic.as_str().into(), json!({"top_k": 40}));
+
+        let merged = merged_ext(&ext, Protocol::OpenAiCompat.as_str());
+        assert!(merged.get("seed").is_none());
+        assert!(merged.get("content").is_none());
+        assert_eq!(merged["top_k"], json!(40));
+    }
+
+    #[test]
+    fn namespaced_omits_an_empty_bag() {
+        assert!(namespaced(UnknownFields::new()).is_empty());
+        assert_eq!(
+            namespaced(json!({"top_k": 40}).as_object().unwrap().clone())["anthropic"],
+            json!({"top_k": 40})
+        );
+    }
+
+    /// The two roles this protocol names round trip with no residue. The other
+    /// two gateway roles deliberately do NOT — they have no wire spelling here
+    /// — which is why this asserts over a pair rather than over [`Role`].
+    #[test]
+    fn the_two_wire_roles_round_trip_with_no_residue() {
+        for role in [Role::User, Role::Assistant] {
+            assert_eq!(role_from_wire(role_to_wire(role).to_string()), (role, None));
+        }
+    }
+
+    #[test]
+    fn an_unknown_wire_role_keeps_its_raw_spelling() {
+        let (role, raw) = role_from_wire("developer".into());
+        assert_eq!(role, Role::User);
+        assert_eq!(raw.as_deref(), Some("developer"));
+    }
+
+    /// A hint with no ttl still renders a breakpoint: the ttl is what is
+    /// optional, the breakpoint itself is the whole point of the object.
+    #[test]
+    fn a_cache_hint_round_trips_through_the_wire_shape() {
+        for ttl in [Some("1h".to_string()), None] {
+            let hint = CacheHint { ttl: ttl.clone() };
+            let control = cache_control(&hint);
+            assert_eq!(control.r#type, "ephemeral");
+            assert_eq!(cache_hint(&control).ttl, ttl);
+        }
+    }
+}

--- a/crates/warpllm/src/gateway/mod.rs
+++ b/crates/warpllm/src/gateway/mod.rs
@@ -22,6 +22,14 @@
 //! the wire shapes instead would make `protocol` depend on the gateway and
 //! leave a per-provider adapter nowhere clean to sit.
 
+// Nothing routes to Anthropic yet: `client.rs` picks an exchange by the routed
+// model's surface, and no surface names this protocol until the registry and
+// the dispatch land. Being unreachable is what makes these conversions safe to
+// land ahead of that — but it also means every item here reads as dead. Drop
+// this attribute on the change that wires the client; it should stop being
+// needed there.
+#[allow(dead_code)]
+pub(crate) mod anthropic;
 pub(crate) mod error;
 pub(crate) mod openai_compat;
 pub(crate) mod types;

--- a/crates/warpllm/src/gateway/openai_compat/api/chat_completions/response.rs
+++ b/crates/warpllm/src/gateway/openai_compat/api/chat_completions/response.rs
@@ -274,12 +274,50 @@ fn render_choice(completion: &types::Completion, position: usize, provider: &str
         .and_then(|v| v.as_u64())
         .unwrap_or(position as u64) as u32;
     Choice {
-        finish_reason: completion.finish_reason_raw.clone(),
+        finish_reason: render_finish_reason(
+            &completion.finish_reason_raw,
+            completion.finish_reason,
+        ),
         index,
         logprobs: take_typed(&mut unknown_fields, "logprobs"),
         message: render_message(&completion.message, provider),
         unknown_fields,
     }
+}
+
+/// The finish reason as THIS protocol spells it.
+///
+/// `finish_reason_raw` is authoritative — it is what the provider actually said
+/// — but only where this protocol shares the vocabulary it was said in. Once a
+/// second protocol can reach a caller here, it no longer always does: Anthropic
+/// says `tool_use` for what OpenAI calls `tool_calls`, and echoing it would
+/// hand an OpenAI client a value its own enum does not contain, which every
+/// official SDK reads as unrecognized.
+///
+/// So the raw string wins when reading it back yields the same meaning, and the
+/// gateway's enum wins when it does not. Same-protocol replies always take the
+/// first branch, which is what keeps their round trip byte-exact — including
+/// spellings this crate does not model, like the legacy `function_call`.
+///
+/// Shared with [`stream`](super::stream) rather than restated there: a chunk's
+/// finish reason and a whole reply's are the same field arriving at different
+/// times, and two copies of this rule could answer differently for one exchange
+/// — a streamed call would end in a word its unstreamed twin never uses.
+pub(super) fn render_finish_reason(raw: &str, reason: FinishReason) -> String {
+    if FinishReason::from_raw(raw) == reason {
+        return raw.to_string();
+    }
+    match reason {
+        FinishReason::Stop => "stop",
+        FinishReason::Length => "length",
+        FinishReason::ToolCalls => "tool_calls",
+        FinishReason::ContentFilter => "content_filter",
+        // Unreachable: `from_raw` maps everything it does not recognize to
+        // `Other`, so an `Other` completion always agrees with its raw string
+        // above. Echoing it is the answer that branch would have given anyway.
+        FinishReason::Other => raw,
+    }
+    .to_string()
 }
 
 fn render_message(message: &types::Message, provider: &str) -> ChatCompletionResponseMessage {
@@ -320,6 +358,20 @@ fn render_message(message: &types::Message, provider: &str) -> ChatCompletionRes
             // dropping the block loses nothing. Media and tool results have
             // no rendering on this protocol at all; they can only arise
             // cross-protocol, which warpllm does not do yet.
+            //
+            // THAT LAST SENTENCE EXPIRES WITH THE ANTHROPIC DISPATCH, and the
+            // casualty is specific enough to name: Anthropic requires a run of
+            // its own signed `thinking` blocks to come back UNTOUCHED alongside
+            // tool results. Ingest preserves the signature and the retained
+            // wire content, but neither reaches a caller here — the block is
+            // dropped, and `Protocol::may_read` correctly denies this renderer
+            // the `anthropic` bag — so a caller has nothing to echo, and the
+            // next request renders a `tool_use` turn with no `thinking` before
+            // it. Anthropic rejects that. Whoever wires the dispatch either
+            // carries the blocks in a caller-visible form that round trips with
+            // the signature intact, or refuses thinking for cross-protocol tool
+            // conversations. Dropping silently is the one option that is not
+            // available.
             _ => {}
         }
     }
@@ -433,6 +485,39 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    /// A reply that came in on ANOTHER protocol must leave in this one's
+    /// vocabulary. Anthropic says `tool_use`; an OpenAI client's own enum has
+    /// no such value, and every official SDK reads it as unrecognized — so the
+    /// raw echo that is right for a same-protocol reply is wrong here.
+    #[test]
+    fn a_foreign_finish_reason_is_rendered_in_this_protocols_words() {
+        let rows = [
+            ("tool_use", FinishReason::ToolCalls, "tool_calls"),
+            ("end_turn", FinishReason::Stop, "stop"),
+            ("max_tokens", FinishReason::Length, "length"),
+            ("refusal", FinishReason::ContentFilter, "content_filter"),
+        ];
+        for (raw, reason, expected) in rows {
+            assert_eq!(render_finish_reason(raw, reason), expected, "{raw}");
+        }
+    }
+
+    /// ...and a reply that came in on THIS protocol keeps its exact spelling,
+    /// including one this crate does not model. That is what keeps the
+    /// same-protocol round trip byte-exact.
+    #[test]
+    fn a_native_finish_reason_keeps_its_exact_spelling() {
+        for raw in [
+            "stop",
+            "length",
+            "tool_calls",
+            "content_filter",
+            "function_call",
+        ] {
+            assert_eq!(render_finish_reason(raw, FinishReason::from_raw(raw)), raw);
+        }
+    }
 
     fn parse(body: Value) -> CreateChatCompletionResponse {
         serde_json::from_value(body).unwrap()

--- a/crates/warpllm/src/gateway/openai_compat/api/chat_completions/stream.rs
+++ b/crates/warpllm/src/gateway/openai_compat/api/chat_completions/stream.rs
@@ -23,7 +23,8 @@ use crate::protocol::openai_compat::chat_completions::types::{
 use crate::types::Protocol;
 
 use super::response::{
-    ingest_usage, plain, render_usage, take_nullable_string, take_string, take_typed,
+    ingest_usage, plain, render_finish_reason, render_usage, take_nullable_string, take_string,
+    take_typed,
 };
 use crate::gateway::openai_compat::{merged_ext, namespaced, role_from_wire, role_to_wire};
 
@@ -268,11 +269,31 @@ fn render_stream_choice(
         .unwrap_or(position as u64) as u32;
     StreamChoice {
         delta: render_delta(&completion.delta, provider),
-        finish_reason: completion.finish_reason_raw.clone(),
+        finish_reason: render_delta_finish_reason(completion),
         index,
         logprobs: take_typed(&mut unknown_fields, "logprobs"),
         unknown_fields,
     }
+}
+
+/// [`render_finish_reason`] for a chunk, where the field is absent on every
+/// chunk of a choice but the last.
+///
+/// A chunk needs the same translation a whole reply does, and for a sharper
+/// reason: a streamed call and its unstreamed twin must END THE SAME WAY. If
+/// only the whole-reply renderer spoke this protocol's vocabulary, the same
+/// request to the same model would report `tool_calls` unstreamed and
+/// `tool_use` streamed, and a caller branching on it would take a different
+/// path for no reason it could see.
+fn render_delta_finish_reason(completion: &types::CompletionDelta) -> Option<String> {
+    let raw = completion.finish_reason_raw.as_deref()?;
+    // The pair is documented to be absent and present together. `Other` is what
+    // a raw string this crate does not recognize reads as anyway, so it is the
+    // inert answer if they ever came apart — the helper echoes `raw` for it.
+    Some(render_finish_reason(
+        raw,
+        completion.finish_reason.unwrap_or(FinishReason::Other),
+    ))
 }
 
 fn render_delta(delta: &types::MessageDelta, provider: &str) -> ChatCompletionStreamResponseDelta {
@@ -343,6 +364,79 @@ mod tests {
 
     fn parse(body: Value) -> CreateChatCompletionStreamResponse {
         serde_json::from_value(body).unwrap()
+    }
+
+    fn ending_chunk(raw: &str, reason: FinishReason) -> types::ChatResponseChunk {
+        types::ChatResponseChunk {
+            id: "chunk-1".into(),
+            model: "claude-opus-5".into(),
+            created: None,
+            completions: vec![types::CompletionDelta {
+                delta: types::MessageDelta::default(),
+                finish_reason: Some(reason),
+                finish_reason_raw: Some(raw.to_string()),
+                ext: types::ProviderExt::new(),
+            }],
+            usage: None,
+            ext: types::ProviderExt::new(),
+            source: None,
+        }
+    }
+
+    /// A chunk that came in on ANOTHER protocol must end in this one's
+    /// vocabulary, exactly as a whole reply does — and for a sharper reason:
+    /// the streamed and unstreamed forms of one request must end the same way,
+    /// or a caller branching on `finish_reason` takes a different path for a
+    /// difference it cannot see.
+    #[test]
+    fn a_foreign_finish_reason_is_rendered_in_this_protocols_words() {
+        let rows = [
+            ("tool_use", FinishReason::ToolCalls, "tool_calls"),
+            ("end_turn", FinishReason::Stop, "stop"),
+            ("max_tokens", FinishReason::Length, "length"),
+            ("refusal", FinishReason::ContentFilter, "content_filter"),
+        ];
+        for (raw, reason, expected) in rows {
+            let wire = render_chunk(&ending_chunk(raw, reason), "anthropic");
+            assert_eq!(
+                wire.choices[0].finish_reason.as_deref(),
+                Some(expected),
+                "{raw}"
+            );
+        }
+    }
+
+    /// ...and the two really do agree, which is the property the shared helper
+    /// exists for. Comparing them directly is what would catch one renderer
+    /// being changed without the other.
+    #[test]
+    fn a_chunk_and_a_whole_reply_end_the_same_way() {
+        for (raw, reason) in [
+            ("tool_use", FinishReason::ToolCalls),
+            ("end_turn", FinishReason::Stop),
+            ("stop", FinishReason::Stop),
+            ("function_call", FinishReason::Other),
+        ] {
+            let chunk = render_chunk(&ending_chunk(raw, reason), "anthropic");
+            assert_eq!(
+                chunk.choices[0].finish_reason,
+                Some(super::super::response::render_finish_reason(raw, reason)),
+                "{raw}"
+            );
+        }
+    }
+
+    /// Every chunk of a choice but the last carries no finish reason at all,
+    /// and must not grow one.
+    #[test]
+    fn a_chunk_that_does_not_end_a_choice_carries_no_finish_reason() {
+        let mut chunk = ending_chunk("stop", FinishReason::Stop);
+        chunk.completions[0].finish_reason = None;
+        chunk.completions[0].finish_reason_raw = None;
+        assert_eq!(
+            render_chunk(&chunk, "anthropic").choices[0].finish_reason,
+            None
+        );
     }
 
     fn round_trip(body: Value, provider: &str) {

--- a/crates/warpllm/src/gateway/openai_compat/mod.rs
+++ b/crates/warpllm/src/gateway/openai_compat/mod.rs
@@ -29,9 +29,19 @@ use crate::types::Protocol;
 /// namespace first (the target speaks it), overlaid by the provider's own
 /// namespace. Other providers' namespaces are ignored — a field meant for
 /// one provider never leaks into another.
+///
+/// And neither does another PROTOCOL's, which is a different claim and needs
+/// [`Protocol::may_read`] to hold: a provider is allowed to share its name with
+/// the protocol it defines, so a bag keyed `"anthropic"` may hold either
+/// Anthropic passthrough or Anthropic's own retained wire fields, and this
+/// renderer cannot tell them apart. Reading it would flatten a retained
+/// `content` block ARRAY in beside this protocol's typed `content` string.
 pub(crate) fn merged_ext(ext: &ProviderExt, provider: &str) -> UnknownFields {
     let mut merged = UnknownFields::new();
     for namespace in [Protocol::OpenAiCompat.as_str(), provider] {
+        if !Protocol::OpenAiCompat.may_read(namespace) {
+            continue;
+        }
         if let Some(Value::Object(fields)) = ext.get(namespace) {
             for (key, value) in fields {
                 merged.insert(key.clone(), value.clone());
@@ -112,6 +122,40 @@ mod tests {
         assert!(
             merged.get("mistral_only").is_none(),
             "another provider's namespace leaked into this render"
+        );
+    }
+
+    /// The collision that made [`Protocol::may_read`] necessary. A provider
+    /// named for a protocol addresses that protocol's bag, and this renderer
+    /// cannot distinguish the two — so it must read neither.
+    ///
+    /// The failure this prevents is not a dropped field: Anthropic retains its
+    /// whole wire `content` ARRAY under that key, `render_message` never pops
+    /// `content`, and `unknown_fields` is `#[serde(flatten)]`. Reading it emits
+    /// TWO `content` keys in one OpenAI message object — the typed string and
+    /// the block array — which most clients resolve last-wins.
+    #[test]
+    fn a_provider_named_for_another_protocol_does_not_leak_its_bag() {
+        let mut ext = ProviderExt::new();
+        ext.insert(
+            Protocol::Anthropic.as_str().into(),
+            json!({"content": [{"type": "text", "text": "hi"}], "stop_sequence": null}),
+        );
+        ext.insert(
+            Protocol::OpenAiCompat.as_str().into(),
+            json!({"system_fingerprint": "fp_1"}),
+        );
+
+        let merged = merged_ext(&ext, Protocol::Anthropic.as_str());
+        assert!(
+            merged.get("content").is_none(),
+            "Anthropic's retained content array reached an OpenAI render"
+        );
+        assert!(merged.get("stop_sequence").is_none());
+        assert_eq!(
+            merged["system_fingerprint"],
+            json!("fp_1"),
+            "this protocol's own bag must still be read"
         );
     }
 

--- a/crates/warpllm/src/gateway/types/response.rs
+++ b/crates/warpllm/src/gateway/types/response.rs
@@ -59,13 +59,35 @@ impl FinishReason {
 /// Token accounting in the widest cross-provider units; fields a provider
 /// doesn't report stay `None`. Protocol-specific residue (detail objects,
 /// unknown fields) rides `ext` so rendering back is lossless.
+///
+/// # The cached counts are a BREAKDOWN, never addends
+///
+/// [`input_tokens`](Self::input_tokens) is the WHOLE input, cached tokens
+/// included, and [`cache_read_tokens`](Self::cache_read_tokens) and
+/// [`cache_write_tokens`](Self::cache_write_tokens) say how much of it was
+/// which. [`total_tokens`](Self::total_tokens) is then input + output, and
+/// adding the cache counts on top double-counts them.
+///
+/// Stated here rather than left to each protocol because the two wire formats
+/// disagree and the difference is invisible in the field name: OpenAI's
+/// `prompt_tokens` already includes its `cached_tokens`, while Anthropic's
+/// `input_tokens` counts only what came AFTER the last cache breakpoint. A
+/// protocol whose wire value is exclusive has to add the cache counts back on
+/// ingest — otherwise the same conversation reports a different `prompt_tokens`
+/// depending on which backend served it, and `cached_tokens` can exceed the
+/// prompt it is supposedly part of.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(crate) struct Usage {
+    /// The whole input, INCLUDING whatever was read from or written to cache.
     pub input_tokens: Option<u64>,
     pub output_tokens: Option<u64>,
+    /// `input_tokens + output_tokens`. Not a third independent number.
     pub total_tokens: Option<u64>,
+    /// Part of `output_tokens`, not additional to it.
     pub reasoning_tokens: Option<u64>,
+    /// Part of `input_tokens`, not additional to it.
     pub cache_read_tokens: Option<u64>,
+    /// Part of `input_tokens`, not additional to it.
     pub cache_write_tokens: Option<u64>,
     #[serde(default, skip_serializing_if = "ProviderExt::is_empty")]
     pub ext: ProviderExt,

--- a/crates/warpllm/src/protocol/anthropic/messages/mod.rs
+++ b/crates/warpllm/src/protocol/anthropic/messages/mod.rs
@@ -6,11 +6,4 @@
 
 pub mod types;
 
-// Nothing outside this module's own tests calls the transport yet: its only
-// caller is `crate::gateway::anthropic::api::messages::exchange`, which lands
-// with the conversions. Being unreachable is what makes this module safe to
-// land ahead of them — but it also means every item here reads as dead. Drop
-// this attribute when the conversions arrive; it should stop being needed on
-// the same change.
-#[allow(dead_code)]
 pub(crate) mod transport;

--- a/crates/warpllm/src/protocol/anthropic/messages/transport.rs
+++ b/crates/warpllm/src/protocol/anthropic/messages/transport.rs
@@ -100,6 +100,16 @@ pub(crate) async fn post(
         })
 }
 
+// ---------------------------------------------------------------------------
+// Streaming.
+//
+// Everything below here is still unreachable: the conversions that call `post`
+// have landed, and the ones that read events have not. Each item carries its
+// own `allow` rather than the module carrying one, so that a NON-streaming item
+// going dead is still a warning — and so that deleting these is exactly the
+// change that wires the stream up.
+// ---------------------------------------------------------------------------
+
 /// [`Outcome`] for a streamed request. Same contract: a non-2xx is DATA, and
 /// only the caller decides which [`Error`] it becomes.
 ///
@@ -108,6 +118,7 @@ pub(crate) async fn post(
 /// past the headers, so the status decision is made before the first event and
 /// never again.
 #[derive(Debug)]
+#[allow(dead_code)] // staged: read once the stream conversions land
 pub(crate) enum StreamOutcome {
     Ok(EventStream),
     /// The status, raw body, and header evidence, verbatim — see
@@ -133,6 +144,7 @@ pub(crate) enum StreamOutcome {
 /// applied here rather than on the [`reqwest::Client`] because reqwest's own
 /// `read_timeout` is builder-scoped: setting it there would bind every
 /// non-streamed request too, or cost a second connection pool to avoid that.
+#[allow(dead_code)] // staged: read once the stream conversions land
 pub(crate) async fn post_stream(
     http: &reqwest::Client,
     provider: &'static str,
@@ -213,6 +225,7 @@ fn request(
 /// caller here is a loop, and a loop needs no combinators, no pinning, and no
 /// dependency.
 #[derive(Debug)]
+#[allow(dead_code)] // staged: read once the stream conversions land
 pub(crate) struct EventStream {
     response: reqwest::Response,
     provider: &'static str,
@@ -243,6 +256,7 @@ pub(crate) struct EventStream {
 /// follows one. A reader that kept waiting would sit until the socket closed
 /// and then report a truncation, burying the reason the provider actually
 /// gave.
+#[allow(dead_code)] // staged: read once the stream conversions land
 fn ends_the_stream(event: &MessageStreamEvent) -> bool {
     matches!(
         event,
@@ -250,6 +264,7 @@ fn ends_the_stream(event: &MessageStreamEvent) -> bool {
     )
 }
 
+#[allow(dead_code)] // staged: read once the stream conversions land
 impl EventStream {
     /// The next event, or `None` once the stream ends.
     ///

--- a/crates/warpllm/src/protocol/anthropic/messages/types.rs
+++ b/crates/warpllm/src/protocol/anthropic/messages/types.rs
@@ -19,9 +19,16 @@
 //! an EGRESS protocol: nothing but `render_request` constructs a
 //! [`CreateMessageRequest`], so a field no renderer sets earns nothing by
 //! being typed and still reaches Anthropic through `unknown_fields`. So
-//! `top_k`, `metadata`, `service_tier`, `container`, `inference_geo`,
-//! `output_config` and a top-level `cache_control` are all deliberately
-//! untyped. Add one when a conversion needs to set or read it, not before.
+//! `top_k`, `metadata`, `service_tier`, `container`, `inference_geo` and a
+//! top-level `cache_control` are all deliberately untyped. Add one when a
+//! conversion needs to set or read it, not before.
+//!
+//! [`OutputConfig`] is what "not before" looks like from the other side: it
+//! was on that list until the conversions arrived and found that BOTH its
+//! fields have a gateway home — `format` is `ChatRequest::response_format` and
+//! `effort` is `ReasoningConfig::effort` — so a renderer now has to construct
+//! one. Same for [`OutputTokensDetails`], which carries the only count
+//! `Usage::reasoning_tokens` can be filled from.
 //!
 //! # Two structural differences from chat completions
 //!
@@ -168,6 +175,56 @@ pub struct CreateMessageRequest {
     pub tool_choice: Option<ToolChoice>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thinking: Option<ThinkingConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_config: Option<OutputConfig>,
+    #[serde(flatten)]
+    pub unknown_fields: UnknownFields,
+}
+
+/// What the reply must look like and how hard the model works on it.
+///
+/// Two unrelated controls under one key, which is Anthropic's arrangement
+/// rather than a grouping warpllm chose.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct OutputConfig {
+    /// A schema the reply must satisfy — Anthropic's structured outputs, and
+    /// the counterpart of chat completions' `response_format`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<OutputFormat>,
+    /// `"low"`, `"medium"`, `"high"`, `"xhigh"` or `"max"`. Absent means
+    /// `"high"`, which Anthropic documents as behaving identically to omitting
+    /// it.
+    ///
+    /// A `String`, not an enum, per the codegen policy — and the policy earns
+    /// its keep here: `xhigh` and `max` are both newer than the parameter, and
+    /// the set is documented per model rather than once.
+    ///
+    /// This is where an effort level lives now. It is NOT part of `thinking`,
+    /// and Anthropic says so directly: "Don't pass `adaptive` as an `effort`
+    /// value: `adaptive` is a thinking mode, not an effort level."
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+    #[serde(flatten)]
+    pub unknown_fields: UnknownFields,
+}
+
+/// The shape a reply must take.
+///
+/// A struct with a `type` string rather than a `type`-tagged enum, because
+/// there is exactly one variant — `json_schema` — and a single-variant union
+/// would be a dispatch with nothing to dispatch on. [`CacheControl`] is
+/// modelled the same way for the same reason.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutputFormat {
+    /// Conventionally `"json_schema"`, the only format documented today.
+    #[serde(rename = "type")]
+    pub r#type: String,
+    /// REQUIRED for `json_schema`, and optional here only so that a format
+    /// type Anthropic adds later — one carrying something other than a schema
+    /// — parses rather than failing the whole request. Same instinct as an
+    /// `Unknown` arm, in the one shape that has no room for one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<Value>,
     #[serde(flatten)]
     pub unknown_fields: UnknownFields,
 }
@@ -543,13 +600,22 @@ unknown_means_an_unknown_tag!(ThinkingConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ThinkingEnabled {
     pub budget_tokens: u32,
+    /// See [`ThinkingAdaptive::display`] — the field is documented to work
+    /// "in both modes", so it sits on both arms rather than only on the newer
+    /// one. It is invalid on [`ThinkingDisabled`], where there is nothing to
+    /// display, which is why that arm has no such field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display: Option<String>,
     #[serde(flatten)]
     pub unknown_fields: UnknownFields,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ThinkingAdaptive {
-    /// `"summarized"` or `"omitted"`.
+    /// `"summarized"` returns the thinking text; `"omitted"` returns thinking
+    /// blocks with an empty `thinking` field. Both are billed identically and
+    /// both must be passed back unchanged on the next turn — this controls
+    /// what the caller SEES, not whether the model thinks.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display: Option<String>,
     #[serde(flatten)]
@@ -611,6 +677,35 @@ pub struct Usage {
         skip_serializing_if = "Option::is_none"
     )]
     pub cache_read_input_tokens: Option<Option<u32>>,
+    /// Documented nullable, hence the three-state spelling. `cache_creation`,
+    /// `server_tool_use`, `service_tier` and `inference_geo` stay untyped
+    /// beside it: none has a gateway field to be lifted into, so each earns
+    /// more by riding `unknown_fields` verbatim.
+    #[serde(
+        default,
+        deserialize_with = "present_or_null",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub output_tokens_details: Option<Option<OutputTokensDetails>>,
+    #[serde(flatten)]
+    pub unknown_fields: UnknownFields,
+}
+
+/// The breakdown of `output_tokens`.
+///
+/// One field today, and it is the reason this type is modelled at all: nothing
+/// else on the wire says how much of the reply was thinking, and
+/// `Usage::reasoning_tokens` has nowhere else to come from. Thinking tokens
+/// are BILLED as output tokens and already counted in `output_tokens`, so this
+/// is a breakdown, never an addend.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct OutputTokensDetails {
+    #[serde(
+        default,
+        deserialize_with = "present_or_null",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub thinking_tokens: Option<Option<u32>>,
     #[serde(flatten)]
     pub unknown_fields: UnknownFields,
 }

--- a/crates/warpllm/src/types.rs
+++ b/crates/warpllm/src/types.rs
@@ -51,6 +51,9 @@ pub(crate) enum Protocol {
     /// The OpenAI-compatible chat completions wire format, implemented at
     /// [`crate::protocol::openai_compat`].
     OpenAiCompat,
+    /// Anthropic's Messages wire format, implemented at
+    /// [`crate::protocol::anthropic`].
+    Anthropic,
 }
 
 impl Protocol {
@@ -63,6 +66,45 @@ impl Protocol {
     pub(crate) fn as_str(self) -> &'static str {
         match self {
             Protocol::OpenAiCompat => "openai_compat",
+            Protocol::Anthropic => "anthropic",
+        }
+    }
+
+    /// Every protocol warpllm implements.
+    ///
+    /// Hand-written because [`Protocol`] is `non_exhaustive` and nothing
+    /// derives a variant list. [`from_name`](Self::from_name) reads THIS rather
+    /// than spelling the names a second time, so the forward and inverse
+    /// mappings cannot drift apart; the test below is what forces a new variant
+    /// into it.
+    const PROTOCOLS: &'static [Protocol] = &[Protocol::OpenAiCompat, Protocol::Anthropic];
+
+    /// The inverse of [`as_str`](Self::as_str): does this string name a
+    /// PROTOCOL? Asked of a provider name, which is the only case where the
+    /// answer changes anything — see [`may_read`](Self::may_read).
+    pub(crate) fn from_name(name: &str) -> Option<Self> {
+        Self::PROTOCOLS.iter().copied().find(|p| p.as_str() == name)
+    }
+
+    /// Whether a renderer for `self` may read the gateway `ext` bag keyed
+    /// `namespace`.
+    ///
+    /// Its own protocol's bag, yes. A provider's bag, yes. ANOTHER protocol's
+    /// bag, never — that is the layer rule ("a renderer reads only the IR and
+    /// its own namespace") turned into code, because the two are otherwise
+    /// indistinguishable: a provider may deliberately share a name with the
+    /// protocol it defines, and `anthropic` is both. Without this, an Anthropic
+    /// reply rendered for an OpenAI caller would flatten Anthropic's retained
+    /// `content` block array in beside OpenAI's typed `content` string and emit
+    /// both under one key.
+    ///
+    /// Where the names DO match — an Anthropic renderer reading the `anthropic`
+    /// provider — the bag is read exactly as before. That shadow is intended;
+    /// a field addressed to "anthropic" is addressed to both.
+    pub(crate) fn may_read(self, namespace: &str) -> bool {
+        match Self::from_name(namespace) {
+            Some(owner) => owner == self,
+            None => true,
         }
     }
 }
@@ -131,6 +173,45 @@ impl Api {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// [`Protocol::PROTOCOLS`] is hand-written, so this walks it and matches
+    /// exhaustively: adding a variant fails to COMPILE here until someone
+    /// visits the list. Round-tripping each name is what pins `from_name` as
+    /// the true inverse of `as_str`.
+    #[test]
+    fn every_protocol_name_maps_back_to_its_variant() {
+        for &protocol in Protocol::PROTOCOLS {
+            match protocol {
+                Protocol::OpenAiCompat | Protocol::Anthropic => {}
+            }
+            assert_eq!(Protocol::from_name(protocol.as_str()), Some(protocol));
+        }
+        assert_eq!(Protocol::from_name("deepseek"), None);
+        assert_eq!(Protocol::from_name("openai"), None);
+    }
+
+    /// The layer rule as a table. The diagonal is every protocol reading its
+    /// own bag, and the off-diagonal is the leak `may_read` exists to stop —
+    /// including the case that motivated it, an OpenAI renderer serving the
+    /// `anthropic` provider.
+    #[test]
+    fn a_renderer_reads_its_own_bag_and_no_other_protocols() {
+        for &reader in Protocol::PROTOCOLS {
+            for &other in Protocol::PROTOCOLS {
+                assert_eq!(
+                    reader.may_read(other.as_str()),
+                    reader == other,
+                    "{} reading {}",
+                    reader.as_str(),
+                    other.as_str()
+                );
+            }
+            assert!(
+                reader.may_read("deepseek"),
+                "a provider bag whose name is not a protocol's must stay readable"
+            );
+        }
+    }
 
     /// Every surface with the protocol it is spoken in, so a new variant has
     /// one place to be added for the checks below to cover it.

--- a/crates/warpllm/tests/protocol/anthropic/messages/fixtures/request/doc-extended-thinking-request.json
+++ b/crates/warpllm/tests/protocol/anthropic/messages/fixtures/request/doc-extended-thinking-request.json
@@ -1,0 +1,15 @@
+{
+  "model": "claude-sonnet-4-6",
+  "max_tokens": 16000,
+  "thinking": {
+    "type": "enabled",
+    "budget_tokens": 10000,
+    "display": "summarized"
+  },
+  "messages": [
+    {
+      "role": "user",
+      "content": "Are there an infinite number of prime numbers such that n mod 4 == 3?"
+    }
+  ]
+}

--- a/crates/warpllm/tests/protocol/anthropic/messages/fixtures/request/doc-structured-output-request.json
+++ b/crates/warpllm/tests/protocol/anthropic/messages/fixtures/request/doc-structured-output-request.json
@@ -1,0 +1,29 @@
+{
+  "model": "claude-opus-5",
+  "max_tokens": 4096,
+  "output_config": {
+    "effort": "medium",
+    "format": {
+      "type": "json_schema",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "city": { "type": "string" },
+          "population": { "type": "integer" }
+        },
+        "required": ["city", "population"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "thinking": {
+    "type": "adaptive",
+    "display": "omitted"
+  },
+  "messages": [
+    {
+      "role": "user",
+      "content": "Which US city had the largest population in 2020?"
+    }
+  ]
+}

--- a/crates/warpllm/tests/protocol/anthropic/messages/losslessness.rs
+++ b/crates/warpllm/tests/protocol/anthropic/messages/losslessness.rs
@@ -262,16 +262,35 @@ fn text_or_blocks() -> BoxedStrategy<Value> {
     .boxed()
 }
 
+/// The breakdown of `output_tokens`, whose one field is where
+/// `Usage::reasoning_tokens` comes from.
+fn output_tokens_details() -> BoxedStrategy<Value> {
+    (
+        optional_nullable((0u32..4000).prop_map(Value::from).boxed()),
+        unknown_fields(),
+    )
+        .prop_map(|(thinking, unknown)| object(vec![("thinking_tokens", thinking)], unknown))
+        .boxed()
+}
+
 fn usage() -> BoxedStrategy<Value> {
     let count = || optional_nullable((0u32..4000).prop_map(Value::from).boxed());
-    (0u32..4000, 0u32..4000, count(), count(), unknown_fields())
-        .prop_map(|(input, output, creation, read, unknown)| {
+    (
+        0u32..4000,
+        0u32..4000,
+        count(),
+        count(),
+        optional_nullable(output_tokens_details()),
+        unknown_fields(),
+    )
+        .prop_map(|(input, output, creation, read, details, unknown)| {
             object(
                 vec![
                     ("input_tokens", Some(json!(input))),
                     ("output_tokens", Some(json!(output))),
                     ("cache_creation_input_tokens", creation),
                     ("cache_read_input_tokens", read),
+                    ("output_tokens_details", details),
                 ],
                 unknown,
             )
@@ -578,15 +597,21 @@ fn tool_choice() -> BoxedStrategy<Value> {
 /// All three thinking vocabularies. They are mutually exclusive per MODEL, not
 /// per protocol version, so every one of them is a body warpllm may have to
 /// read back.
+///
+/// `display` rides both of the arms that think and NEITHER `disabled` — where
+/// Anthropic documents it as invalid, there being nothing to display.
 fn thinking_config() -> BoxedStrategy<Value> {
     prop_oneof![
-        (1u32..64_000, unknown_fields()).prop_map(|(budget, unknown)| object(
-            vec![
-                ("type", Some(json!("enabled"))),
-                ("budget_tokens", Some(json!(budget))),
-            ],
-            unknown,
-        )),
+        (1u32..64_000, optional(text()), unknown_fields()).prop_map(
+            |(budget, display, unknown)| object(
+                vec![
+                    ("type", Some(json!("enabled"))),
+                    ("budget_tokens", Some(json!(budget))),
+                    ("display", display),
+                ],
+                unknown,
+            )
+        ),
         (optional(text()), unknown_fields()).prop_map(|(display, unknown)| object(
             vec![("type", Some(json!("adaptive"))), ("display", display)],
             unknown,
@@ -595,6 +620,37 @@ fn thinking_config() -> BoxedStrategy<Value> {
             .prop_map(|unknown| object(vec![("type", Some(json!("disabled")))], unknown)),
     ]
     .boxed()
+}
+
+/// The two unrelated controls Anthropic files under one key.
+fn output_config() -> BoxedStrategy<Value> {
+    (
+        optional(output_format()),
+        optional(text()),
+        unknown_fields(),
+    )
+        .prop_map(|(format, effort, unknown)| {
+            object(vec![("format", format), ("effort", effort)], unknown)
+        })
+        .boxed()
+}
+
+/// `schema` is REQUIRED for the one format Anthropic documents and optional on
+/// this type, so that a format type it adds later parses instead of failing the
+/// whole request. Both states are generated, because both must come back as
+/// themselves.
+fn output_format() -> BoxedStrategy<Value> {
+    (
+        optional(Just(json!({"type": "object"})).boxed()),
+        unknown_fields(),
+    )
+        .prop_map(|(schema, unknown)| {
+            object(
+                vec![("type", Some(json!("json_schema"))), ("schema", schema)],
+                unknown,
+            )
+        })
+        .boxed()
 }
 
 fn input_message() -> BoxedStrategy<Value> {
@@ -634,13 +690,14 @@ fn request() -> BoxedStrategy<Value> {
             ),
             optional(tool_choice()),
             optional(thinking_config()),
+            optional(output_config()),
             unknown_fields(),
         ),
     )
         .prop_map(
             |(
                 (model, messages, max_tokens, system, temperature, top_p),
-                (stop_sequences, stream, tools, tool_choice, thinking, unknown),
+                (stop_sequences, stream, tools, tool_choice, thinking, output_config, unknown),
             )| {
                 object(
                     vec![
@@ -655,6 +712,7 @@ fn request() -> BoxedStrategy<Value> {
                         ("tools", tools),
                         ("tool_choice", tool_choice),
                         ("thinking", thinking),
+                        ("output_config", output_config),
                     ],
                     unknown,
                 )

--- a/crates/warpllm/tests/protocol/anthropic/messages/mod.rs
+++ b/crates/warpllm/tests/protocol/anthropic/messages/mod.rs
@@ -21,9 +21,8 @@
 //! capture from `tests/live_stream.rs` is what would prove it reads what
 //! Anthropic sends. The deliberate additions to the documented bodies are
 //! fields warpllm does not model — `stop_details`, `container`,
-//! `cache_creation`, `output_tokens_details`, `service_tier`, `top_k`,
-//! `metadata`, a document's `citations` — which are exactly the ones a round
-//! trip would silently lose.
+//! `cache_creation`, `service_tier`, `top_k`, `metadata`, a document's
+//! `citations` — which are exactly the ones a round trip would silently lose.
 
 use warpllm::protocol::anthropic::messages::types::{
     CreateMessageRequest, Message, MessageStreamEvent,


### PR DESCRIPTION
The second slice of #23: the non-streaming conversions and the error vocabulary. Still nothing routes here — `Client` picks an exchange by the routed model's surface and no surface names this protocol until the roster lands — so no caller-visible behaviour changes. The streaming conversions are the next slice and are deliberately not in this one.

## Three plan decisions the docs overturned

Each was written before Anthropic had the vocabulary to keep it, and each moves from *refuse* to *translate*:

| gateway | Anthropic | was going to |
|---|---|---|
| `response_format` | `output_config.format` | return `NotImplemented` |
| `reasoning_effort` | `output_config.effort` | render nothing and record it |
| `ReasoningConfig::exclude` | `thinking.display` | (unmapped) |

Only the schema-**less** `json_object` mode is still refused, because Anthropic requires a schema. Each of these forced a wire type PR A had deliberately left untyped — which is that file's own rule working as intended: *add one when a conversion needs to set or read it, not before*.

**The plan's "pick the thinking arm by routed model" is withdrawn.** A budget can only be `enabled` (the sole arm taking one) and its absence can only be `adaptive` (the sole arm working without one), so the gateway form alone determines the arm. Picking by model version would mean inventing a budget for a model that wants none, or discarding one the caller wrote. A model that rejects the arm says so by name, in a 400.

## A bug in shipped code, found by the cross-protocol test

`finish_reason_raw` is documented as authoritative on render. That holds only where the target **shares the vocabulary it was said in**: Anthropic says `tool_use` for what OpenAI calls `tool_calls`, so an OpenAI caller reaching Claude would have received a value absent from its own enum, which every official SDK reads as unrecognized. Nothing could produce it before this change.

`render_finish_reason` now prefers the raw string when reading it back yields the same meaning, and falls to the gateway enum when it does not. `stream.rs` shares that one helper rather than restating it — the streamed and unstreamed forms of one request must end the same way, and two copies of the rule could answer differently.

## `Usage::input_tokens` needed a meaning before it could be filled

OpenAI's `prompt_tokens` already includes its `cached_tokens`; Anthropic's `input_tokens` counts only what came *after* the last cache breakpoint. The IR never said which it meant, so a cached Claude reply rendered to OpenAI came out self-contradicting — `cached_tokens` larger than the prompt it is a subset of, and a total that was not prompt + completion. The gateway field now documents the cached counts as a **breakdown**, and this protocol adds them back on ingest while retaining the wire value so the normalization is reversible.

## What is refused rather than sent

- **Audio** — no Anthropic block in any shape; dropping it would send a request reading as if the caller never attached it.
- **Inline bytes with no media type** — chat completions' `file` part carries bytes and a filename and declares no MIME type, so its ingest fills an empty string rather than guessing from the extension. That ingest's own comment says a target requiring one "has to say so"; this is it saying so.
- **A system message after the conversation starts** — hoisting reorders what the model sees, rendering it as a user turn fabricates one.
- **A tool with no arguments schema**, and **unparseable tool arguments**, each named in the error.

## Promote but retain, and why it carries more weight here

The gateway's content blocks have no `ext` of their own, so a **known** block's residue — a text block's `citations`, a source's vendor fields, an explicit `null` where the gateway holds only present-or-absent — has nowhere to be filed one field at a time. Promotion loses it precisely *because* the block parsed: a shape warpllm does not recognize reaches the `Unknown` arm and survives whole, while one it does recognize would be rebuilt from the fields it could hold. Both directions retain the whole `content` array and prefer it on render.

That retention is itself a catch-all, and **a round-trip test passes vacuously in front of one**. So every retained path ships with a second test that does not benefit from it: the gateway view is asserted directly, and a response carrying no retained content is rendered from its blocks — a broken promotion cannot hide behind a replayed array.

The tool-result merge stops at any message that already describes a whole wire turn. The retained content is the provenance test and exactly the right one: `merged_ext` reads only this protocol's namespace, so a tool message from chat completions has no `content` key here however much residue it carries under its own name. Without that stop, two native tool-result turns merged into one and every turn after the first lost its residue — while still passing any test that only checked a single turn.

## Errors have two signals, not three

Anthropic sends no `code`, so the status table does the work the strongest tier does next door — and the ordering matters more for it: `invalid_request_error` is the documented catch-all for "other 4XX status codes not listed", so reading the family before the status would report a 402 billing failure as a malformed request. 529 has to be mapped because it falls outside `classify`'s residual. 409 deliberately is not: a conflict is nothing warpllm can cause on `/messages`, and `InvalidRequest` would send a caller to fix a payload that is fine.

## Verification

`./scripts/test-all.sh` green — fmt, clippy `-D warnings`, the workspace, Node, Python, and the codegen drift check. 59 new unit tests; both protocol proptests extended to the new wire fields; two new request fixtures. Every subtle claim was mutation-tested: break the fix, confirm the test fails, restore.