### PR TITLE
Route to OpenCode Zen's chat-completion half

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,47 @@ incompatible, and `^0.1` will not upgrade you into one.
   A provider name the roster does not hold fails when the client is built, not
   at the request that happened to route there.
 
+- **OpenCode Zen**, a new `opencode` provider reached at `opencode.ai/zen/v1`
+  with `OPENCODE_API_KEY`, serving sixteen models: `deepseek-v4-pro` and
+  `-flash`, `glm-5.1` and `glm-5.2`, `minimax-m2.7` and `m3`, Kimi K2.6
+  through K3, Zen's own `big-pickle`, and the six `-free` models it bills at
+  nothing during their evaluation window.
+
+  Zen is the first provider here that does not serve its whole catalog over one
+  protocol. It publishes an endpoint PER MODEL — `/chat/completions`,
+  `/responses`, `/messages`, or Google's `/models/<id>` — and only the first is
+  a surface warpllm implements, so that is what this provider is.
+
+  **Zen's GPT models are deliberately absent**, and so are Grok and Muse: all
+  twenty-four sit on `/responses`, the Responses API, which warpllm does not
+  implement yet. Registering them would hand back a model string that resolves
+  and then fails upstream on every request, so they wait for that surface —
+  the same reason `openai/gpt-5-pro` has never been on the roster. Zen's Claude
+  and Qwen models (`/messages`) and its Gemini models (`/models/<id>`) are out
+  for the same kind of reason: neither protocol has an `api:` here at all.
+
+  `glm-5`, `kimi-k2.5` and `minimax-m2.5` are absent although Zen serves all
+  three on chat completions and still returns them from `GET /zen/v1/models`:
+  its DEPRECATED MODELS section retired them on 2026-05-14, 2026-08-05 and
+  2026-08-05, every date already past. The live successors — `glm-5.2`,
+  `kimi-k3`, `minimax-m3` — are on the roster instead.
+
+  Nothing states an endpoint but that docs table, so a Zen model added to the
+  wrong one would lint clean and bill for a request that reaches nothing.
+  `no_opencode_entry_sits_on_a_surface_warpllm_cannot_reach` is the gate, and
+  it matches on family prefix so a name Zen adds later is caught without the
+  test being edited.
+
+  No `capabilities` on any entry: Zen publishes a price per model and no
+  context window, output ceiling, or concurrency figure. Every model is
+  re-hosted, so the original provider's numbers are not Zen's to promise.
+
+  The streaming surface was registered on inference — Zen documents no request
+  parameter at all, and prescribes `@ai-sdk/openai-compatible` as the client
+  for exactly these models — and then checked against the live endpoint, which
+  returns OpenAI-compatible SSE chunks that survive the whole warpllm path.
+  `live_stream.rs` carries a Zen row so it stays checked.
+
 ### Changed
 
 - **Source-breaking for Rust only.** `ClientConfig` gained a field, so an

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ the provider needs and change the model string. Nothing else moves.
 | `openai/gpt-5-nano` | `OPENAI_API_KEY` |
 | `deepseek/deepseek-v4-flash` | `DEEPSEEK_API_KEY` |
 | `kimi/kimi-k3` | `MOONSHOT_API_KEY` |
+| `opencode/glm-5.2` | `OPENCODE_API_KEY` |
 | `openrouter/anthropic/claude-sonnet-4` | `OPENROUTER_API_KEY` |
 
 The `provider/` prefix is required. warpllm matches the whole string against its

