### PR TITLE
Lift authentication out of the transports into a credential of its own

### DIFF
--- a/crates/warpllm/src/auth/header.rs
+++ b/crates/warpllm/src/auth/header.rs
@@ -1,0 +1,156 @@
+//! A secret sent in a named header — the whole of authentication for every
+//! provider on the roster today.
+//!
+//! One type for two spellings. `Authorization: Bearer sk-…` and Anthropic's
+//! `x-api-key: sk-ant-…` are the same act with a different header name and a
+//! different prefix, so they are two constructors rather than two variants; an
+//! Azure-style `api-key:` would be a third and add no code. What they are NOT
+//! is interchangeable: Anthropic reads `x-api-key` and OpenAI-compatible hosts
+//! read `Authorization`, so the constructor a provider gets is a fact about
+//! that provider, decided by [`crate::credentials`].
+
+use reqwest::header::{AUTHORIZATION, HeaderName, HeaderValue};
+
+use crate::error::{Error, Result};
+
+/// A secret presented as `{prefix}{secret}` under one header name.
+pub(crate) struct Header {
+    name: HeaderName,
+    /// What precedes the secret in the header value. `"Bearer "` for
+    /// [`Header::bearer`], empty everywhere else — a scheme token belongs to
+    /// the header's grammar, not to the key.
+    prefix: &'static str,
+    secret: String,
+}
+
+impl Header {
+    /// `Authorization: Bearer <secret>`.
+    pub(crate) fn bearer(secret: String) -> Self {
+        Self {
+            name: AUTHORIZATION,
+            prefix: "Bearer ",
+            secret,
+        }
+    }
+
+    /// `x-api-key: <secret>`, and deliberately no `Authorization` alongside it.
+    ///
+    /// Unreachable outside tests until a provider routes to Anthropic — see
+    /// [`Authenticator::anthropic_api_key`](super::Authenticator::anthropic_api_key).
+    #[allow(dead_code)]
+    pub(crate) fn anthropic_api_key(secret: String) -> Self {
+        Self {
+            name: HeaderName::from_static("x-api-key"),
+            prefix: "",
+            secret,
+        }
+    }
+
+    /// Writes the header onto a built request.
+    ///
+    /// `insert` rather than `append`: a credential replaces whatever was there,
+    /// so a transport that set one by hand cannot end up sending two.
+    ///
+    /// The value is marked SENSITIVE, which is what keeps the secret out of
+    /// [`reqwest::Request`]'s own `Debug` — a request is a natural thing to log
+    /// when one fails — and out of the HPACK index on an HTTP/2 connection.
+    /// `reqwest::RequestBuilder::bearer_auth`, which this replaces, did the
+    /// same; the Anthropic transport's hand-written `.header("x-api-key", …)`
+    /// did not, and now does.
+    pub(crate) fn apply(&self, mut request: reqwest::Request) -> Result<reqwest::Request> {
+        let mut value = HeaderValue::from_str(&format!("{}{}", self.prefix, self.secret))
+            // The secret itself is NOT in the message. A key with a stray
+            // newline is the usual cause, and naming the header is enough to
+            // find it.
+            .map_err(|_| {
+                Error::Internal(format!(
+                    "the credential for `{}` holds a byte that cannot be sent in a header",
+                    self.name
+                ))
+            })?;
+        value.set_sensitive(true);
+        request.headers_mut().insert(self.name.clone(), value);
+        Ok(request)
+    }
+}
+
+/// The header name, never its value. A derived `Debug` prints the API key the
+/// moment a [`Header`] reaches a `tracing` field or a panic message — the same
+/// hazard [`crate::credentials::Credentials`] hand-writes its own `Debug` for.
+impl std::fmt::Debug for Header {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Header")
+            .field("name", &self.name)
+            .field("secret", &"<redacted>")
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request() -> reqwest::Request {
+        reqwest::Client::new()
+            .post("https://example.invalid/v1/chat/completions")
+            .body("{}")
+            .build()
+            .expect("a well-formed request")
+    }
+
+    /// The prefix belongs to the header's grammar, so it is present for bearer
+    /// and absent for a bare key — with no space left behind by the empty one.
+    #[test]
+    fn the_prefix_is_part_of_the_value_and_only_where_it_belongs() {
+        let signed = Header::bearer("sk-openai".into()).apply(request()).unwrap();
+        assert_eq!(signed.headers()[AUTHORIZATION], "Bearer sk-openai");
+
+        let signed = Header::anthropic_api_key("sk-ant-demo".into())
+            .apply(request())
+            .unwrap();
+        assert_eq!(signed.headers()["x-api-key"], "sk-ant-demo");
+    }
+
+    /// A second application replaces the first. Nothing does this today, and
+    /// the alternative — two `Authorization` headers, one stale — is the kind
+    /// of failure a provider reports as a plain 401.
+    #[test]
+    fn applying_twice_leaves_one_header() {
+        let once = Header::bearer("first".into()).apply(request()).unwrap();
+        let twice = Header::bearer("second".into()).apply(once).unwrap();
+        assert_eq!(twice.headers().get_all(AUTHORIZATION).iter().count(), 1);
+        assert_eq!(twice.headers()[AUTHORIZATION], "Bearer second");
+    }
+
+    /// A key with a newline in it is a configuration mistake, and it must fail
+    /// as one rather than as a 401 from the provider. The message names the
+    /// header and never the value.
+    #[test]
+    fn a_secret_that_cannot_be_a_header_value_is_rejected() {
+        let error = Header::bearer("sk-with-a\nnewline".into())
+            .apply(request())
+            .expect_err("a newline cannot travel in a header");
+        let rendered = error.to_string();
+        assert!(rendered.contains("authorization"), "{rendered}");
+        assert!(!rendered.contains("sk-with-a"), "{rendered}");
+    }
+
+    /// A request is a natural thing to log when one fails, and its `Debug`
+    /// prints every header. The sensitive flag is what stops that being a leak.
+    #[test]
+    fn the_secret_does_not_survive_into_the_requests_own_debug() {
+        let signed = Header::bearer("sk-secret-value".into())
+            .apply(request())
+            .unwrap();
+        let rendered = format!("{signed:?}");
+        assert!(!rendered.contains("sk-secret-value"), "{rendered}");
+    }
+
+    /// `Debug` on the credential itself: the header, none of the secret.
+    #[test]
+    fn debug_redacts_the_secret() {
+        let rendered = format!("{:?}", Header::bearer("sk-secret-value".into()));
+        assert!(rendered.contains("authorization"), "{rendered}");
+        assert!(!rendered.contains("sk-secret-value"), "{rendered}");
+    }
+}

