### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ Versions follow [semantic versioning](https://semver.org). While the project is
 pre-1.0, a breaking change bumps the MINOR number: `0.1.x` and `0.2.x` are
 incompatible, and `^0.1` will not upgrade you into one.
 
-## [Unreleased]
+## [0.4.0] - 2026-08-16
+
+Two additions and one source-break. A client can now declare the providers it
+serves — narrowing both which environment variables are read and which models
+are routable — and OpenCode Zen joins the roster as `opencode`.
+
+The break is Rust-only and one line to fix: `ClientConfig` gained a field, so an
+exhaustive struct literal no longer compiles. Python and TypeScript are purely
+additive, and a Rust caller already using `..Default::default()` is unaffected.
+That is what moves the MINOR number rather than the patch, per the versioning
+note at the top of this file — `^0.3` will not upgrade you into it.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "warpllm"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "proptest",
  "reqwest",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "warpllm-codegen"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "schemars",
  "serde_json",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "warpllm-node"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "warpllm-python"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "warpllm-server"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.85"

--- a/README.md
+++ b/README.md
@@ -149,22 +149,24 @@ This project is to lay out the most resilient open source productionization laye
 ## Status
 
 > [!IMPORTANT]
-> The published packages are **0.3.1**, which adds streaming — from the Rust
-> core, both SDKs, and the HTTP gateway — alongside the Kimi provider and the
-> rest of OpenAI's chat-completion roster. It is a **breaking** release:
-> response fields that are optional *and* nullable now tell an absent key from
-> an explicit `null`, so their type changed in all three languages. See the
-> [changelog](CHANGELOG.md) before upgrading from `0.2.x`.
+> The published packages are **0.4.0**, which adds the OpenCode Zen provider
+> and lets a client declare the providers it serves. It is **source-breaking
+> for Rust only**: `ClientConfig` gained a field, so an exhaustive struct
+> literal no longer compiles — add `providers: None`, or switch to
+> `..Default::default()`. Python and TypeScript are purely additive. See the
+> [changelog](CHANGELOG.md) before upgrading from `0.3.x`.
 >
 > The OpenAI-compatible HTTP gateway has landed on `main` but is **not
 > released yet**.
 
-| | Released (0.3.1) | On `main` |
+| | Released (0.4.0) | On `main` |
 | --- | --- | --- |
 | OpenAI chat completions, non-streaming | Yes | Yes |
 | `provider/model` routing strings | Provider registry | Provider registry |
 | DeepSeek, OpenRouter | Yes | Yes |
 | Kimi | Yes | Yes |
+| OpenCode Zen | Yes | Yes |
+| Declaring the providers a client serves | Yes | Yes |
 | OpenAI-compatible HTTP gateway | — | Unreleased |
 | Streaming | Yes | Yes |
 | Failover, load balancing, caching, metrics | — | — |

--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-android-arm64')
         const bindingPackageVersion = require('@warpllm/warpllm-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-android-arm-eabi')
         const bindingPackageVersion = require('@warpllm/warpllm-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-win32-x64-gnu')
         const bindingPackageVersion = require('@warpllm/warpllm-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-win32-x64-msvc')
         const bindingPackageVersion = require('@warpllm/warpllm-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-win32-ia32-msvc')
         const bindingPackageVersion = require('@warpllm/warpllm-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-win32-arm64-msvc')
         const bindingPackageVersion = require('@warpllm/warpllm-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@warpllm/warpllm-darwin-universal')
       const bindingPackageVersion = require('@warpllm/warpllm-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-darwin-x64')
         const bindingPackageVersion = require('@warpllm/warpllm-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-darwin-arm64')
         const bindingPackageVersion = require('@warpllm/warpllm-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-freebsd-x64')
         const bindingPackageVersion = require('@warpllm/warpllm-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-freebsd-arm64')
         const bindingPackageVersion = require('@warpllm/warpllm-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-x64-musl')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-x64-gnu')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-arm64-musl')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-arm64-gnu')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-arm-musleabihf')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-loong64-musl')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-loong64-gnu')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-riscv64-musl')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-riscv64-gnu')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-linux-ppc64-gnu')
         const bindingPackageVersion = require('@warpllm/warpllm-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-linux-s390x-gnu')
         const bindingPackageVersion = require('@warpllm/warpllm-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-openharmony-arm64')
         const bindingPackageVersion = require('@warpllm/warpllm-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-openharmony-x64')
         const bindingPackageVersion = require('@warpllm/warpllm-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-openharmony-arm')
         const bindingPackageVersion = require('@warpllm/warpllm-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@warpllm/warpllm",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@warpllm/warpllm",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.7",

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@warpllm/warpllm",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A warp-speed, robust AI gateway",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Version bump only — no behaviour change. Everything shipping here already
merged: the provider declaration work and OpenCode Zen (#65).

## Why 0.4.0 and not 0.3.2

`ClientConfig` gained a `providers` field and carries no `#[non_exhaustive]`,
so a downstream exhaustive struct literal no longer compiles. The changelog
already recorded that as source-breaking; this makes the version agree with it.
Per the versioning note at the top of `CHANGELOG.md`, a pre-1.0 break moves the
MINOR number, so `^0.3` will not pull anyone into it unasked.

Rust-only. Python and TypeScript are purely additive, and a Rust caller already
using `..Default::default()` needs no change.

## What moved

| File | Why |
| --- | --- |
| `Cargo.toml` | `[workspace.package] version`, inherited by all five crates |
| `bindings/node/package.json` | npm version; the release gate asserts it equals the workspace version and the tag |
| `bindings/node/package-lock.json` | same version, two lines |
| `bindings/node/index.js` | generated but committed — see below |
| `Cargo.lock` | the five workspace members |
| `CHANGELOG.md` | `[Unreleased]` → `[0.4.0] - 2026-08-16`, with a lead paragraph naming the break |
| `README.md` | status block and the released/`main` table |

`bindings/node/index.js` is the one that is easy to miss. It is generated by
`napi build` but committed, and it hardcodes the native binding version it will
accept — 52 occurrences. Left at `0.3.1`, every npm install running with
`NAPI_RS_ENFORCE_VERSION_CHECK` set would throw
`Native binding package version mismatch, expected 0.3.1 but got 0.4.0`. The CI
codegen job would not have caught it: it never runs `napi build`.

## Verified locally

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`,
  `cargo test --workspace` — 14 suites green
- Python: 32 passed. The extension had to be force-rebuilt to pick up the new
  version, which is also what proves the PyPI package derives it from
  `Cargo.toml` — `warpllm==0.3.1` → `warpllm==0.4.0`
- Node: `npm ci`, `napi build --platform`, 23 tests green
- `cargo run -p warpllm-codegen` regenerates nothing
- The release workflow's own gate, run by hand:
  `workspace=0.4.0 package.json=0.4.0 tag_would_be=v0.4.0` → passes

Tag `v0.4.0` after this merges; that is what triggers crates.io, PyPI and npm.