--- a/crates/warpllm/src/client.rs
+++ b/crates/warpllm/src/client.rs
@@ -732,7 +732,7 @@ mod tests {
             let message = err.to_string();
             assert!(message.contains("openia"), "{message}");
             assert!(
-                message.contains("deepseek, kimi, openai, openrouter"),
+                message.contains("deepseek, kimi, openai, opencode, openrouter"),
                 "{message}"
             );
             assert!(matches!(err, Error::InvalidInput(_)), "{err:?}");

--- a/crates/warpllm/src/registry/mod.rs
+++ b/crates/warpllm/src/registry/mod.rs
@@ -220,7 +220,7 @@ mod tests {
         let registry = load::load(yaml).unwrap();
         assert_eq!(
             providers(&registry),
-            vec!["deepseek", "kimi", "openai", "openrouter"]
+            vec!["deepseek", "kimi", "openai", "opencode", "openrouter"]
         );
         assert_eq!(
             keys(&registry),
@@ -249,6 +249,22 @@ mod tests {
                 "openai/gpt-5.6-sol",
                 "openai/gpt-5.6-terra",
                 "openai/o3",
+                "opencode/big-pickle",
+                "opencode/deepseek-v4-flash",
+                "opencode/deepseek-v4-flash-free",
+                "opencode/deepseek-v4-pro",
+                "opencode/glm-5.1",
+                "opencode/glm-5.2",
+                "opencode/hy3-free",
+                "opencode/kimi-k2.6",
+                "opencode/kimi-k2.7-code",
+                "opencode/kimi-k3",
+                "opencode/laguna-s-2.1-free",
+                "opencode/mimo-v2.5-free",
+                "opencode/minimax-m2.7",
+                "opencode/minimax-m3",
+                "opencode/nemotron-3-ultra-free",
+                "opencode/nemotron-3.5-lightning-free",
                 "openrouter/anthropic/claude-opus-4",
                 "openrouter/anthropic/claude-sonnet-4",
                 "openrouter/auto",
@@ -438,6 +454,43 @@ mod tests {
             assert!(msg.contains(model_str), "{msg}");
             assert!(msg.contains("no registered model spec"), "{msg}");
         }
+    }
+
+    /// OpenCode Zen is the one provider on the roster serving its catalog
+    /// across FOUR protocols, and only one of them is a surface warpllm has.
+    /// Zen states the endpoint per model and nowhere else — there is nothing
+    /// in a request or a response that says which one a name sits on — so a
+    /// `/responses` or `/messages` model added here would load, lint, pass
+    /// `every_shipped_model_serves_exactly_the_implemented_surfaces`, and then
+    /// send a live, billed request to an endpoint that does not serve it.
+    ///
+    /// This is the only gate on that. It is a prefix check rather than a list
+    /// of the 40-odd names, so a model Zen adds to a family it already serves
+    /// elsewhere is caught without this test being edited.
+    #[test]
+    fn no_opencode_entry_sits_on_a_surface_warpllm_cannot_reach() {
+        // `/zen/v1/responses`: every GPT, plus Grok and Muse.
+        // `/zen/v1/messages`: Claude and Qwen.
+        // `/zen/v1/models/<id>`: Gemini.
+        let elsewhere = ["gpt-", "grok-", "muse-", "claude-", "qwen", "gemini-"];
+        for key in REGISTRY.models.keys() {
+            let Some(name) = key.strip_prefix("opencode/") else {
+                continue;
+            };
+            for prefix in elsewhere {
+                assert!(
+                    !name.starts_with(prefix),
+                    "`{key}`: OpenCode Zen serves `{prefix}…` models on an endpoint \
+                     other than /chat/completions, so this entry would route a paid \
+                     request nowhere. Check the endpoint column of \
+                     <https://opencode.ai/docs/zen/> before registering a Zen model."
+                );
+            }
+        }
+        // The registry is still closed to them by name, the same as any
+        // unlisted model.
+        assert!(fetch_model("opencode/gpt-5-nano").is_err());
+        assert!(fetch_model("opencode/claude-opus-5").is_err());
     }
 
     /// A slash-containing name needs an entry of its own, and the registry

--- a/crates/warpllm/src/registry/specs.yaml
+++ b/crates/warpllm/src/registry/specs.yaml
@@ -85,6 +85,22 @@
 #                                          <https://platform.kimi.ai/docs/api/chat>,
 #                                          <https://openrouter.ai/docs/api-reference/streaming>
 #                                          (all checked 2026-08-12).
+#
+#                                          `opencode` is the one exception, and
+#                                          it is listed on weaker evidence:
+#                                          Zen's docs describe no request
+#                                          parameter at all, `stream` included.
+#                                          What they do is name
+#                                          `@ai-sdk/openai-compatible` as the
+#                                          client for every model registered
+#                                          here, which is the AI SDK's chat
+#                                          completions binding and streams over
+#                                          SSE — and OpenCode's own agent
+#                                          streams every reply through this
+#                                          endpoint. Inference from the client
+#                                          Zen prescribes, then, rather than a
+#                                          line in its docs (checked
+#                                          2026-08-16).
 #   openai_compat_responses                OpenAI's Responses API. Not
 #                                          implemented yet.
 #
@@ -392,6 +408,135 @@ providers:
         capabilities:
           max_input_tokens: 200000
           max_output_tokens: 100000
+
+  # <https://opencode.ai/docs/zen/> (checked 2026-08-16). An aggregator, and
+  # the only one on this roster that does not serve its whole catalog over one
+  # protocol: Zen publishes an endpoint PER MODEL, and the four it uses are
+  # `/chat/completions`, `/responses`, `/messages`, and Google's
+  # `/models/<id>`. Only the first is a surface warpllm implements, so this
+  # provider is the models sitting on it and nothing else. Every entry below
+  # was checked against the endpoint column of that page's model table, which
+  # is the only place Zen states it.
+  #
+  # `OPENCODE_API_KEY`, sent as a bearer token. Zen is a real key-authenticated
+  # API and not only a TUI integration: the docs say to copy the key out of the
+  # dashboard, and `/connect` merely stores that same key for the terminal app.
+  # Sending a bad one to `/chat/completions` gets HTTP 401 and
+  # `{"error":{"type":"AuthError","message":"Invalid API key."}}`.
+  #
+  # The Zen page never names the variable. `models.dev` does, and it is the
+  # registry OpenCode itself reads to configure this provider — `env:
+  # [OPENCODE_API_KEY]`, `api: https://opencode.ai/zen/v1`, both matching the
+  # two lines below exactly. <https://models.dev/api.json>, key `opencode`.
+  #
+  # A `-free` suffix is part of the name Zen serves, not a flag — those models
+  # are billed at nothing during a beta evaluation window, and Zen may
+  # withdraw one when the window closes.
+  #
+  # No `capabilities` on any entry below, and that is the docs rather than an
+  # oversight: Zen publishes a price per model and nothing else — no context
+  # window, no output ceiling, no concurrency. Every model here is re-hosted,
+  # so the original provider's figures are not Zen's to promise, the same
+  # reasoning the `openrouter/` note below spells out.
+  #
+  # `models.dev` DOES carry a window and an output ceiling per Zen model, and
+  # they are deliberately not copied here. It records one figure per HOST, and
+  # the hosts disagree enormously — `glm-5.2` alone spans 200,000 to 1,048,576
+  # of context and 16,384 to 1,048,576 of output across the providers it lists,
+  # so a figure filed under `opencode` is that registry's claim about Zen and
+  # not Zen's about itself. It is also not a liveness signal: it still lists
+  # `glm-5`, `kimi-k2.5` and `minimax-m2.5`, all retired below, along with two
+  # dozen more Zen no longer serves. Good for `env:` and `api:`, which are
+  # facts about reaching the host; not good enough for a number a caller sizes
+  # a prompt against.
+  #
+  # Deliberately absent, all checked 2026-08-16 against the same table:
+  # - Every GPT model, and Grok and Muse with them — 24 names Zen serves at
+  #   `/zen/v1/responses`. That is `openai_compat_responses`, which warpllm
+  #   does not implement, so an entry for one would load and then refuse every
+  #   request routed to it. Same reason `openai/gpt-5-pro` is missing above.
+  # - The Claude and Qwen models, at `/zen/v1/messages`, and the Gemini
+  #   models, at `/zen/v1/models/<id>`. Neither protocol has an `api:` on this
+  #   roster at all.
+  # - OpenCode Go, the cheaper plan reached at `/zen/go/v1/…` with a catalog
+  #   of its own. A second base URL is a second provider entry, not a variant
+  #   of this one. <https://opencode.ai/docs/go/>
+  # - `glm-5` (deprecated 2026-05-14), `kimi-k2.5` and `minimax-m2.5` (both
+  #   2026-08-05). Zen serves chat completions for all three and still returns
+  #   them from `GET /zen/v1/models`, which is exactly why the model table is
+  #   not enough to check an entry against: the DEPRECATED MODELS section
+  #   further down that same page is the only place the dates appear, and all
+  #   three had already passed when this provider was added. Their live
+  #   successors — `glm-5.2`, `kimi-k3`, `minimax-m3` — are registered above.
+  opencode:
+    base_url: "https://opencode.ai/zen/v1"
+    env_api_key: OPENCODE_API_KEY
+    models:
+      # Zen's own unbranded model, listed with no upstream attributed to it.
+      opencode/big-pickle:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
+      opencode/deepseek-v4-flash:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
+      opencode/deepseek-v4-flash-free:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
+      opencode/deepseek-v4-pro:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
+      opencode/glm-5.1:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
+      opencode/glm-5.2:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
+      opencode/hy3-free:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
+      opencode/kimi-k2.6:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
+      opencode/kimi-k2.7-code:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
+      opencode/kimi-k3:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
+      opencode/laguna-s-2.1-free:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
+      opencode/mimo-v2.5-free:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
+      opencode/minimax-m2.7:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
+      opencode/minimax-m3:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
+      opencode/nemotron-3-ultra-free:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
+      opencode/nemotron-3.5-lightning-free:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
 
   # <https://openrouter.ai/docs/api-reference> (checked 2026-08-06).
   #

--- a/crates/warpllm/tests/live_stream.rs
+++ b/crates/warpllm/tests/live_stream.rs
@@ -35,9 +35,29 @@ use warpllm::{
 /// `max_completion_tokens`, while the others still take `max_tokens`. warpllm
 /// passes either through untouched rather than translating between them, so
 /// the caller is what has to know, and here that is this table.
-const MODELS: [(&str, &str); 3] = [
+///
+/// `opencode` earns its row for a reason the others do not need: every other
+/// provider here documents `stream` on the endpoint, and Zen documents no
+/// request parameter at all. Its streaming surface was registered on inference
+/// from the client Zen prescribes — `@ai-sdk/openai-compatible` — so this is
+/// the only place that claim meets the wire.
+///
+/// It is a `-free` model, and the only row here that is. Zen bills per request
+/// and refuses a paid model OUTRIGHT when the account carries no payment
+/// method — `CreditsError` at HTTP 401, not a warning — so a paid pick would
+/// leave a contributor holding a perfectly good `OPENCODE_API_KEY` watching
+/// this fail for a reason that is not warpllm's.
+///
+/// The free tier's own cost is a per-model `FreeUsageLimitError`, generous
+/// enough for the one request per run this makes but not for a burst. Two
+/// consequences worth knowing before changing this line: a rerun in quick
+/// succession can 429, and Zen may withdraw a free model when its evaluation
+/// window closes. Both surface as this test naming the model it failed on,
+/// which is why the name is printed rather than only asserted.
+const MODELS: [(&str, &str); 4] = [
     ("openai/gpt-5-nano", "max_completion_tokens"),
     ("deepseek/deepseek-v4-flash", "max_tokens"),
+    ("opencode/laguna-s-2.1-free", "max_tokens"),
     (
         "openrouter/~deepseek/deepseek-v4-flash-latest",
         "max_tokens",

--- a/crates/warpllm/tests/providers.rs
+++ b/crates/warpllm/tests/providers.rs
@@ -13,6 +13,9 @@ mod deepseek_chat_completions;
 #[path = "providers/deepseek/config_env.rs"]
 mod deepseek_config_env;
 
+#[path = "providers/opencode/config_env.rs"]
+mod opencode_config_env;
+
 #[path = "providers/openrouter/config_env.rs"]
 mod openrouter_config_env;
 

--- a/crates/warpllm/tests/providers/opencode/config_env.rs
+++ b/crates/warpllm/tests/providers/opencode/config_env.rs
@@ -1,0 +1,67 @@
+use crate::openai_common::{openai_completion_body, request};
+use warpllm::{Client, ClientConfig, Error};
+use wiremock::matchers::{header, method};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Env mutation is process-global, so these scenarios run inside one test
+/// body (temp-env serializes the unsafe set/unset around the closure).
+#[test]
+fn opencode_key_resolves_per_provider() {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+
+    temp_env::with_var("OPENCODE_API_KEY", Some("sk-opencode-env"), || {
+        runtime.block_on(async {
+            // 1. Zen requests use OPENCODE_API_KEY as bearer, and the key's
+            //    last segment is what goes upstream — Zen's own identifiers
+            //    are one segment, so no entry carries a `model:` override the
+            //    way every `openrouter/` one has to.
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(header("authorization", "Bearer sk-opencode-env"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(openai_completion_body()))
+                .expect(1)
+                .mount(&server)
+                .await;
+            let client = Client::new(ClientConfig {
+                base_url: Some(server.uri()),
+                ..Default::default()
+            })
+            .unwrap();
+            client
+                .chat_completions(request("opencode/kimi-k3"))
+                .await
+                .unwrap();
+
+            let sent = &server.received_requests().await.unwrap()[0];
+            let body: serde_json::Value = serde_json::from_slice(&sent.body).unwrap();
+            assert_eq!(body["model"], "kimi-k3");
+        });
+    });
+
+    temp_env::with_vars(
+        [
+            ("MOONSHOT_API_KEY", Some("sk-moonshot-env")),
+            ("OPENCODE_API_KEY", None),
+        ],
+        || {
+            runtime.block_on(async {
+                // 2. Zen re-hosts Moonshot's weights, and a Moonshot key must
+                //    still not satisfy it: `opencode/kimi-k3` and
+                //    `kimi/kimi-k3` are two accounts at two hosts that happen
+                //    to serve one model. The error names Zen's own variable.
+                let client = Client::new(ClientConfig::default()).unwrap();
+                let err = client
+                    .chat_completions(request("opencode/kimi-k3"))
+                    .await
+                    .unwrap_err();
+                match err {
+                    Error::MissingApiKey { provider, env_var } => {
+                        assert_eq!(provider, "opencode");
+                        assert_eq!(env_var, Some("OPENCODE_API_KEY"));
+                    }
+                    other => panic!("expected MissingApiKey, got {other:?}"),
+                }
+            });
+        },
+    );
+}


### PR DESCRIPTION
Closes #50.

OpenCode Zen joins the roster as `opencode`, reached at `opencode.ai/zen/v1`
with `OPENCODE_API_KEY`. Sixteen models, all on the one surface warpllm
implements.

## Why only sixteen

Zen is the first provider here that does not serve its whole catalog over one
protocol. It publishes an endpoint **per model**, and uses four of them:

| Endpoint | Models | Status here |
| --- | --- | --- |
| `/chat/completions` | DeepSeek, GLM, Kimi, MiniMax, `big-pickle`, the `-free` tier | **registered** |
| `/responses` | all 20 GPT models, Grok, Muse | absent |
| `/messages` | Claude, Qwen | absent |
| `/models/<id>` | Gemini | absent |

The issue asked for the OpenAI models. All twenty sit on `/responses` — that is
`openai_compat_responses`, which warpllm does not implement, so an entry for one
would load, lint, and then refuse or misroute every request made to it. That is
the same reason `openai/gpt-5-pro` has never been on the roster. They land the
day that surface does. Claude/Qwen and Gemini are out because neither protocol
has an `api:` on this roster at all.

## Deprecated models

`glm-5`, `kimi-k2.5` and `minimax-m2.5` are deliberately absent. Zen still
serves all three on `/chat/completions` and still returns them from
`GET /zen/v1/models` — the retirement appears **only** in the DEPRECATED MODELS
prose section of the Zen docs, which dates them 2026-05-14, 2026-08-05 and
2026-08-05. Every one of those dates has already passed. Their live successors
`glm-5.2`, `kimi-k3` and `minimax-m3` are registered instead.

This is worth knowing for the next roster edit: neither the model table nor the
API is a liveness signal for Zen, and neither is `models.dev`, which still
lists those three plus roughly two dozen more Zen no longer serves.

## No capabilities

Zen publishes a price per model and nothing else — no context window, no output
ceiling, no concurrency. `models.dev` does carry figures, and they are
deliberately not copied: it records one per **host**, and the hosts disagree
enormously (`glm-5.2` alone spans 200,000–1,048,576 context and
16,384–1,048,576 output across the providers it lists), so a number filed under
`opencode` there is that registry's claim about Zen rather than Zen's about
itself.

## Streaming rests on weaker evidence than the rest of the roster

Every other provider documents `stream` on the endpoint. Zen documents no
request parameter at all. What it does is prescribe `@ai-sdk/openai-compatible`
as the client for exactly these models — the AI SDK's chat-completions binding,
which streams over SSE. `specs.yaml` says so plainly rather than citing a line
that does not exist, and `live_stream.rs` gained a Zen row so the claim is
checked against the wire instead of only asserted.

## Verified against the live API

Ran against the real Zen endpoint with a live key.

**Routing, auth, base URL, model names** — all seven free-tier models return a
real completion (`finish_reason: stop`, usage reported). The nine paid models
return Zen's `CreditsError` because the test account carries no payment method;
that is the account's state, not the route's.

**Streaming** — Zen emits OpenAI-compatible SSE (`chat.completion.chunk`,
`delta.content`, `finish_reason`), and it survives the whole warpllm path:

```
$ OPENCODE_API_KEY=... cargo test -p warpllm --test live_stream -- --ignored --nocapture
opencode/laguna-s-2.1-free: 3 chunks, finish_reason ["stop", "stop"], usage sent
streamed: ["opencode/laguna-s-2.1-free"]
test every_configured_provider_streams_chunks_warpllm_can_hold ... ok
```

So the streaming surface is no longer an inference. `live_stream.rs` uses a
`-free` model deliberately: Zen refuses a paid model outright when the account
has no payment method, so a paid pick would fail for a reason that is not
warpllm's. The tradeoff is a per-model `FreeUsageLimitError` — fine for the one
request per run this makes, but a rapid rerun can 429.

**Error classification, one rough edge found** — `429` came back correctly
classified and attributed to `opencode`. Credit exhaustion does not; see below.

## Tests

- `no_opencode_entry_sits_on_a_surface_warpllm_cannot_reach` — the gate for the
  hazard this PR introduces. Nothing but that docs table says which endpoint a
  Zen model uses, so a wrongly-filed entry would lint clean and bill for a
  request that reaches nothing. Matches on family prefix, so a name Zen adds
  later is caught without editing the test.
- `providers/opencode/config_env.rs` — pins that a `MOONSHOT_API_KEY` does not
  satisfy `opencode/kimi-k3`. Same weights, two accounts at two hosts.

## Follow-up, not in this PR

Zen reports credit exhaustion as **HTTP 401** with
`{"error":{"type":"CreditsError","message":"No payment method…"}}` and no
`code`. warpllm classifies that as `Error::Authentication`, so a billing
problem reads as a bad API key. It is not fixable with a provider override:
`classify` consults `protocol.from_status` (tier 4) before any
`provider.from_type` (tier 5), and 401 genuinely *is* auth for a bad key — Zen
returns `AuthError` at the same status. Distinguishing them needs the mapper to
see status and type together, which is a change to shared precedence and
belongs on its own.