--- a/crates/warpllm/src/auth/mod.rs
+++ b/crates/warpllm/src/auth/mod.rs
@@ -1,0 +1,148 @@
+//! How a provider's credential is presented on the wire.
+//!
+//! One [`Authenticator`] per provider, resolved by [`crate::credentials`] and
+//! handed to a transport, which applies it to a request it has otherwise
+//! finished building. That split is the point: the PATH and the ENVELOPE differ
+//! per wire format and belong to a protocol's transport, while the CREDENTIAL
+//! differs per provider and belongs here. Vertex (#25) is the case that settles
+//! it — one OAuth token serves both the Anthropic Messages and the Google
+//! `generateContent` surfaces under a single provider entry, so a credential
+//! filed under either protocol would have to be built twice.
+//!
+//! At the crate root rather than under [`crate::protocol`], and for the same
+//! reason [`crate::http`] is: this is transport machinery every protocol module
+//! uses and none of them owns. `protocol` is indexed by wire format; a
+//! credential is not.
+//!
+//! # A whole request, not a header
+//!
+//! [`Authenticator::authenticate`] takes a built [`reqwest::Request`] and hands
+//! one back. A `headers() -> (name, value)` seam would be smaller and could not
+//! express SigV4 (#24), which signs the method, the URL, the headers AND a hash
+//! of the body — there is no value to compute without them. Building first and
+//! authenticating second is what makes the body available to sign, and it costs
+//! the simple case nothing.
+//!
+//! It is `async` and fallible though nothing here is either yet. Both arrive
+//! with the first cloud credential — SigV4 can fail on a body it cannot read,
+//! and an OAuth token can await a refresh — and a call site written
+//! `auth.authenticate(request).await?` today does not change when they do.
+//!
+//! # Secrets and `Debug`
+//!
+//! Every variant's payload HAND-WRITES its own [`std::fmt::Debug`]. A derived
+//! one prints the secret the moment the value lands in a `tracing` field or a
+//! panic message, which is the same reasoning behind [`crate::credentials`]'s.
+//! The header value is additionally marked sensitive, so the secret does not
+//! survive into [`reqwest::Request`]'s own `Debug` either.
+
+mod header;
+
+#[cfg(test)]
+pub(crate) mod testing;
+
+use crate::error::Result;
+
+pub(crate) use header::Header;
+
+/// One provider's resolved credential.
+///
+/// An enum rather than a trait: the crate's only trait is `ErrorMapper`, and it
+/// is one because the provider-override table is genuinely open-ended. The set
+/// of ways to authenticate is not — it grows by an issue at a time, and a
+/// closed match is what makes a new one fail to compile until every site
+/// handles it. `Protocol` in [`crate::types`] is kept as a one-variant enum on
+/// the same reasoning.
+///
+/// A variant holds a RESOLVED value, never a resolver. `SigV4 { keys, region }`
+/// rather than `SigV4 { chain }`, so a credential built in a test is literals
+/// and cannot reach `~/.aws/config`, honour `AWS_PROFILE`, or call out to
+/// instance metadata. `credentials::with_env` exists to keep the ambient
+/// environment out of tests; a resolver parked in here would walk straight
+/// around it.
+///
+/// `Debug` is derived HERE and hand-written on each payload — see the module
+/// docs. A variant added without doing that leaks its secret.
+#[derive(Debug)]
+pub(crate) enum Authenticator {
+    /// A secret sent in a named header. `Authorization: Bearer …` and
+    /// Anthropic's `x-api-key: …` differ only in the header name and the
+    /// prefix, so they are one variant rather than two.
+    Header(Header),
+    // SigV4 { .. }        <- #24, in `sigv4.rs`
+    // OauthBearer { .. }  <- #25, in `oauth.rs`
+}
+
+impl Authenticator {
+    /// `Authorization: Bearer <secret>` — what every provider on the roster
+    /// today uses, and what an OpenAI-compatible endpoint expects.
+    pub(crate) fn bearer(secret: String) -> Self {
+        Self::Header(Header::bearer(secret))
+    }
+
+    /// `x-api-key: <secret>` — Anthropic's spelling, which deliberately does
+    /// NOT also set `Authorization`.
+    ///
+    /// Reads as dead outside tests, and is: nothing routes to Anthropic yet, so
+    /// [`crate::credentials`] never picks this scheme and the whole
+    /// `gateway::anthropic` tree that would reach it is staged behind the same
+    /// attribute. Both allows come off on the change that adds the roster entry
+    /// and the surface — the same change that drops the one at
+    /// `gateway/mod.rs`.
+    #[allow(dead_code)]
+    pub(crate) fn anthropic_api_key(secret: String) -> Self {
+        Self::Header(Header::anthropic_api_key(secret))
+    }
+
+    /// Applies this credential to a request that is otherwise complete.
+    ///
+    /// Takes the request by value and hands it back, rather than mutating
+    /// through `&mut`: a signing scheme has to read the whole request —
+    /// method, URL, headers, body — before it can add anything, and a borrow
+    /// that is simultaneously handing out the pieces and taking the header map
+    /// is a shape the simple case would be paying for.
+    pub(crate) async fn authenticate(&self, request: reqwest::Request) -> Result<reqwest::Request> {
+        match self {
+            Authenticator::Header(header) => header.apply(request),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::testing::applied;
+    use super::*;
+
+    #[tokio::test]
+    async fn bearer_sets_an_authorization_header() {
+        let auth = Authenticator::bearer("sk-openai".into());
+        assert_eq!(
+            applied(&auth, "authorization").await.as_deref(),
+            Some("Bearer sk-openai")
+        );
+        assert_eq!(applied(&auth, "x-api-key").await, None);
+    }
+
+    /// Anthropic reads `x-api-key` and nothing else. An `Authorization` header
+    /// alongside it is not merely redundant — a proxy in front of Anthropic may
+    /// read one and be answered by the other.
+    #[tokio::test]
+    async fn an_anthropic_key_never_lands_in_an_authorization_header() {
+        let auth = Authenticator::anthropic_api_key("sk-ant-demo".into());
+        assert_eq!(
+            applied(&auth, "x-api-key").await.as_deref(),
+            Some("sk-ant-demo")
+        );
+        assert_eq!(applied(&auth, "authorization").await, None);
+    }
+
+    /// `Debug` is what a panic or a `tracing` field prints. It must name the
+    /// header and none of the secret — the enum's derive is only as safe as the
+    /// payload's own impl.
+    #[test]
+    fn debug_redacts_the_secret() {
+        let rendered = format!("{:?}", Authenticator::bearer("sk-secret-value".into()));
+        assert!(rendered.contains("authorization"), "{rendered}");
+        assert!(!rendered.contains("sk-secret-value"), "{rendered}");
+    }
+}

--- a/crates/warpllm/src/auth/testing.rs
+++ b/crates/warpllm/src/auth/testing.rs
@@ -1,0 +1,27 @@
+//! What an [`Authenticator`] actually puts on a request, for tests elsewhere.
+//!
+//! Goes through a real [`reqwest::Request`] rather than reading the variant's
+//! fields: what these tests are about is the wire, and the fields are private
+//! anyway. Shared rather than copied because `credentials` asserts the same
+//! thing this module does — that the right secret reached the right provider
+//! under the right header — and a second copy would be a second thing to keep
+//! in step with the schemes as they grow.
+
+use super::Authenticator;
+
+/// The value `authenticator` sets for `name`, or `None` if it sets that header
+/// at all.
+pub(crate) async fn applied(authenticator: &Authenticator, name: &str) -> Option<String> {
+    let request = reqwest::Client::new()
+        .post("https://example.invalid/v1/chat/completions")
+        .body("{}")
+        .build()
+        .expect("a well-formed request");
+    authenticator
+        .authenticate(request)
+        .await
+        .expect("a header credential cannot fail on a valid secret")
+        .headers()
+        .get(name)
+        .map(|value| String::from_utf8_lossy(value.as_bytes()).into_owned())
+}

--- a/crates/warpllm/src/client.rs
+++ b/crates/warpllm/src/client.rs
@@ -2,6 +2,7 @@
 
 use std::time::Duration;
 
+use crate::auth::Authenticator;
 use crate::config::{ClientConfig, DEFAULT_TIMEOUT_SECS};
 use crate::credentials::Credentials;
 use crate::error::{Error, Result};
@@ -26,7 +27,7 @@ pub struct Client {
 struct ModelDefinition<'a> {
     provider: &'static ProviderSpec,
     model: &'static ModelSpec,
-    api_key: &'a str,
+    auth: &'a Authenticator,
 }
 
 impl Client {
@@ -126,7 +127,7 @@ impl Client {
         let ModelDefinition {
             provider,
             model,
-            api_key,
+            auth,
         } = self.validate(&requested_model, Api::OpenAiCompatChatCompletions)?;
 
         // Ingest answers to the protocol warpllm was CALLED with, which is
@@ -144,7 +145,7 @@ impl Client {
             &self.http,
             provider.name(),
             self.base_url(provider),
-            api_key,
+            auth,
         )
         .await?;
         let mut completion =
@@ -175,7 +176,7 @@ impl Client {
         let ModelDefinition {
             provider,
             model,
-            api_key,
+            auth,
         } = self.validate(&requested_model, Api::OpenAiCompatChatCompletionsStream)?;
 
         let normalized =
@@ -186,7 +187,7 @@ impl Client {
                 &self.http,
                 provider.name(),
                 self.base_url(provider),
-                api_key,
+                auth,
                 self.config
                     .stream_read_timeout_secs
                     .map(Duration::from_secs),
@@ -224,7 +225,7 @@ impl Client {
         Ok(ModelDefinition {
             provider,
             model,
-            api_key: self.api_key(provider)?,
+            auth: self.authenticator(provider)?,
         })
     }
 
@@ -251,14 +252,14 @@ impl Client {
         }
     }
 
-    /// The routed provider's key, from the snapshot this client took of the
-    /// environment when it was built.
+    /// The routed provider's credential, from the snapshot this client took of
+    /// the environment when it was built.
     ///
     /// A miss is not "the variable is unset now" but "it was unset then", and
     /// the error still names the variable to set, because that is the remedy
     /// either way. A provider with no `env_api_key` has no key source at all,
     /// so the error names the roster rather than a variable nothing reads.
-    fn api_key(&self, provider: &'static ProviderSpec) -> Result<&str> {
+    fn authenticator(&self, provider: &'static ProviderSpec) -> Result<&Authenticator> {
         self.credentials
             .get(provider.name())
             .ok_or(Error::MissingApiKey {
@@ -518,7 +519,7 @@ mod tests {
     #[test]
     fn a_provider_with_no_env_api_key_names_the_roster() {
         let err = client(ClientConfig::default())
-            .api_key(demo_provider("https://api.demo.test", None))
+            .authenticator(demo_provider("https://api.demo.test", None))
             .unwrap_err();
         match &err {
             Error::MissingApiKey { provider, env_var } => {
@@ -666,9 +667,12 @@ mod tests {
 
     /// An inline key routes a provider whose variable is absent — the point of
     /// carrying one at all.
-    #[test]
-    fn an_inline_key_admits_a_provider_the_environment_cannot() {
-        with_env(&[], || {
+    #[tokio::test]
+    async fn an_inline_key_admits_a_provider_the_environment_cannot() {
+        // Built inside the lock, asserted outside it: `with_env` takes a
+        // synchronous closure, and reading what a credential puts on a request
+        // is now an await.
+        let client = with_env(&[], || {
             let config = ClientConfig {
                 providers: Some(BTreeMap::from([(
                     "openai".to_string(),
@@ -678,12 +682,17 @@ mod tests {
                 )])),
                 ..Default::default()
             };
-            let client = Client::new(config).unwrap();
-            let admitted = client
-                .validate("openai/gpt-5.6", Api::OpenAiCompatChatCompletions)
-                .unwrap();
-            assert_eq!(admitted.api_key, "sk-inline");
+            Client::new(config).unwrap()
         });
+        let admitted = client
+            .validate("openai/gpt-5.6", Api::OpenAiCompatChatCompletions)
+            .unwrap();
+        assert_eq!(
+            crate::auth::testing::applied(admitted.auth, "authorization")
+                .await
+                .as_deref(),
+            Some("Bearer sk-inline")
+        );
     }
 
     /// The compatibility claim at the routing gate: saying nothing leaves the
@@ -788,7 +797,7 @@ mod tests {
             &client.http,
             "demo",
             &server.uri(),
-            "k",
+            &Authenticator::bearer("k".into()),
         )
         .await
         .unwrap();
@@ -842,7 +851,7 @@ mod tests {
             &client.http,
             provider.name(),
             client.base_url(provider),
-            "k",
+            &Authenticator::bearer("k".into()),
         )
         .await
         .unwrap();

--- a/crates/warpllm/src/credentials.rs
+++ b/crates/warpllm/src/credentials.rs
@@ -12,6 +12,14 @@
 //! providers are looked at — a client that named two of them reads two
 //! variables, not the roster's worth.
 //!
+//! What each provider gets is an [`Authenticator`] — the resolved credential
+//! AND how it goes on the wire — rather than the bare string it used to be.
+//! The two halves are separate on purpose: a SOURCE is where a secret comes
+//! from, which is what the paragraph above is about, and a SCHEME is how it
+//! goes on the request. Only the two together make a provider reachable, and
+//! they vary independently — Bedrock (#24) will take an AWS chain under a
+//! signature, Vertex (#25) an OAuth token under a bearer header.
+//!
 //! Read once, at construction. A snapshot rather than a live read, so the set of
 //! providers a client can reach cannot change under it mid-flight, and so the
 //! answer can be logged at the one moment a caller is set up to see it. The cost
@@ -20,17 +28,18 @@
 
 use std::collections::{BTreeMap, HashMap};
 
+use crate::auth::Authenticator;
 use crate::config::ProviderConfig;
 use crate::registry::{self, ProviderSpec};
 
-/// The API keys this process holds, keyed by provider name.
+/// The credentials this process holds, keyed by provider name.
 ///
 /// A `HashMap`, matching the registry's own tables: this answers one question,
-/// "the key for this provider", and answers it on every request. Iteration
-/// order is unspecified and varies run to run, so everything that RENDERS the
-/// set goes through [`Credentials::names`] instead.
+/// "the credential for this provider", and answers it on every request.
+/// Iteration order is unspecified and varies run to run, so everything that
+/// RENDERS the set goes through [`Credentials::names`] instead.
 pub(crate) struct Credentials {
-    keys: HashMap<&'static str, String>,
+    keys: HashMap<&'static str, Authenticator>,
 }
 
 impl Credentials {
@@ -49,17 +58,32 @@ impl Credentials {
     /// provider, so a request routed to it should say so rather than send
     /// `Authorization: Bearer ` upstream and report back whatever the provider
     /// makes of it.
+    ///
+    /// The scheme is chosen HERE, and it is [`Authenticator::bearer`] for
+    /// everything, because every provider on the roster is an OpenAI-compatible
+    /// host that reads `Authorization`. [`Self::key_for`] owns the source and
+    /// says nothing about presentation; this is the seam where the table that
+    /// makes the scheme a real choice goes, with the first provider that is not
+    /// bearer.
     pub(crate) fn resolve(declared: Option<&BTreeMap<String, ProviderConfig>>) -> Self {
         let keys = match declared {
             None => registry::providers()
-                .filter_map(|provider| Some((provider.name(), Self::key_for(provider, None)?)))
+                .filter_map(|provider| {
+                    Some((
+                        provider.name(),
+                        Authenticator::bearer(Self::key_for(provider, None)?),
+                    ))
+                })
                 .collect(),
             Some(declared) => declared
                 .iter()
                 .filter_map(|(name, entry)| {
                     let provider = registry::provider(name)
                         .expect("Client::new refuses a declaration the roster does not hold");
-                    Some((provider.name(), Self::key_for(provider, Some(entry))?))
+                    Some((
+                        provider.name(),
+                        Authenticator::bearer(Self::key_for(provider, Some(entry))?),
+                    ))
                 })
                 .collect(),
         };
@@ -103,11 +127,11 @@ impl Credentials {
         (!key.is_empty()).then_some(key)
     }
 
-    /// This provider's key, or `None` when the environment held none at
+    /// This provider's credential, or `None` when no source held a key at
     /// construction — which is what makes "warpllm cannot reach this provider"
     /// answerable without a request.
-    pub(crate) fn get(&self, provider: &str) -> Option<&str> {
-        self.keys.get(provider).map(String::as_str)
+    pub(crate) fn get(&self, provider: &str) -> Option<&Authenticator> {
+        self.keys.get(provider)
     }
 
     /// The providers a request can be routed to, in name order.
@@ -150,6 +174,11 @@ impl std::fmt::Debug for Credentials {
 /// contributor who exports a third provider's key failing an assertion about
 /// which providers are available — and would quietly add every new provider to
 /// every snapshot as the roster grows.
+///
+/// The closure is SYNCHRONOUS, and the lock is released when it returns. A test
+/// asserting what a credential puts on the wire therefore builds its
+/// [`Credentials`] inside and awaits outside, rather than holding a
+/// process-global lock across an await.
 #[cfg(test)]
 pub(crate) fn with_env<T>(vars: &[(&str, Option<&str>)], body: impl FnOnce() -> T) -> T {
     let mut settings: std::collections::BTreeMap<String, Option<String>> = registry::providers()
@@ -169,29 +198,44 @@ mod tests {
     const OPENAI: &str = "OPENAI_API_KEY";
     const DEEPSEEK: &str = "DEEPSEEK_API_KEY";
 
+    /// The credential this provider would send, read off a real request.
+    ///
+    /// Asserted through the wire rather than against a stored string, because
+    /// holding a key and presenting it are now two claims and only one of them
+    /// is a `String` anyone can compare. Which source the key came from is what
+    /// most of these tests are about; that it arrives as `Bearer …` is the
+    /// other half, and this asserts both at once.
+    async fn sent(credentials: &Credentials, provider: &str) -> Option<String> {
+        crate::auth::testing::applied(credentials.get(provider)?, "authorization").await
+    }
+
     /// A key for one provider makes that provider available and says nothing
     /// about any other — the roster is not the availability list.
-    #[test]
-    fn one_key_admits_one_provider() {
-        with_env(&[(OPENAI, Some("sk-openai")), (DEEPSEEK, None)], || {
-            let credentials = Credentials::resolve(None);
-            assert_eq!(credentials.names(), vec!["openai"]);
-            assert_eq!(credentials.get("openai"), Some("sk-openai"));
-            assert_eq!(credentials.get("deepseek"), None);
+    #[tokio::test]
+    async fn one_key_admits_one_provider() {
+        let credentials = with_env(&[(OPENAI, Some("sk-openai")), (DEEPSEEK, None)], || {
+            Credentials::resolve(None)
         });
+        assert_eq!(credentials.names(), vec!["openai"]);
+        assert_eq!(
+            sent(&credentials, "openai").await.as_deref(),
+            Some("Bearer sk-openai")
+        );
+        assert!(credentials.get("deepseek").is_none());
     }
 
     /// Every provider whose variable is set is available at once, in name
-    /// order.
-    #[test]
-    fn every_set_key_admits_its_provider() {
-        with_env(
+    /// order, each carrying its OWN key.
+    #[tokio::test]
+    async fn every_set_key_admits_its_provider() {
+        let credentials = with_env(
             &[(OPENAI, Some("sk-openai")), (DEEPSEEK, Some("sk-deepseek"))],
-            || {
-                let credentials = Credentials::resolve(None);
-                assert_eq!(credentials.names(), vec!["deepseek", "openai"]);
-                assert_eq!(credentials.get("deepseek"), Some("sk-deepseek"));
-            },
+            || Credentials::resolve(None),
+        );
+        assert_eq!(credentials.names(), vec!["deepseek", "openai"]);
+        assert_eq!(
+            sent(&credentials, "deepseek").await.as_deref(),
+            Some("Bearer sk-deepseek")
         );
     }
 
@@ -203,7 +247,7 @@ mod tests {
         with_env(&[(OPENAI, None), (DEEPSEEK, None)], || {
             let credentials = Credentials::resolve(None);
             assert!(credentials.names().is_empty());
-            assert_eq!(credentials.get("openai"), None);
+            assert!(credentials.get("openai").is_none());
         });
     }
 
@@ -222,7 +266,7 @@ mod tests {
     #[test]
     fn an_unknown_provider_is_never_available() {
         with_env(&[(OPENAI, Some("sk-openai"))], || {
-            assert_eq!(Credentials::resolve(None).get("mistral"), None);
+            assert!(Credentials::resolve(None).get("mistral").is_none());
         });
     }
 
@@ -277,42 +321,50 @@ mod tests {
             || {
                 let credentials = Credentials::resolve(Some(&declare(&[("openai", None)])));
                 assert_eq!(credentials.names(), vec!["openai"]);
-                assert_eq!(credentials.get("deepseek"), None);
+                assert!(credentials.get("deepseek").is_none());
             },
         );
     }
 
     /// Declaring a provider without a key of its own leaves the environment
     /// doing exactly what it did before — declaring is not opting out of it.
-    #[test]
-    fn a_declaration_with_no_key_still_reads_the_environment() {
-        with_env(&[(OPENAI, Some("sk-openai")), (DEEPSEEK, None)], || {
-            let credentials = Credentials::resolve(Some(&declare(&[("openai", None)])));
-            assert_eq!(credentials.get("openai"), Some("sk-openai"));
+    #[tokio::test]
+    async fn a_declaration_with_no_key_still_reads_the_environment() {
+        let credentials = with_env(&[(OPENAI, Some("sk-openai")), (DEEPSEEK, None)], || {
+            Credentials::resolve(Some(&declare(&[("openai", None)])))
         });
+        assert_eq!(
+            sent(&credentials, "openai").await.as_deref(),
+            Some("Bearer sk-openai")
+        );
     }
 
     /// The more specific statement wins. A caller who wrote a key into the
     /// config has no other way to make the ambient environment yield.
-    #[test]
-    fn an_inline_key_wins_over_the_environment() {
-        with_env(&[(OPENAI, Some("sk-from-the-environment"))], || {
-            let credentials =
-                Credentials::resolve(Some(&declare(&[("openai", Some("sk-inline"))])));
-            assert_eq!(credentials.get("openai"), Some("sk-inline"));
+    #[tokio::test]
+    async fn an_inline_key_wins_over_the_environment() {
+        let credentials = with_env(&[(OPENAI, Some("sk-from-the-environment"))], || {
+            Credentials::resolve(Some(&declare(&[("openai", Some("sk-inline"))])))
         });
+        assert_eq!(
+            sent(&credentials, "openai").await.as_deref(),
+            Some("Bearer sk-inline")
+        );
     }
 
     /// `""` is unstated, not a stated nothing — the same judgement the
     /// environment's own empty value gets. A caller writing
     /// `os.environ.get("OPENAI_API_KEY", "")` into their config must not
     /// thereby disable a provider whose key is right there.
-    #[test]
-    fn an_empty_inline_key_falls_back_to_the_environment() {
-        with_env(&[(OPENAI, Some("sk-openai"))], || {
-            let credentials = Credentials::resolve(Some(&declare(&[("openai", Some(""))])));
-            assert_eq!(credentials.get("openai"), Some("sk-openai"));
+    #[tokio::test]
+    async fn an_empty_inline_key_falls_back_to_the_environment() {
+        let credentials = with_env(&[(OPENAI, Some("sk-openai"))], || {
+            Credentials::resolve(Some(&declare(&[("openai", Some(""))])))
         });
+        assert_eq!(
+            sent(&credentials, "openai").await.as_deref(),
+            Some("Bearer sk-openai")
+        );
     }
 
     /// Falling back to nothing is still nothing. Neither source held a key, so

--- a/crates/warpllm/src/gateway/anthropic/api/messages/exchange.rs
+++ b/crates/warpllm/src/gateway/anthropic/api/messages/exchange.rs
@@ -1,6 +1,7 @@
 //! The upstream half of a message exchange: gateway types in, gateway types
 //! out.
 
+use crate::auth::Authenticator;
 use crate::error::Result;
 use crate::gateway::anthropic::error::error_from_body;
 use crate::gateway::types;
@@ -29,11 +30,11 @@ pub(crate) async fn exchange(
     http: &reqwest::Client,
     provider: &'static str,
     base_url: &str,
-    api_key: &str,
+    auth: &Authenticator,
     max_output_tokens: Option<u32>,
 ) -> Result<types::ChatResponse> {
     let wire = render_request(request, provider, max_output_tokens)?;
-    match transport::post(http, provider, base_url, api_key, &wire).await? {
+    match transport::post(http, provider, base_url, auth, &wire).await? {
         Outcome::Ok(response) => Ok(ingest_response(response)),
         Outcome::Status {
             status,

--- a/crates/warpllm/src/gateway/openai_compat/api/chat_completions/exchange.rs
+++ b/crates/warpllm/src/gateway/openai_compat/api/chat_completions/exchange.rs
@@ -2,6 +2,7 @@
 
 use std::time::Duration;
 
+use crate::auth::Authenticator;
 use crate::error::Result;
 use crate::gateway::openai_compat::error::error_from_body;
 use crate::gateway::types;
@@ -30,10 +31,10 @@ pub(crate) async fn exchange(
     http: &reqwest::Client,
     provider: &'static str,
     base_url: &str,
-    api_key: &str,
+    auth: &Authenticator,
 ) -> Result<types::ChatResponse> {
     let wire = render_request(request, provider)?;
-    match transport::post(http, provider, base_url, api_key, &wire).await? {
+    match transport::post(http, provider, base_url, auth, &wire).await? {
         Outcome::Ok(response) => Ok(ingest_response(response)),
         Outcome::Status {
             status,
@@ -64,11 +65,11 @@ pub(crate) async fn exchange_stream(
     http: &reqwest::Client,
     provider: &'static str,
     base_url: &str,
-    api_key: &str,
+    auth: &Authenticator,
     read_timeout: Option<Duration>,
 ) -> Result<ChatChunkStream> {
     let wire = render_request(request, provider)?;
-    match transport::post_stream(http, provider, base_url, api_key, &wire, read_timeout).await? {
+    match transport::post_stream(http, provider, base_url, auth, &wire, read_timeout).await? {
         StreamOutcome::Ok(chunks) => Ok(ChatChunkStream { chunks }),
         StreamOutcome::Status {
             status,

--- a/crates/warpllm/src/lib.rs
+++ b/crates/warpllm/src/lib.rs
@@ -1,5 +1,6 @@
 //! Core engine for warpllm, a warp-speed, robust AI gateway.
 
+mod auth;
 mod client;
 mod config;
 mod credentials;

--- a/crates/warpllm/src/protocol/anthropic/messages/transport.rs
+++ b/crates/warpllm/src/protocol/anthropic/messages/transport.rs
@@ -3,20 +3,26 @@
 //! the module path spells the API's name rather than its route.
 //!
 //! Everything Anthropic does differently at the HTTP layer is in this file and
-//! nowhere else — the path, the key header, and the version header:
+//! nowhere else — the path and the version header:
 //!
 //! | | openai_compat | anthropic |
 //! |---|---|---|
 //! | path | `{base_url}/chat/completions` | `{base_url}/messages` |
-//! | auth | `Authorization: Bearer …` | `x-api-key: …` |
 //! | extra | — | `anthropic-version: 2023-06-01` |
 //!
 //! That containment is the point: Bedrock (#24) and Vertex (#25) speak the same
-//! Messages shapes over different transports and auth, so they contribute a
-//! sibling of this file and reuse [`types`](super::types) whole.
+//! Messages shapes over different transports, so they contribute a sibling of
+//! this file and reuse [`types`](super::types) whole.
+//!
+//! What is NOT in this table any more is the credential. `x-api-key: …` is a
+//! fact about `api.anthropic.com`, not about the Messages wire format — the
+//! same shapes reach Bedrock under a SigV4 signature and Vertex under an OAuth
+//! token — so it belongs to the provider's [`Authenticator`] and would
+//! otherwise be the one thing each of those siblings had to reimplement.
 
 use std::time::Duration;
 
+use crate::auth::Authenticator;
 use crate::error::{Error, Result};
 use crate::http::{SseFrames, network_error, read_response};
 use crate::protocol::anthropic::messages::types::{
@@ -69,7 +75,7 @@ pub(crate) async fn post(
     http: &reqwest::Client,
     provider: &'static str,
     base_url: &str,
-    api_key: &str,
+    auth: &Authenticator,
     body: &CreateMessageRequest,
 ) -> Result<Outcome> {
     if body.stream == Some(true) {
@@ -77,10 +83,7 @@ pub(crate) async fn post(
             "stream: true asks for events; a whole reply cannot carry them".into(),
         ));
     }
-    let response = request(http, base_url, api_key, body)
-        .send()
-        .await
-        .map_err(|e| network_error(provider, e))?;
+    let response = send(http, provider, base_url, auth, body).await?;
 
     let parts = read_response(provider, response).await?;
     if !(200..300).contains(&parts.status) {
@@ -135,7 +138,7 @@ pub(crate) enum StreamOutcome {
 /// asked for.
 ///
 /// REQUIRES a body that already asks for a stream, and REFUSES one that does
-/// not rather than setting the flag on its behalf — see [`request`].
+/// not rather than setting the flag on its behalf — see [`send`].
 ///
 /// A non-2xx body is read to the end here, exactly as [`post`] does: an error
 /// reply is small, complete, and worth nothing streamed.
@@ -149,7 +152,7 @@ pub(crate) async fn post_stream(
     http: &reqwest::Client,
     provider: &'static str,
     base_url: &str,
-    api_key: &str,
+    auth: &Authenticator,
     body: &CreateMessageRequest,
     read_timeout: Option<Duration>,
 ) -> Result<StreamOutcome> {
@@ -158,10 +161,7 @@ pub(crate) async fn post_stream(
             "a streamed request must carry stream: true".into(),
         ));
     }
-    let response = request(http, base_url, api_key, body)
-        .send()
-        .await
-        .map_err(|e| network_error(provider, e))?;
+    let response = send(http, provider, base_url, auth, body).await?;
 
     if !(200..300).contains(&response.status().as_u16()) {
         let parts = read_response(provider, response).await?;
@@ -205,16 +205,32 @@ pub(crate) async fn post_stream(
 /// the gateway form's answer on the body; this asserts that it did.
 ///
 /// `openai_compat`'s transport checks the same invariant the same way.
-fn request(
+///
+/// The credential is applied to a BUILT [`reqwest::Request`] rather than to the
+/// builder, so that a signing scheme (#24) can read the method, the URL and the
+/// body it has to sign; `reqwest`'s own `send` would have executed the request
+/// before anything could touch it. `anthropic-version` stays here, because that
+/// one IS a fact about this wire format.
+async fn send(
     http: &reqwest::Client,
+    provider: &'static str,
     base_url: &str,
-    api_key: &str,
+    auth: &Authenticator,
     body: &CreateMessageRequest,
-) -> reqwest::RequestBuilder {
-    http.post(format!("{}/messages", base_url.trim_end_matches('/')))
-        .header("x-api-key", api_key)
+) -> Result<reqwest::Response> {
+    let request = http
+        .post(format!("{}/messages", base_url.trim_end_matches('/')))
         .header("anthropic-version", API_VERSION)
         .json(body)
+        // NOT `Error::Network`: nothing was sent, and nothing was going to be.
+        // A URL that will not parse is a warpllm bug or a misconfigured
+        // `base_url`, and calling it a network error would send someone
+        // looking at the provider's status page.
+        .build()
+        .map_err(|e| Error::Internal(format!("could not build the {provider} request: {e}")))?;
+    http.execute(auth.authenticate(request).await?)
+        .await
+        .map_err(|e| network_error(provider, e))
 }
 
 /// The events of one streamed reply, read off the socket as they arrive.
@@ -385,6 +401,14 @@ mod tests {
 
     use super::*;
 
+    /// The credential every call below sends. `x-api-key`, because that is what
+    /// `api.anthropic.com` reads — but the choice is made here rather than in
+    /// `send`, which is the whole point: Bedrock and Vertex send these same
+    /// bodies under a credential of their own.
+    fn key() -> Authenticator {
+        Authenticator::anthropic_api_key("sk-ant-demo".into())
+    }
+
     fn reply() -> serde_json::Value {
         serde_json::json!({
             "id": "msg_1",
@@ -403,7 +427,7 @@ mod tests {
             &reqwest::Client::new(),
             "anthropic",
             &server.uri(),
-            "sk-ant-demo",
+            &key(),
             &CreateMessageRequest::default(),
         )
         .await
@@ -497,7 +521,7 @@ mod tests {
             &reqwest::Client::new(),
             "anthropic",
             &format!("{}/", server.uri()),
-            "sk-ant-demo",
+            &key(),
             &CreateMessageRequest::default(),
         )
         .await;
@@ -543,7 +567,7 @@ mod tests {
             &reqwest::Client::new(),
             "anthropic",
             &server.uri(),
-            "sk-ant-demo",
+            &key(),
             &streamed(),
             // Unbounded, which is the default and what every test but the
             // stall one below wants: a mock answers instantly, so a limit
@@ -828,7 +852,7 @@ mod tests {
             &reqwest::Client::new(),
             "anthropic",
             &format!("http://{addr}"),
-            "sk-ant-demo",
+            &key(),
             &streamed(),
             Some(LIMIT),
         )
@@ -874,7 +898,7 @@ mod tests {
             &reqwest::Client::new(),
             "anthropic",
             &server.uri(),
-            "sk-ant-demo",
+            &key(),
             &CreateMessageRequest {
                 model: "claude-opus-5".to_string(),
                 max_tokens: 7,
@@ -910,7 +934,7 @@ mod tests {
                 &reqwest::Client::new(),
                 "anthropic",
                 &server.uri(),
-                "sk-ant-demo",
+                &key(),
                 &CreateMessageRequest {
                     stream,
                     ..Default::default()
@@ -940,7 +964,7 @@ mod tests {
             &reqwest::Client::new(),
             "anthropic",
             &server.uri(),
-            "sk-ant-demo",
+            &key(),
             &CreateMessageRequest {
                 stream: Some(true),
                 ..Default::default()

--- a/crates/warpllm/src/protocol/anthropic/mod.rs
+++ b/crates/warpllm/src/protocol/anthropic/mod.rs
@@ -9,9 +9,16 @@
 //! around.
 //!
 //! Bedrock (#24) and Vertex (#25) also speak Messages, over different
-//! transports and auth. When they arrive they reuse [`messages::types`] whole
-//! and contribute a transport apiece — which is the reason those two live at
+//! transports. When they arrive they reuse [`messages::types`] whole and
+//! contribute a transport apiece — which is the reason those two live at
 //! different layers here.
+//!
+//! A transport apiece and NOT an auth apiece: what those two also differ in is
+//! the credential, and that is a fact about the provider rather than about this
+//! wire format, so it lives at [`crate::auth`] and a transport is handed one.
+//! Vertex is what makes the distinction load-bearing — one token there serves
+//! both this protocol and Google's own — so a credential filed under either
+//! would have to be built twice.
 //!
 //! SHAPES AND TRANSPORT ONLY. Turning an Anthropic error body into warpllm's
 //! canonical failure form is an ingest conversion and lives with every other

--- a/crates/warpllm/src/protocol/openai_compat/chat_completions/transport.rs
+++ b/crates/warpllm/src/protocol/openai_compat/chat_completions/transport.rs
@@ -4,6 +4,7 @@
 
 use std::time::Duration;
 
+use crate::auth::Authenticator;
 use crate::error::{Error, Result};
 use crate::http::{SseFrames, network_error, read_response};
 use crate::protocol::openai_compat::chat_completions::types::{
@@ -54,7 +55,7 @@ pub(crate) async fn post(
     http: &reqwest::Client,
     provider: &'static str,
     base_url: &str,
-    api_key: &str,
+    auth: &Authenticator,
     body: &CreateChatCompletionRequest,
 ) -> Result<Outcome> {
     if body.stream == Some(true) {
@@ -62,16 +63,7 @@ pub(crate) async fn post(
             "stream: true asks for chunks; a whole reply cannot carry them".into(),
         ));
     }
-    let response = http
-        .post(format!(
-            "{}/chat/completions",
-            base_url.trim_end_matches('/')
-        ))
-        .bearer_auth(api_key)
-        .json(body)
-        .send()
-        .await
-        .map_err(|e| network_error(provider, e))?;
+    let response = send(http, provider, base_url, auth, body).await?;
 
     let parts = read_response(provider, response).await?;
     if !(200..300).contains(&parts.status) {
@@ -148,7 +140,7 @@ pub(crate) async fn post_stream(
     http: &reqwest::Client,
     provider: &'static str,
     base_url: &str,
-    api_key: &str,
+    auth: &Authenticator,
     body: &CreateChatCompletionRequest,
     read_timeout: Option<Duration>,
 ) -> Result<StreamOutcome> {
@@ -157,16 +149,7 @@ pub(crate) async fn post_stream(
             "a streamed request must carry stream: true".into(),
         ));
     }
-    let response = http
-        .post(format!(
-            "{}/chat/completions",
-            base_url.trim_end_matches('/')
-        ))
-        .bearer_auth(api_key)
-        .json(body)
-        .send()
-        .await
-        .map_err(|e| network_error(provider, e))?;
+    let response = send(http, provider, base_url, auth, body).await?;
 
     if !(200..300).contains(&response.status().as_u16()) {
         let parts = read_response(provider, response).await?;
@@ -186,6 +169,45 @@ pub(crate) async fn post_stream(
         truncated: false,
         read_timeout,
     }))
+}
+
+/// The request both entry points send, differing only in the body's `stream`
+/// — built, authenticated, and executed.
+///
+/// The three steps are one function because the middle one needs the first to
+/// have finished. A credential is applied to a BUILT [`reqwest::Request`] rather
+/// than a builder, so that a signing scheme (#24) can read the method, the URL
+/// and the body it has to sign; `reqwest`'s own `send` would have executed the
+/// request before anything could touch it.
+///
+/// Which header the credential lands in is [`Authenticator`]'s, not this
+/// file's. `Authorization: Bearer …` is what every host on the roster reads,
+/// but it is a fact about those HOSTS rather than about this wire format —
+/// Azure's OpenAI-compatible endpoints read `api-key`, and a self-hosted one
+/// (#22) may read neither — so the spelling belongs to the provider and this
+/// file states only the path.
+async fn send(
+    http: &reqwest::Client,
+    provider: &'static str,
+    base_url: &str,
+    auth: &Authenticator,
+    body: &CreateChatCompletionRequest,
+) -> Result<reqwest::Response> {
+    let request = http
+        .post(format!(
+            "{}/chat/completions",
+            base_url.trim_end_matches('/')
+        ))
+        .json(body)
+        // NOT `Error::Network`: nothing was sent, and nothing was going to be.
+        // A URL that will not parse is a warpllm bug or a misconfigured
+        // `base_url`, and calling it a network error would send someone
+        // looking at the provider's status page.
+        .build()
+        .map_err(|e| Error::Internal(format!("could not build the {provider} request: {e}")))?;
+    http.execute(auth.authenticate(request).await?)
+        .await
+        .map_err(|e| network_error(provider, e))
 }
 
 /// The chunks of one streamed reply, read off the socket as they arrive.
@@ -337,12 +359,19 @@ mod tests {
 
     use super::*;
 
+    /// The credential every call below sends. A bearer token, because that is
+    /// what an OpenAI-compatible host reads — which provider gets which scheme
+    /// is `crate::credentials`', not this module's.
+    fn key() -> Authenticator {
+        Authenticator::bearer("sk-demo".into())
+    }
+
     async fn post_to(server: &MockServer) -> Result<Outcome> {
         post(
             &reqwest::Client::new(),
             "demo",
             &server.uri(),
-            "sk-demo",
+            &key(),
             &CreateChatCompletionRequest::default(),
         )
         .await
@@ -439,7 +468,7 @@ mod tests {
             &reqwest::Client::new(),
             "demo",
             &server.uri(),
-            "sk-demo",
+            &key(),
             &streamed(),
             // Unbounded, which is the default and what every test but the
             // stall one below wants: a mock answers instantly, so a limit
@@ -684,7 +713,7 @@ mod tests {
             &reqwest::Client::new(),
             "demo",
             &format!("http://{addr}"),
-            "sk-demo",
+            &key(),
             &streamed(),
             Some(LIMIT),
         )
@@ -730,7 +759,7 @@ mod tests {
                 &reqwest::Client::new(),
                 "demo",
                 &server.uri(),
-                "sk-demo",
+                &key(),
                 &CreateChatCompletionRequest {
                     stream: body,
                     ..Default::default()
@@ -760,7 +789,7 @@ mod tests {
             &reqwest::Client::new(),
             "demo",
             &server.uri(),
-            "sk-demo",
+            &key(),
             &CreateChatCompletionRequest {
                 stream: Some(true),
                 ..Default::default()
@@ -789,7 +818,7 @@ mod tests {
             &reqwest::Client::new(),
             "demo",
             &format!("{}/", server.uri()),
-            "sk-demo",
+            &key(),
             &CreateChatCompletionRequest::default(),
         )
         .await;


### PR DESCRIPTION
Rebased onto #63 and then #62, both of which changed what this is for the better.

#63 settled where a key comes **from** — a declaration, or the environment
variable the roster names. This settles what warpllm does with one. Refactor
only: the same header reaches the same host carrying the same value, and every
existing assertion about that passes untouched.

## The half #63 could not reach

A credential is still a `String`, threaded as `&str` through four function
boundaries and turned into a header by hand in each protocol's transport. That
fits every provider on the roster and stops fitting for the two on the roadmap:

| | breaks | how |
|---|---|---|
| #24 Bedrock | presentation | SigV4 **signs** a request rather than labelling it |
| #25 Vertex | lifetime | an OAuth token from ADC expires and is refreshed |

One is not a header value at all; the other is not a `String` for long.
`key_for` returning `Option<String>` answers neither, and there is nowhere
above it to put the answer.

`protocol/anthropic/mod.rs` proposed one: Bedrock and Vertex "speak Messages,
over different transports **and auth**… and contribute a transport apiece."
That is right for the **path and the envelope** and wrong for **auth**. Vertex
serves two protocols under one credential, so it would implement auth twice;
and an Azure-style host would need a clone of the whole `openai_compat`
transport to change one header name.

So transport keeps owning the URL and the envelope. Auth comes out, and that
module's promise is amended to say so.

## Why a whole request, not a header pair

```rust
async fn authenticate(&self, request: reqwest::Request) -> Result<reqwest::Request>
```

SigV4 signs the method, the URL, the headers **and** a hash of the body — there
is no header value to compute without them. A `headers() -> (name, value)` seam
would be smaller and could not express Bedrock at all, which would push signing
back into a Bedrock-specific transport: the thing this exists to prevent.
Building first and authenticating second is what makes the body available to
sign, and it costs the simple case nothing.

Verified against the locked reqwest 0.12.28 rather than assumed:
`RequestBuilder::json` sets a `Reusable(Bytes)` body, so **every** body warpllm
sends today is readable via `Body::as_bytes()`.

It is `async` and fallible although nothing here is either yet. Both arrive with
the first cloud credential — signing can fail on a body it cannot read, an OAuth
token can await a refresh — and a call site written
`auth.authenticate(request).await?` today does not change when they do.

## Why an enum, not a trait

The crate's only trait is `ErrorMapper`, and it is one because the
provider-override table is genuinely open-ended. The set of ways to
authenticate is not: it grows an issue at a time, and a closed match is what
makes a new one fail to compile until every site handles it. `Protocol` in
`types.rs` is kept as a one-variant enum on the same reasoning.

A variant holds a **resolved value**, never a resolver — `SigV4 { keys, region }`
rather than `SigV4 { chain }`. Otherwise a `Credentials` built in a unit test
reads `~/.aws/config`, honours `AWS_PROFILE`, and can reach instance metadata,
which is precisely the hazard `credentials::with_env` exists to prevent, one
level deeper.

## Why the crate root, not `protocol/`

For the reason `http.rs` is there: transport machinery every protocol module
uses and none of them owns. `protocol/` is indexed by **wire format**
(`openai_compat/`, `anthropic/`), and a credential is not indexed that way at
all.

Vertex is the case that settles it — one OAuth token serves both the Messages
and the `generateContent` surfaces under a single provider entry, so that file
belongs to neither directory. Anthropic's transport is the case that shows it:
`x-api-key` is a fact about `api.anthropic.com`, not about the Messages wire
format, and the table in that module's header of "everything Anthropic does
differently at the HTTP layer" is a row shorter for it. `anthropic-version`
stays, because that one *is* a fact about the wire format.

Files are named by **scheme**, not by provider — `header.rs`, then `sigv4.rs`
and `oauth.rs` as those land. SigV4 is not Bedrock-specific, and a `bedrock.rs`
would misfile the one axis auth is independent of.

## What this does to #62's and #63's code

`key_for` is untouched and still answers `Option<String>`: where a secret comes
from and how it is presented vary independently, and #63 owns the first.
`resolve` wraps its answer in `Authenticator::bearer` — which is the seam the
provider → scheme table goes through later — and `Credentials` holds
`HashMap<&'static str, Authenticator>`. `ModelDefinition.api_key` becomes
`.auth`. All eight of #63's declaration tests are intact.

From #62, `gateway::anthropic::api::messages::exchange` takes the credential in
place of the key, which is the same edit its `openai_compat` counterpart gets
and keeps the two signatures the mirror they are meant to be.

Several `credentials` tests become `async`. `get` no longer hands back a
`String` to compare, so what a provider holds is asserted by reading the header
it puts on a **real request** — the stronger claim anyway, since it covers
presentation as well as source. `with_env` takes a synchronous closure, so they
build inside the lock and await outside it rather than holding a process-global
lock across an await.

## The one thing that changed on the wire

The credential header is now marked **sensitive**. `reqwest`'s `bearer_auth`
already did that, so the OpenAI-compatible path is untouched; the Anthropic
transport's hand-written `.header("x-api-key", …)` did not, and now does.

It keeps the secret out of `reqwest::Request`'s own `Debug` — a request is a
natural thing to log when one fails — and off the HPACK index on an HTTP/2
connection. There is a test pinning it, alongside one pinning that
`Authenticator`'s `Debug` names the header and never the value.

## Deliberately not here

- **The provider → scheme table.** Every provider on the roster is bearer, so it
  would ship with one legal value and nothing to catch. It lands with the first
  provider that is not — which is also when the two `allow(dead_code)` marks on
  the Anthropic constructor come off.
- **A shared `http::send` helper.** It would make `protocol`'s leaf transitively
  depend on `auth` and dissolve the per-transport containment that module's own
  doc asserts. Each transport calls `authenticate` itself.
- **Endpoint work.** The regional and project-scoped endpoints #24 and #25 need
  are their own change.

## Verification

All four CI jobs green. Locally, the same four:

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo test --workspace` — 459 passed, 1 ignored
- `bindings/python`: `uv run pytest` — 32 passed
- `bindings/node`: `napi build --platform` + `npm test` — 23 passed
- `cargo run -p warpllm-codegen` — no generated file changed

The proof that nothing moved is the assertions that did not have to change:
`posts_to_chat_completions_with_a_bearer_token`,
`the_api_key_does_not_go_in_an_authorization_header`, `MissingApiKey` still
rendering 401 `invalid_api_key`, `ProviderNotDeclared` still rendering 400, and
all 14 of `warpllm-server`'s end-to-end tests, which drive the full
server → client → transport path against a mock upstream and assert
`authorization: Bearer …` arrives, streaming and not.

Not run: anything against a live provider — no provider keys were available in
the environment this was built in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
