### PR TITLE
Read Anthropic's stream, one value at a time

### DIFF
--- a/crates/warpllm/src/gateway/anthropic/api/messages/exchange.rs
+++ b/crates/warpllm/src/gateway/anthropic/api/messages/exchange.rs
@@ -1,12 +1,16 @@
 //! The upstream half of a message exchange: gateway types in, gateway types
 //! out.
 
+use std::time::Duration;
+
 use crate::auth::Authenticator;
 use crate::error::Result;
 use crate::gateway::anthropic::error::error_from_body;
 use crate::gateway::types;
-use crate::protocol::anthropic::messages::transport::{self, Outcome};
+use crate::protocol::anthropic::messages::transport::{self, EventStream, Outcome, StreamOutcome};
+use crate::protocol::anthropic::messages::types::MessageStreamEvent;
 
+use super::stream::{StreamState, ingest_event};
 use super::{ingest_response, render_request};
 
 /// Renders the gateway request for this protocol, posts it, and ingests the
@@ -48,5 +52,320 @@ pub(crate) async fn exchange(
             retry_after,
             request_id,
         )),
+    }
+}
+
+/// [`exchange`] for a streamed reply: gateway types on both ends, the same
+/// order stated once, and the same error mapping.
+///
+/// The failure it can report is only the one that happens BEFORE any event — a
+/// refused request, a rate limit, an unreachable host. Once the stream is open
+/// there is no status left to map, and a failure surfaces on the stream itself.
+///
+/// `read_timeout` travels through rather than being read from a client, which
+/// is what keeps this stateless.
+pub(crate) async fn exchange_stream(
+    request: &types::ChatRequest,
+    http: &reqwest::Client,
+    provider: &'static str,
+    base_url: &str,
+    auth: &Authenticator,
+    max_output_tokens: Option<u32>,
+    read_timeout: Option<Duration>,
+) -> Result<ChatChunkStream> {
+    // `render_request` puts `stream: true` on the body from the gateway form;
+    // the transport CHECKS it rather than setting it, so a request whose
+    // gateway form says otherwise fails here rather than being silently
+    // corrected. See `transport::send`.
+    let wire = render_request(request, provider, max_output_tokens)?;
+    match transport::post_stream(http, provider, base_url, auth, &wire, read_timeout).await? {
+        StreamOutcome::Ok(events) => Ok(ChatChunkStream {
+            events,
+            provider,
+            // The one thing the stream needs from the request, and the reason
+            // it is read here: Anthropic reports a stream's totals whether or
+            // not anyone asked, and only the request knows whether anyone did.
+            state: StreamState::new(request.stream_include_usage == Some(true)),
+        }),
+        StreamOutcome::Status {
+            status,
+            body,
+            retry_after,
+            request_id,
+        } => Err(error_from_body(
+            provider,
+            status,
+            &body,
+            retry_after,
+            request_id,
+        )),
+    }
+}
+
+/// The gateway's view of a stream: wire events in, [`types::ChatResponseChunk`]
+/// out — but NOT one for one.
+///
+/// This is the seam its openai_compat counterpart says it exists for, and the
+/// reason that one can be "thin on purpose" while this one cannot. Two things
+/// differ, and both are this protocol's shape rather than an implementation
+/// choice:
+///
+/// * **State.** `id` and `model` arrive once, on `message_start`, and every
+///   gateway chunk requires them. [`StreamState`] is the memory that makes that
+///   possible, and it lives here because a stream is the only scope that
+///   outlives a single event.
+/// * **Events that are not chunks.** `content_block_stop` and `ping` carry
+///   nothing a chunk can hold, so they ingest to `None` and this loop skips
+///   them rather than emitting empty values. `message_stop` joins them
+///   whenever the caller did not ask for the stream's totals, which are the
+///   only thing it has to say.
+/// * **A request field the stream reads.** `stream_include_usage`, for the
+///   same reason — see [`StreamState`].
+/// * **An event that is a FAILURE.** See [`Self::next`].
+#[derive(Debug)]
+pub(crate) struct ChatChunkStream {
+    events: EventStream,
+    provider: &'static str,
+    state: StreamState,
+}
+
+/// The status a mid-stream failure is classified against.
+///
+/// There is no real one: the HTTP exchange already answered 200 and the failure
+/// arrived after it, which is exactly the case `error.rs`'s `type` table exists
+/// for. Passing the status that WAS sent keeps `classify` honest — it finds no
+/// status rule, falls to the family, and reports `overloaded_error` as an
+/// overload rather than as an unattributed server fault.
+const AFTER_THE_HEADERS: u16 = 200;
+
+impl ChatChunkStream {
+    /// The next chunk, skipping the events that carry no gateway content and
+    /// converting the one that carries a failure.
+    ///
+    /// A loop rather than a single read: skipping is not the same as ending,
+    /// and returning `None` for a `ping` would cut a live stream short at the
+    /// first keepalive.
+    ///
+    /// The `error` arm is the reason this cannot be a plain skip. Anthropic
+    /// sends errors mid-stream after a 200 — an overload during generation —
+    /// and `EventStream` hands one over as `Ok(event)` with the stream marked
+    /// COMPLETE, because to the transport it is a well-formed event that ends
+    /// the stream. Skipping it the way a `ping` is skipped would read the next
+    /// event, get `None` from a completed stream, and report a truncated reply
+    /// as a finished one — burying the reason the provider gave under a clean
+    /// EOF. So it becomes an [`Err`] here, at the one layer that knows a
+    /// failure from an absence.
+    pub(crate) async fn next(&mut self) -> Option<Result<types::ChatResponseChunk>> {
+        loop {
+            let event = match self.events.next().await? {
+                Ok(event) => event,
+                Err(error) => return Some(Err(error)),
+            };
+            if let MessageStreamEvent::Error(_) = &event {
+                return Some(Err(self.failure(&event)));
+            }
+            if let Some(chunk) = ingest_event(event, &mut self.state) {
+                return Some(Ok(chunk));
+            }
+        }
+    }
+
+    /// A mid-stream `error` event as the failure it reports.
+    ///
+    /// Serialized whole rather than reaching into the payload: `error_from_body`
+    /// reads the `{"type": "error", "error": {…}}` envelope this is, so the
+    /// mid-stream and the non-2xx paths classify one shape through one table.
+    fn failure(&self, event: &MessageStreamEvent) -> crate::Error {
+        let body = serde_json::to_string(event).unwrap_or_default();
+        error_from_body(self.provider, AFTER_THE_HEADERS, &body, None, None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+    use crate::auth::Authenticator;
+    use crate::gateway::types::{GenerationParams, Role};
+
+    const START: &str = concat!(
+        "event: message_start\n",
+        r#"data: {"type":"message_start","message":{"id":"msg_1","type":"message","#,
+        r#""role":"assistant","model":"claude-opus-5","content":[],"#,
+        r#""stop_reason":null,"stop_sequence":null,"#,
+        r#""usage":{"input_tokens":4,"output_tokens":1}}}"#,
+        "\n\n",
+    );
+
+    fn request() -> types::ChatRequest {
+        types::ChatRequest {
+            model: "claude-opus-5".into(),
+            messages: vec![types::Message {
+                role: Role::User,
+                content: vec![types::ContentBlock::Text {
+                    text: "hi".into(),
+                    cache: None,
+                }],
+                ext: types::ProviderExt::new(),
+            }],
+            // The transport CHECKS this rather than setting it, so the gateway
+            // form has to say so before `render_request` can put it on the body.
+            stream: true,
+            params: GenerationParams {
+                max_tokens: Some(16),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    /// Opens a stream against a body the mock serves verbatim.
+    async fn stream_of(body: String) -> ChatChunkStream {
+        opened(request(), body).await
+    }
+
+    /// [`stream_of`] for a request the caller shaped, which is the only way to
+    /// reach what the stream reads OFF that request.
+    async fn opened(request: types::ChatRequest, body: String) -> ChatChunkStream {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(body),
+            )
+            .mount(&server)
+            .await;
+        let stream = exchange_stream(
+            &request,
+            &reqwest::Client::new(),
+            "anthropic",
+            &server.uri(),
+            &Authenticator::anthropic_api_key("sk-ant-demo".into()),
+            None,
+            None,
+        )
+        .await
+        .expect("a 200 opens a stream");
+        // The mock server must outlive the socket.
+        std::mem::forget(server);
+        stream
+    }
+
+    async fn collect(mut stream: ChatChunkStream) -> Vec<Result<types::ChatResponseChunk>> {
+        let mut chunks = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            chunks.push(chunk);
+        }
+        chunks
+    }
+
+    /// THE failure this seam exists to prevent. Anthropic reports an overload
+    /// mid-generation as an `error` EVENT after a 200, and the transport hands
+    /// it over as a well-formed event that ends the stream. A reader that
+    /// skipped it the way it skips a `ping` would then read a completed stream,
+    /// get `None`, and report a half-written reply as a finished one — the
+    /// provider's reason buried under a clean EOF.
+    #[tokio::test]
+    async fn a_mid_stream_error_is_a_failure_and_not_a_clean_end() {
+        let chunks = collect(
+            stream_of(format!(
+                "{START}event: error\ndata: {}\n\n",
+                r#"{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}"#
+            ))
+            .await,
+        )
+        .await;
+
+        let last = chunks.last().expect("the stream produced nothing at all");
+        let error = last
+            .as_ref()
+            .expect_err("the mid-stream error was reported as a successful chunk");
+        assert!(
+            matches!(error, crate::Error::Overloaded(_)),
+            "the family decided the meaning: {error}"
+        );
+        assert!(error.to_string().contains("Overloaded"), "{error}");
+    }
+
+    /// The events that carry nothing ARE skipped, which is the behaviour the
+    /// error arm above must not be confused with. A `ping` between two content
+    /// events must not end the stream or produce an empty chunk.
+    #[tokio::test]
+    async fn keepalives_and_block_boundaries_are_skipped_not_ended() {
+        let chunks = collect(
+            stream_of(format!(
+                "{START}\
+                 event: ping\ndata: {{\"type\":\"ping\"}}\n\n\
+                 event: content_block_start\ndata: {}\n\n\
+                 event: ping\ndata: {{\"type\":\"ping\"}}\n\n\
+                 event: content_block_delta\ndata: {}\n\n\
+                 event: content_block_stop\ndata: {{\"type\":\"content_block_stop\",\"index\":0}}\n\n\
+                 event: message_delta\ndata: {}\n\n\
+                 event: message_stop\ndata: {{\"type\":\"message_stop\"}}\n\n",
+                r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#,
+                r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}"#,
+                r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":9}}"#,
+            ))
+            .await,
+        )
+        .await;
+
+        assert!(
+            chunks.iter().all(Result::is_ok),
+            "a well-formed stream reported a failure"
+        );
+        // message_start, block start, block delta, message delta — and NOT the
+        // two pings, the block stop, or the message stop, which carries the
+        // totals this request did not ask for. See the test below.
+        assert_eq!(chunks.len(), 4, "contentless events produced chunks");
+        assert_eq!(
+            chunks.last().unwrap().as_ref().unwrap().completions[0]
+                .finish_reason_raw
+                .as_deref(),
+            Some("end_turn")
+        );
+        assert!(
+            chunks
+                .iter()
+                .all(|chunk| chunk.as_ref().unwrap().usage.is_none()),
+            "totals nobody asked for reached the caller"
+        );
+    }
+
+    /// And the same transcript, for a caller who DID ask, grows one chunk: the
+    /// totals, on a chunk of their own.
+    ///
+    /// The gating lives in [`StreamState`] and the decision to apply it lives
+    /// HERE, in the one place that can see the request — so a test against the
+    /// state alone would pass with this seam reading nothing at all.
+    #[tokio::test]
+    async fn a_caller_who_asked_for_the_totals_gets_them_on_a_chunk_of_their_own() {
+        let chunks = collect(
+            opened(
+                types::ChatRequest {
+                    stream_include_usage: Some(true),
+                    ..request()
+                },
+                format!(
+                    "{START}\
+                     event: message_delta\ndata: {}\n\n\
+                     event: message_stop\ndata: {{\"type\":\"message_stop\"}}\n\n",
+                    r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":9}}"#,
+                ),
+            )
+            .await,
+        )
+        .await;
+
+        // message_start, message_delta, and the totals `message_stop` carries.
+        assert_eq!(chunks.len(), 3);
+        let totals = chunks.last().unwrap().as_ref().unwrap();
+        assert!(totals.completions.is_empty());
+        let usage = totals.usage.as_ref().expect("the totals were asked for");
+        assert_eq!(usage.output_tokens, Some(9));
+        assert_eq!(usage.input_tokens, Some(4));
     }
 }

--- a/crates/warpllm/src/gateway/anthropic/api/messages/mod.rs
+++ b/crates/warpllm/src/gateway/anthropic/api/messages/mod.rs
@@ -1,16 +1,17 @@
 //! `Api::AnthropicMessages` ↔ the gateway forms.
 //!
 //! Split the way its openai_compat sibling is: [`request`] and [`response`] are
-//! the conversions, [`exchange`] is the one place this protocol's order —
-//! render, post, ingest — is stated.
+//! the conversions, [`stream`] is the streamed counterpart of [`response`], and
+//! [`exchange`] is the one place this protocol's order — render, post, ingest —
+//! is stated, for both the whole reply and the streamed one.
 //!
-//! The streaming half — the named-event mapping and the chunk stream carrying
-//! it — lands separately. It is the harder piece and earns its own review
-//! rather than being buried in this one.
+//! [`stream`] is the one module here that does NOT promise a byte-exact round
+//! trip. Its contract is reassembly-equivalence, for reasons its own docs give.
 
 mod exchange;
 mod request;
 mod response;
+mod stream;
 
 // Nothing calls these yet. warpllm is CALLED in another protocol and only
 // SPEAKS this one, so `ingest_request` and `render_response` wait on an
@@ -20,7 +21,8 @@ mod response;
 // unused halves are what the round-trip tests are written against.
 #[allow(unused_imports)]
 pub(crate) use self::{
-    exchange::exchange,
+    exchange::{ChatChunkStream, exchange, exchange_stream},
     request::{ingest_request, render_request},
     response::{ingest_response, render_response},
+    stream::{ingest_event, render_event},
 };

--- a/crates/warpllm/src/gateway/anthropic/api/messages/request.rs
+++ b/crates/warpllm/src/gateway/anthropic/api/messages/request.rs
@@ -122,9 +122,13 @@ pub(crate) fn ingest_request(request: CreateMessageRequest, model: &str) -> type
         // the blocks, where `ingest_block` puts them.
         cache: None,
         stream: stream.unwrap_or(false),
-        // No counterpart: Anthropic reports usage on every stream
-        // unconditionally, so there is no opt-in to record.
-        stream_include_usage: None,
+        // No wire counterpart, and `None` would be the wrong reading of that:
+        // Anthropic reports a stream's totals unconditionally, so a caller who
+        // speaks this protocol has asked for them by construction. Saying so
+        // is what keeps the counts in the gateway form on this protocol's own
+        // path, and what makes an OpenAI backend send the trailing usage chunk
+        // this protocol requires when a request crosses the other way.
+        stream_include_usage: Some(true),
         ext: namespaced(anthropic),
         source: Some(IngestSource {
             protocol: Protocol::Anthropic,
@@ -1004,6 +1008,22 @@ mod tests {
         let body = maximal_body();
         let normalized = ingest_request(wire(body.clone()), "claude-opus-5");
         assert_eq!(rendered(&normalized), body);
+    }
+
+    /// A caller who speaks this protocol has asked for a stream's totals by
+    /// construction — Anthropic reports them unconditionally, so there is no
+    /// state in which one of its callers does not want them. `None` would read
+    /// as "no opinion" and cost them the counts on their own protocol's path.
+    ///
+    /// It is a request field with no wire spelling here, so nothing about the
+    /// round trip above can catch it going wrong.
+    #[test]
+    fn an_anthropic_caller_has_asked_for_a_streams_totals() {
+        let request = ingest_request(wire(maximal_body()), "claude-opus-5");
+        assert_eq!(request.stream_include_usage, Some(true));
+        // And it stays a gateway-form fact: Anthropic has no `stream_options`,
+        // so saying so must not put anything on the wire.
+        assert_eq!(rendered(&request), maximal_body());
     }
 
     /// The gateway view, so a change to the mapping fails on the mapping rather

--- a/crates/warpllm/src/gateway/anthropic/api/messages/response.rs
+++ b/crates/warpllm/src/gateway/anthropic/api/messages/response.rs
@@ -136,7 +136,11 @@ pub(crate) fn ingest_response(response: Message) -> types::ChatResponse {
 /// spellings and shares not one of these. `finish_reason_raw` stays
 /// authoritative on render, so this only has to be right for callers matching
 /// on the enum.
-fn finish_reason(stop_reason: Option<&str>) -> FinishReason {
+///
+/// Shared with `stream.rs` rather than copied: the streamed and unstreamed
+/// forms of one request must end the same way, and two copies of this table
+/// could answer differently.
+pub(super) fn finish_reason(stop_reason: Option<&str>) -> FinishReason {
     match stop_reason {
         Some("end_turn" | "stop_sequence") => FinishReason::Stop,
         // Both ran out of room: one hit the caller's ceiling, the other the
@@ -622,6 +626,25 @@ fn from_fields<T: DeserializeOwned + Default>(fields: UnknownFields) -> T {
 pub(super) fn take_string(fields: &mut UnknownFields, key: &str) -> Option<String> {
     match fields.remove(key) {
         Some(Value::String(value)) => Some(value),
+        _ => None,
+    }
+}
+
+/// A THREE-STATE string out of residue: absent stays absent, an explicit null
+/// comes back as one.
+///
+/// [`take_typed`] cannot do this job, which is the reason this exists. Asked for
+/// an `Option<String>` it reads a stored `null` as an absent outer option — so
+/// the two states it is meant to tell apart come back identical, and an absent
+/// key round trips as an explicit null.
+pub(super) fn take_nullable_string(
+    fields: &mut UnknownFields,
+    key: &str,
+) -> Option<Option<String>> {
+    match fields.remove(key) {
+        Some(Value::String(value)) => Some(Some(value)),
+        Some(Value::Null) => Some(None),
+        // Absent, or corrupted past its wire type: drop the field.
         _ => None,
     }
 }

--- a/crates/warpllm/src/gateway/anthropic/api/messages/stream.rs
+++ b/crates/warpllm/src/gateway/anthropic/api/messages/stream.rs
@@ -1,0 +1,1327 @@
+//! Stream conversions: Anthropic's named events → gateway chunks (ingest) and
+//! back (render).
+//!
+//! # The contract is reassembly-equivalence, not event-level losslessness
+//!
+//! Everywhere else in this crate a round trip is byte-exact. Here it cannot be,
+//! and saying so is the honest version of the claim: `content_block_stop` and
+//! `ping` carry no gateway content, so they ingest to `None` and no render can
+//! put them back where they were. What IS promised is that a transcript
+//! ingested and reassembled equals the [`Message`] the unstreamed call would
+//! have returned — which is the contract `reassembly.rs` pins, and the one a
+//! consumer actually depends on.
+//!
+//! # Two facts make the mapping tractable
+//!
+//! **Every delta is self-describing.** `text_delta`, `thinking_delta` and
+//! `input_json_delta` each carry their own `type`, so a reader never has to
+//! remember what kind of block an index opened. Only `content_block_start`
+//! establishes a tool call's `id` and `name`, and those belong on the chunk
+//! that start produces. That is why [`StreamState`] holds no per-index map.
+//!
+//! **`ChatResponseChunk` requires `id` and `model` on every chunk**, and
+//! Anthropic sends them once, on `message_start`. That is the whole of the
+//! state, and it is unavoidable rather than convenient.
+//!
+//! # What `render_event` does NOT yet do
+//!
+//! Rendering a SAME-PROTOCOL chunk is complete: the retained wire event decides
+//! the shape and replays it. Rendering a chunk from another protocol is not,
+//! and the gap is structural rather than an omission — it is one chunk to one
+//! event, where a faithful translation needs to buffer:
+//!
+//! * chat completions puts a stream's totals on a TRAILING chunk that carries
+//!   no choices, so it arrives after the chunk that has the stop reason. This
+//!   renders each alone, and the one with no choices renders to nothing;
+//! * a fragment carrying a tool call's `id`, `name` AND argument text is two
+//!   events here, so only the opener is emitted;
+//! * a tool call's index is remapped by neither side — see the note below.
+//!
+//! None of that is reachable today: nothing renders a foreign chunk to this
+//! wire, because doing so needs an Anthropic-shaped INGRESS, which is out of
+//! scope. The function is written for the round-trip tests and as the honest
+//! starting point for that work, and this list is what that work owes.
+//!
+//! # A stream's totals are the caller's to ask for
+//!
+//! Anthropic states them on `message_delta`, unconditionally. Chat completions
+//! states them only under `stream_options.include_usage`, and on a TRAILING
+//! chunk that carries no choices — and the IR follows chat completions here,
+//! because [`ChatResponseChunk::usage`](types::ChatResponseChunk::usage) is
+//! documented as present only when the caller asked. So this reads Anthropic's
+//! counts into [`StreamState`] and emits them at `message_stop` as the
+//! completionless chunk the IR already models, or does not emit them at all.
+//!
+//! Neither half costs the same-protocol round trip anything. The wire counts
+//! are RETAINED on the `message_delta` chunk either way, so a render rebuilds
+//! that event from the residue rather than from the promotion; and the
+//! trailing chunk carries no residue, so it renders to nothing — which is
+//! exactly what `message_stop` is.
+//!
+//! # The index is Anthropic's, carried verbatim
+//!
+//! Anthropic's block `index` counts ALL blocks — text at 0, a tool call at 1.
+//! Chat completions' `tool_calls[].index` counts only tool calls, so the two are
+//! different numbers for the same call. This carries Anthropic's through
+//! unchanged: `index` promises to be a stable correlation key and nothing more,
+//! which is exactly what consumers use it for, and remapping would need the
+//! per-index state the previous section just established is not needed.
+
+use serde_json::Value;
+
+use crate::gateway::anthropic::{merged_ext, namespaced, role_from_wire};
+use crate::gateway::types::{self, ContentDelta};
+use crate::protocol::UnknownFields;
+use crate::protocol::anthropic::messages::types::{
+    ContentBlock as WireBlock, ContentBlockDelta, ContentBlockDeltaEvent, ContentBlockStartEvent,
+    InputJsonDelta, Message, MessageDelta as WireMessageDelta, MessageDeltaEvent,
+    MessageDeltaUsage, MessageStartEvent, MessageStreamEvent, TextDelta, ThinkingDelta,
+    ToolUseBlock,
+};
+use crate::types::Protocol;
+
+use super::response::{finish_reason, plain, take_nullable_string, take_typed};
+
+/// What a reader must remember across events, and nothing more.
+///
+/// `id` and `model` because every gateway chunk requires them and Anthropic
+/// sends them once. The input counts because `message_delta` reports only the
+/// cumulative OUTPUT tokens, so the usage on the chunk that carries totals has
+/// to be completed from what `message_start` said. The totals themselves
+/// because they are stated one event before the chunk that carries them.
+#[derive(Debug, Default)]
+pub(crate) struct StreamState {
+    id: String,
+    model: String,
+    input_tokens: Option<u32>,
+    cache_read_tokens: Option<u32>,
+    cache_write_tokens: Option<u32>,
+    /// Whether the caller asked for the stream's totals.
+    ///
+    /// Anthropic reports them whether or not anyone did, so without this the
+    /// counts reach a caller who never requested them, on a protocol whose
+    /// contract is that the field is absent. It gates the PROMOTION only —
+    /// the wire value is retained regardless.
+    report_usage: bool,
+    /// The totals, held from the `message_delta` that states them to the
+    /// `message_stop` that carries them out. Always `None` when
+    /// [`Self::report_usage`] is false, and again once they have been emitted.
+    totals: Option<types::Usage>,
+}
+
+impl StreamState {
+    /// The state one stream starts from.
+    ///
+    /// `report_usage` is the caller's
+    /// [`stream_include_usage`](types::ChatRequest::stream_include_usage);
+    /// everything else is learned from `message_start`.
+    pub(crate) fn new(report_usage: bool) -> Self {
+        Self {
+            report_usage,
+            ..Self::default()
+        }
+    }
+}
+
+/// One wire event as a gateway chunk, or `None` where the event carries no
+/// gateway content.
+///
+/// `None` is not a failure and not a dropped value: `content_block_stop` and
+/// `ping` say nothing a chunk can hold, and inventing an empty chunk for them
+/// would put a value in front of a consumer that the provider never sent.
+///
+/// An `error` event is deliberately NOT handled here. It ends the stream and
+/// becomes an [`Error`](crate::Error) on the stream itself — see
+/// `exchange::ChatChunkStream` — because a failure is not a chunk, and giving
+/// it one would make a consumer that ignores content miss the failure entirely.
+pub(crate) fn ingest_event(
+    event: MessageStreamEvent,
+    state: &mut StreamState,
+) -> Option<types::ChatResponseChunk> {
+    match event {
+        MessageStreamEvent::MessageStart(start) => Some(ingest_message_start(start, state)),
+        MessageStreamEvent::ContentBlockStart(start) => Some(ingest_block_start(start, state)),
+        MessageStreamEvent::ContentBlockDelta(delta) => Some(ingest_block_delta(delta, state)),
+        MessageStreamEvent::MessageDelta(delta) => Some(ingest_message_delta(delta, state)),
+        // No gateway content. See this function's doc.
+        MessageStreamEvent::ContentBlockStop(_) => None,
+        // Content only when the caller asked for the totals, which is the one
+        // thing this protocol says at the end and chat completions says here.
+        MessageStreamEvent::MessageStop(_) => ingest_message_stop(state),
+        MessageStreamEvent::Ping(_) => None,
+        // Ends the stream as an error, never as a chunk.
+        MessageStreamEvent::Error(_) => None,
+        // A named event this gateway does not model. It has no content to lift
+        // and no shape to guess at, so it rides the envelope's own namespace
+        // where a same-protocol render replays it verbatim.
+        MessageStreamEvent::Unknown(value) => Some(unknown_chunk(value, state)),
+    }
+}
+
+/// `message_start` — the only event that establishes identity.
+fn ingest_message_start(
+    start: MessageStartEvent,
+    state: &mut StreamState,
+) -> types::ChatResponseChunk {
+    let MessageStartEvent {
+        message,
+        unknown_fields,
+    } = start;
+    // PROMOTE BUT RETAIN, and here the retained copy is the WHOLE wire message
+    // rather than the leftovers. `id`, `model` and `role` are promoted onto the
+    // chunk and appear in both places, which is the point: this event's payload
+    // is a `Message`, every field of it is required to rebuild one, and a
+    // render that reassembled it from the chunk's promoted values plus partial
+    // residue would have to guess at `type`, at an empty-versus-absent
+    // `content`, and at the three-state nullability of `stop_reason`.
+    //
+    // It also means a field added to `Message` round trips without a change
+    // here, which is why this destructure binds what it promotes and lets the
+    // retained copy answer for the rest.
+    let retained = plain(&message);
+    let Message {
+        id,
+        role,
+        model,
+        usage,
+        // Carried by `retained` above, and read back from it verbatim.
+        r#type: _,
+        content: _,
+        stop_reason: _,
+        stop_sequence: _,
+        unknown_fields: _,
+    } = message;
+
+    state.id = id.clone();
+    state.model = model.clone();
+    state.input_tokens = Some(usage.input_tokens);
+    state.cache_read_tokens = usage.cache_read_input_tokens.flatten();
+    state.cache_write_tokens = usage.cache_creation_input_tokens.flatten();
+
+    let (gateway_role, raw_role) = role_from_wire(role);
+    let mut delta_ext = UnknownFields::new();
+    if let Some(raw) = raw_role {
+        delta_ext.insert("role".into(), Value::String(raw));
+    }
+
+    let mut chunk_ext = UnknownFields::new();
+    chunk_ext.insert("message".into(), retained);
+    chunk_ext.extend(unknown_fields);
+
+    types::ChatResponseChunk {
+        id,
+        model,
+        // Anthropic has no creation timestamp, streamed or not.
+        created: None,
+        completions: vec![types::CompletionDelta {
+            delta: types::MessageDelta {
+                role: Some(gateway_role),
+                content: Vec::new(),
+                ext: namespaced(delta_ext),
+            },
+            finish_reason: None,
+            finish_reason_raw: None,
+            ext: types::ProviderExt::new(),
+        }],
+        // The counts are real but PARTIAL — output is still zero and the reply
+        // has not happened. Reporting them here would have a consumer that adds
+        // up every chunk's usage double-count the input against `message_delta`,
+        // which reports the same totals again at the end.
+        usage: None,
+        ext: namespaced(chunk_ext),
+        source: None,
+    }
+}
+
+/// `content_block_start` — the only event that names a tool call.
+fn ingest_block_start(
+    start: ContentBlockStartEvent,
+    state: &StreamState,
+) -> types::ChatResponseChunk {
+    let ContentBlockStartEvent {
+        index,
+        content_block,
+        unknown_fields,
+    } = start;
+
+    let delta = match &content_block {
+        // The empty opener is a REAL value, matching the `"content": ""` an
+        // OpenAI stream opens with. A consumer concatenating fragments sees the
+        // same sequence either way.
+        WireBlock::Text(text) => ContentDelta::Text {
+            text: text.text.clone(),
+        },
+        WireBlock::ToolUse(call) => ContentDelta::ToolCall {
+            index,
+            id: Some(call.id.clone()),
+            kind: Some("tool_use".into()),
+            name: Some(call.name.clone()),
+            // Arguments arrive as `input_json_delta` fragments. `None` rather
+            // than `Some("")`: this fragment carried no argument text at all,
+            // which the IR distinguishes from one that carried the empty
+            // string.
+            arguments: None,
+        },
+        WireBlock::Thinking(thinking) => ContentDelta::Reasoning {
+            text: thinking.thinking.clone(),
+            provenance: Some(Protocol::Anthropic.as_str().to_string()),
+        },
+        // No `ContentDelta` holds encrypted reasoning — the completed form's
+        // `ReasoningDetail::Encrypted` has no streaming counterpart, because a
+        // signature covers a whole block and cannot ride its fragments. It
+        // passes through whole, which is what it is: not a fragment at all.
+        //
+        // Every other block type reaches here too. A block warpllm does not
+        // model is exactly the case `Unknown` exists for.
+        other => ContentDelta::Unknown(plain(other)),
+    };
+
+    let mut block_ext = UnknownFields::new();
+    block_ext.insert("index".into(), Value::from(index));
+    // Retained whole rather than field by field: this is what a same-protocol
+    // render rebuilds the event from, and the promoted delta above is lossy for
+    // every block whose residue has no gateway field.
+    block_ext.insert("content_block".into(), plain(&content_block));
+    block_ext.extend(unknown_fields);
+
+    chunk(state, delta, block_ext)
+}
+
+/// `content_block_delta` — the fragments themselves.
+fn ingest_block_delta(
+    event: ContentBlockDeltaEvent,
+    state: &StreamState,
+) -> types::ChatResponseChunk {
+    let ContentBlockDeltaEvent {
+        index,
+        delta,
+        unknown_fields,
+    } = event;
+
+    let content = match &delta {
+        ContentBlockDelta::TextDelta(text) => ContentDelta::Text {
+            text: text.text.clone(),
+        },
+        ContentBlockDelta::ThinkingDelta(thinking) => ContentDelta::Reasoning {
+            text: thinking.thinking.clone(),
+            provenance: Some(Protocol::Anthropic.as_str().to_string()),
+        },
+        ContentBlockDelta::InputJsonDelta(json) => ContentDelta::ToolCall {
+            index,
+            // Established by `content_block_start`; a fragment repeats none of
+            // it.
+            id: None,
+            kind: None,
+            name: None,
+            arguments: Some(json.partial_json.clone()),
+        },
+        // No `ContentDelta` holds a signature — the IR says so explicitly, and
+        // the reason is the same one that keeps it off `ContentDelta::Reasoning`:
+        // it covers a whole block, so it is not a fragment of anything. It
+        // survives as residue, which is what makes a run of thinking blocks
+        // reassemble with its signature intact.
+        ContentBlockDelta::SignatureDelta(_) | ContentBlockDelta::Unknown(_) => {
+            ContentDelta::Unknown(plain(&delta))
+        }
+    };
+
+    let mut block_ext = UnknownFields::new();
+    block_ext.insert("index".into(), Value::from(index));
+    block_ext.insert("delta".into(), plain(&delta));
+    block_ext.extend(unknown_fields);
+
+    chunk(state, content, block_ext)
+}
+
+/// `message_delta` — the stop reason and the totals.
+fn ingest_message_delta(
+    event: MessageDeltaEvent,
+    state: &mut StreamState,
+) -> types::ChatResponseChunk {
+    let MessageDeltaEvent {
+        delta,
+        usage,
+        unknown_fields,
+    } = event;
+    let WireMessageDelta {
+        stop_reason,
+        stop_sequence,
+        unknown_fields: delta_unknowns,
+    } = delta;
+
+    let raw = stop_reason.clone().flatten();
+    let mut completion_ext = UnknownFields::new();
+    // Both fields are three-state, and a flatten destroys the distinction the
+    // third state IS. `stop_reason`'s inner string is promoted to
+    // `finish_reason_raw`, so only the present-but-NULL case needs a marker
+    // here; an absent key must leave no residue at all, or it renders back as
+    // an explicit null. `stop_sequence` has no gateway home, so its outer
+    // option is retained exactly when the key was there.
+    if matches!(stop_reason, Some(None)) {
+        completion_ext.insert("stop_reason".into(), Value::Null);
+    }
+    if let Some(sequence) = &stop_sequence {
+        completion_ext.insert(
+            "stop_sequence".into(),
+            sequence.clone().map_or(Value::Null, Value::String),
+        );
+    }
+    completion_ext.extend(delta_unknowns);
+
+    let mut chunk_ext = UnknownFields::new();
+    chunk_ext.insert("usage".into(), plain(&usage));
+    chunk_ext.extend(unknown_fields);
+
+    // Held rather than reported here: the totals belong on a chunk of their
+    // own, and this protocol's stream ends one event later. Skipped entirely
+    // when nobody asked — the retained copy above is what a same-protocol
+    // render reads either way, so this loses nothing.
+    if state.report_usage {
+        state.totals = Some(delta_usage(&usage, state));
+    }
+
+    types::ChatResponseChunk {
+        id: state.id.clone(),
+        model: state.model.clone(),
+        created: None,
+        completions: vec![types::CompletionDelta {
+            delta: types::MessageDelta::default(),
+            finish_reason: raw.as_deref().map(|raw| finish_reason(Some(raw))),
+            finish_reason_raw: raw,
+            ext: namespaced(completion_ext),
+        }],
+        usage: None,
+        ext: namespaced(chunk_ext),
+        source: None,
+    }
+}
+
+/// `message_stop` — the totals, on a chunk that carries nothing else.
+///
+/// `None` unless the caller asked, and `None` a second time if it somehow
+/// arrives twice: the totals are taken, not copied, so a stream cannot report
+/// them more than once.
+///
+/// The chunk holds no residue, which is deliberate rather than an omission —
+/// `message_stop` has no fields to retain, and a render that found none is
+/// right to produce no event.
+fn ingest_message_stop(state: &mut StreamState) -> Option<types::ChatResponseChunk> {
+    let usage = state.totals.take()?;
+    Some(types::ChatResponseChunk {
+        id: state.id.clone(),
+        model: state.model.clone(),
+        created: None,
+        // The usage-only shape the IR already models, and the one chat
+        // completions puts a stream's totals on.
+        completions: Vec::new(),
+        usage: Some(usage),
+        ext: types::ProviderExt::new(),
+        source: None,
+    })
+}
+
+/// An event whose `type` this gateway does not recognize.
+fn unknown_chunk(value: Value, state: &StreamState) -> types::ChatResponseChunk {
+    let mut chunk_ext = UnknownFields::new();
+    chunk_ext.insert("event".into(), value);
+    types::ChatResponseChunk {
+        id: state.id.clone(),
+        model: state.model.clone(),
+        created: None,
+        completions: Vec::new(),
+        usage: None,
+        ext: namespaced(chunk_ext),
+        source: None,
+    }
+}
+
+/// The shape every content-bearing chunk after `message_start` shares.
+fn chunk(
+    state: &StreamState,
+    content: ContentDelta,
+    block_ext: UnknownFields,
+) -> types::ChatResponseChunk {
+    types::ChatResponseChunk {
+        id: state.id.clone(),
+        model: state.model.clone(),
+        created: None,
+        completions: vec![types::CompletionDelta {
+            delta: types::MessageDelta {
+                // Sent once, on the chunk that opened the choice.
+                role: None,
+                content: vec![content],
+                ext: namespaced(block_ext),
+            },
+            finish_reason: None,
+            finish_reason_raw: None,
+            ext: types::ProviderExt::new(),
+        }],
+        usage: None,
+        ext: types::ProviderExt::new(),
+        source: None,
+    }
+}
+
+/// A `message_delta`'s usage, completed from what `message_start` remembered.
+///
+/// The same normalization `response::ingest_usage` does and for the same
+/// reason: Anthropic's `input_tokens` counts only what came AFTER the last
+/// cache breakpoint, while the IR's is the whole input. A protocol whose wire
+/// value is exclusive has to add the cache counts back on ingest.
+///
+/// This event may restate the input counts, and when it does they WIN — a
+/// restated total is the provider correcting itself, and preferring the
+/// remembered one would report a stale number.
+fn delta_usage(usage: &MessageDeltaUsage, state: &StreamState) -> types::Usage {
+    let input = usage.input_tokens.flatten().or(state.input_tokens);
+    let read = usage
+        .cache_read_input_tokens
+        .flatten()
+        .or(state.cache_read_tokens);
+    let write = usage
+        .cache_creation_input_tokens
+        .flatten()
+        .or(state.cache_write_tokens);
+
+    let cached = u64::from(read.unwrap_or(0)) + u64::from(write.unwrap_or(0));
+    let total_input = input.map(|count| u64::from(count) + cached);
+    types::Usage {
+        input_tokens: total_input,
+        output_tokens: Some(u64::from(usage.output_tokens)),
+        total_tokens: total_input.map(|input| input + u64::from(usage.output_tokens)),
+        // A streamed reply reports no thinking breakdown; only the unstreamed
+        // `usage.output_tokens_details` carries one.
+        reasoning_tokens: None,
+        cache_read_tokens: read.map(u64::from),
+        cache_write_tokens: write.map(u64::from),
+        ext: types::ProviderExt::new(),
+    }
+}
+
+/// The inverse of [`ingest_event`], complete for a chunk this protocol
+/// produced and deliberately incomplete for one it did not — see this module's
+/// note on what an Anthropic-shaped ingress owes.
+///
+/// `None` where a chunk maps to no event: the usage-only and keepalive shapes
+/// another protocol produces have no spelling here.
+///
+/// Reads only this protocol's namespace, through [`merged_ext`] — never
+/// `ext.get`, which would bypass [`Protocol::may_read`] and let another
+/// protocol's retained fields onto this wire.
+pub(crate) fn render_event(
+    chunk: &types::ChatResponseChunk,
+    provider: &str,
+) -> Option<MessageStreamEvent> {
+    let mut chunk_ext = merged_ext(&chunk.ext, provider);
+    if let Some(event) = chunk_ext.remove("event") {
+        return Some(MessageStreamEvent::Unknown(event));
+    }
+    if let Some(message) = take_typed(&mut chunk_ext, "message") {
+        return Some(MessageStreamEvent::MessageStart(MessageStartEvent {
+            message,
+            unknown_fields: chunk_ext,
+        }));
+    }
+    let completion = chunk.completions.first()?;
+    if completion.finish_reason_raw.is_some() || chunk_ext.contains_key("usage") {
+        return Some(render_message_delta(chunk, completion, chunk_ext, provider));
+    }
+    render_content_event(completion, provider)
+}
+
+fn render_message_delta(
+    chunk: &types::ChatResponseChunk,
+    completion: &types::CompletionDelta,
+    mut chunk_ext: UnknownFields,
+    provider: &str,
+) -> MessageStreamEvent {
+    let mut completion_ext = merged_ext(&completion.ext, provider);
+    MessageStreamEvent::MessageDelta(MessageDeltaEvent {
+        delta: WireMessageDelta {
+            stop_reason: match completion.finish_reason_raw.clone() {
+                Some(raw) => Some(Some(raw)),
+                // An explicit null and an absent key are different states, and
+                // only the residue remembers which this was.
+                None => completion_ext.remove("stop_reason").map(|_| None),
+            },
+            stop_sequence: take_nullable_string(&mut completion_ext, "stop_sequence"),
+            unknown_fields: completion_ext,
+        },
+        // Retained residue first, then the GATEWAY form — which is the same
+        // order every renderer here uses, and which was missing: reading only
+        // the residue meant a chunk from another protocol reported
+        // `output_tokens: 0` however many it had actually spent.
+        usage: take_typed(&mut chunk_ext, "usage")
+            .or_else(|| chunk.usage.as_ref().map(delta_usage_of))
+            .unwrap_or_else(unknown_usage),
+        unknown_fields: chunk_ext,
+    })
+}
+
+/// The gateway's totals as this event's, the inverse of [`delta_usage`].
+///
+/// Anthropic's `input_tokens` counts only what came AFTER the last cache
+/// breakpoint while the gateway's is the whole input, so the cache counts come
+/// back OUT here. Saturating rather than wrapping: a gateway form built by hand
+/// with a cached count larger than its input is nonsense, and zero is the inert
+/// answer rather than four billion.
+fn delta_usage_of(usage: &types::Usage) -> MessageDeltaUsage {
+    let cached = usage.cache_read_tokens.unwrap_or(0) + usage.cache_write_tokens.unwrap_or(0);
+    MessageDeltaUsage {
+        output_tokens: usage.output_tokens.unwrap_or(0) as u32,
+        input_tokens: usage
+            .input_tokens
+            .map(|input| Some(input.saturating_sub(cached) as u32)),
+        cache_creation_input_tokens: usage.cache_write_tokens.map(|count| Some(count as u32)),
+        cache_read_input_tokens: usage.cache_read_tokens.map(|count| Some(count as u32)),
+        unknown_fields: UnknownFields::new(),
+    }
+}
+
+/// The totals for a chunk that stated none.
+///
+/// `output_tokens` is REQUIRED on this event, so something has to go there and
+/// zero is the only inert value. It is a real limitation rather than a good
+/// answer: chat completions puts its totals on a trailing usage-only chunk that
+/// carries no choices, and one chunk cannot become two events here — see this
+/// module's note on what an Anthropic-shaped ingress owes.
+fn unknown_usage() -> MessageDeltaUsage {
+    MessageDeltaUsage {
+        output_tokens: 0,
+        input_tokens: None,
+        cache_creation_input_tokens: None,
+        cache_read_input_tokens: None,
+        unknown_fields: UnknownFields::new(),
+    }
+}
+
+/// A content-bearing chunk as the event it came from.
+///
+/// The retained `content_block` and `delta` decide which event this was, since
+/// a start and a delta both carry one `ContentDelta` and only the residue tells
+/// them apart. A chunk from ANOTHER protocol has neither, and renders from the
+/// delta alone.
+fn render_content_event(
+    completion: &types::CompletionDelta,
+    provider: &str,
+) -> Option<MessageStreamEvent> {
+    let mut block_ext = merged_ext(&completion.delta.ext, provider);
+    let index = block_ext
+        .remove("index")
+        .and_then(|value| value.as_u64())
+        .map(|index| index as u32);
+
+    if let Some(content_block) = take_typed(&mut block_ext, "content_block") {
+        return Some(MessageStreamEvent::ContentBlockStart(
+            ContentBlockStartEvent {
+                index: index.unwrap_or(0),
+                content_block,
+                unknown_fields: block_ext,
+            },
+        ));
+    }
+    if let Some(delta) = take_typed(&mut block_ext, "delta") {
+        return Some(MessageStreamEvent::ContentBlockDelta(
+            ContentBlockDeltaEvent {
+                index: index.unwrap_or_else(|| delta_index(completion)),
+                delta,
+                unknown_fields: block_ext,
+            },
+        ));
+    }
+    render_foreign_event(
+        completion.delta.content.first()?,
+        index.unwrap_or_else(|| delta_index(completion)),
+        block_ext,
+    )
+}
+
+/// A content fragment from ANOTHER protocol as the event this one spells it
+/// with — which is not always a delta.
+///
+/// A tool call that carries its `id` and `name` is an OPENER, and this protocol
+/// says an opener with `content_block_start`, not with a fragment. Rendering it
+/// as an `input_json_delta` dropped both fields, and a chat-completions opener
+/// carries no argument text either, so the whole event came back `None` — the
+/// one event that names a tool call, rendered as silence.
+///
+/// A fragment carrying an opener AND argument text is the case this cannot
+/// fully express: it is two events here and one chunk there. The start wins,
+/// because `id` and `name` are what nothing later can supply while argument
+/// text arrives again on the next fragment. Buffering the pair is part of what
+/// an Anthropic-shaped ingress owes; see this module's docs.
+fn render_foreign_event(
+    content: &ContentDelta,
+    index: u32,
+    unknown_fields: UnknownFields,
+) -> Option<MessageStreamEvent> {
+    if let ContentDelta::ToolCall {
+        id: Some(id),
+        name: Some(name),
+        ..
+    } = content
+    {
+        return Some(MessageStreamEvent::ContentBlockStart(
+            ContentBlockStartEvent {
+                index,
+                content_block: WireBlock::ToolUse(ToolUseBlock {
+                    id: id.clone(),
+                    name: name.clone(),
+                    // The arguments arrive as fragments after this, exactly as
+                    // Anthropic's own opener carries an empty object.
+                    input: Value::Object(serde_json::Map::new()),
+                    cache_control: None,
+                    unknown_fields: UnknownFields::new(),
+                }),
+                unknown_fields,
+            },
+        ));
+    }
+    Some(MessageStreamEvent::ContentBlockDelta(
+        ContentBlockDeltaEvent {
+            index,
+            delta: render_delta(content)?,
+            unknown_fields,
+        },
+    ))
+}
+
+/// A gateway content delta as this protocol's, for a chunk that arrived with no
+/// retained wire delta — i.e. one from another protocol.
+fn render_delta(content: &ContentDelta) -> Option<ContentBlockDelta> {
+    Some(match content {
+        ContentDelta::Text { text } => ContentBlockDelta::TextDelta(TextDelta {
+            text: text.clone(),
+            unknown_fields: UnknownFields::new(),
+        }),
+        ContentDelta::Reasoning { text, .. } => ContentBlockDelta::ThinkingDelta(ThinkingDelta {
+            thinking: text.clone(),
+            unknown_fields: UnknownFields::new(),
+        }),
+        ContentDelta::ToolCall { arguments, .. } => {
+            ContentBlockDelta::InputJsonDelta(InputJsonDelta {
+                partial_json: arguments.clone()?,
+                unknown_fields: UnknownFields::new(),
+            })
+        }
+        ContentDelta::Unknown(value) => ContentBlockDelta::Unknown(value.clone()),
+    })
+}
+
+/// The index a foreign chunk's delta carries, when there is no retained one.
+fn delta_index(completion: &types::CompletionDelta) -> u32 {
+    match completion.delta.content.first() {
+        Some(ContentDelta::ToolCall { index, .. }) => *index,
+        _ => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::gateway::types::FinishReason;
+
+    fn event(body: Value) -> MessageStreamEvent {
+        serde_json::from_value(body).expect("fixture is a valid event")
+    }
+
+    /// A stream opened by a caller who did NOT ask for the totals, which is
+    /// chat completions' default and the case most of these tests are about.
+    fn started() -> (StreamState, types::ChatResponseChunk) {
+        start(false)
+    }
+
+    /// A stream opened by a caller who DID ask.
+    fn started_asking() -> (StreamState, types::ChatResponseChunk) {
+        start(true)
+    }
+
+    fn start(report_usage: bool) -> (StreamState, types::ChatResponseChunk) {
+        let mut state = StreamState::new(report_usage);
+        let chunk = ingest_event(
+            event(json!({
+                "type": "message_start",
+                "message": {
+                    "id": "msg_1", "type": "message", "role": "assistant",
+                    "model": "claude-opus-5", "content": [],
+                    "stop_reason": null, "stop_sequence": null,
+                    "usage": {"input_tokens": 21, "output_tokens": 0,
+                              "cache_read_input_tokens": 8192,
+                              "cache_creation_input_tokens": 1024}
+                }
+            })),
+            &mut state,
+        )
+        .expect("message_start is a chunk");
+        (state, chunk)
+    }
+
+    fn ingest(body: Value, state: &mut StreamState) -> Option<types::ChatResponseChunk> {
+        ingest_event(event(body), state)
+    }
+
+    /// Identity arrives once and every later chunk carries it, which is the
+    /// whole reason [`StreamState`] exists.
+    #[test]
+    fn message_start_establishes_identity_for_every_later_chunk() {
+        let (mut state, first) = started();
+        assert_eq!(first.id, "msg_1");
+        assert_eq!(first.model, "claude-opus-5");
+        assert_eq!(
+            first.completions[0].delta.role,
+            Some(types::Role::Assistant)
+        );
+
+        let later = ingest(
+            json!({"type": "content_block_delta", "index": 0,
+                   "delta": {"type": "text_delta", "text": "hi"}}),
+            &mut state,
+        )
+        .unwrap();
+        assert_eq!(later.id, "msg_1");
+        assert_eq!(later.model, "claude-opus-5");
+    }
+
+    /// The events that say nothing a chunk can hold produce nothing. An empty
+    /// chunk would be a value the provider never sent.
+    #[test]
+    fn the_contentless_events_produce_no_chunk() {
+        let (mut state, _) = started();
+        for body in [
+            json!({"type": "content_block_stop", "index": 0}),
+            json!({"type": "message_stop"}),
+            json!({"type": "ping"}),
+        ] {
+            assert!(ingest(body.clone(), &mut state).is_none(), "{body}");
+        }
+    }
+
+    /// An `error` event is not a chunk. It ends the stream as an error, and
+    /// producing a chunk for it would let a consumer that reads only content
+    /// miss the failure entirely.
+    #[test]
+    fn an_error_event_is_not_a_chunk() {
+        let (mut state, _) = started();
+        assert!(
+            ingest(
+                json!({"type": "error",
+                       "error": {"type": "overloaded_error", "message": "overloaded"}}),
+                &mut state
+            )
+            .is_none()
+        );
+    }
+
+    /// The full event table, one row at a time, so a change to any single arm
+    /// fails on that arm rather than inside a transcript.
+    #[test]
+    fn the_content_event_table() {
+        let (mut state, _) = started();
+
+        let text = ingest(
+            json!({"type": "content_block_start", "index": 0,
+                   "content_block": {"type": "text", "text": ""}}),
+            &mut state,
+        )
+        .unwrap();
+        assert!(matches!(
+            &text.completions[0].delta.content[0],
+            ContentDelta::Text { text } if text.is_empty()
+        ));
+
+        let call = ingest(
+            json!({"type": "content_block_start", "index": 1,
+                   "content_block": {"type": "tool_use", "id": "tu_1",
+                                     "name": "weather", "input": {}}}),
+            &mut state,
+        )
+        .unwrap();
+        assert!(matches!(
+            &call.completions[0].delta.content[0],
+            ContentDelta::ToolCall { index: 1, id: Some(id), name: Some(name), arguments: None, .. }
+                if id == "tu_1" && name == "weather"
+        ));
+
+        let fragment = ingest(
+            json!({"type": "content_block_delta", "index": 1,
+                   "delta": {"type": "input_json_delta", "partial_json": "{\"city\":"}}),
+            &mut state,
+        )
+        .unwrap();
+        assert!(matches!(
+            &fragment.completions[0].delta.content[0],
+            ContentDelta::ToolCall { index: 1, id: None, name: None, arguments: Some(text), .. }
+                if text == "{\"city\":"
+        ));
+
+        let thinking = ingest(
+            json!({"type": "content_block_delta", "index": 0,
+                   "delta": {"type": "thinking_delta", "thinking": "step"}}),
+            &mut state,
+        )
+        .unwrap();
+        assert!(matches!(
+            &thinking.completions[0].delta.content[0],
+            ContentDelta::Reasoning { text, provenance: Some(p) }
+                if text == "step" && p == "anthropic"
+        ));
+
+        // A signature covers a whole block, so it is not a fragment of one and
+        // no `ContentDelta` holds it. It rides residue instead of being lost.
+        let signature = ingest(
+            json!({"type": "content_block_delta", "index": 0,
+                   "delta": {"type": "signature_delta", "signature": "sig"}}),
+            &mut state,
+        )
+        .unwrap();
+        assert!(matches!(
+            &signature.completions[0].delta.content[0],
+            ContentDelta::Unknown(_)
+        ));
+    }
+
+    /// Anthropic's index counts ALL blocks and chat completions' counts only
+    /// tool calls. Carrying Anthropic's verbatim is a documented divergence,
+    /// so it gets a test rather than a comment alone.
+    #[test]
+    fn the_block_index_is_anthropics_not_remapped() {
+        let (mut state, _) = started();
+        // Text at 0, so the FIRST tool call is at 1 — a chat-completions
+        // reader would have called it 0.
+        let call = ingest(
+            json!({"type": "content_block_start", "index": 1,
+                   "content_block": {"type": "tool_use", "id": "tu_1",
+                                     "name": "w", "input": {}}}),
+            &mut state,
+        )
+        .unwrap();
+        assert!(matches!(
+            call.completions[0].delta.content[0],
+            ContentDelta::ToolCall { index: 1, .. }
+        ));
+    }
+
+    /// `message_start`'s counts are partial — output has not happened — so
+    /// reporting usage there would double-count against `message_delta`, which
+    /// restates the totals at the end.
+    #[test]
+    fn usage_is_reported_once_and_includes_the_cached_input() {
+        let (mut state, first) = started_asking();
+        assert!(first.usage.is_none(), "partial totals were reported early");
+
+        assert!(
+            ingest(
+                json!({"type": "message_delta",
+                       "delta": {"stop_reason": "end_turn", "stop_sequence": null},
+                       "usage": {"output_tokens": 16}}),
+                &mut state,
+            )
+            .unwrap()
+            .usage
+            .is_none(),
+            "the totals rode the chunk that carries the stop reason"
+        );
+
+        let usage = ingest(json!({"type": "message_stop"}), &mut state)
+            .expect("a caller who asked gets a chunk for the totals")
+            .usage
+            .unwrap();
+        // 21 uncached + 8192 read + 1024 written, per the IR's rule that the
+        // cached counts are a BREAKDOWN of the input, never addends to it.
+        assert_eq!(usage.input_tokens, Some(9237));
+        assert_eq!(usage.output_tokens, Some(16));
+        assert_eq!(usage.total_tokens, Some(9253));
+        assert_eq!(usage.cache_read_tokens, Some(8192));
+        assert_eq!(usage.cache_write_tokens, Some(1024));
+    }
+
+    /// A restated input count is the provider correcting itself; the remembered
+    /// one is stale the moment it does.
+    #[test]
+    fn a_restated_input_count_wins_over_the_remembered_one() {
+        let (mut state, _) = started_asking();
+        ingest(
+            json!({"type": "message_delta",
+                   "delta": {"stop_reason": "end_turn"},
+                   "usage": {"output_tokens": 16, "input_tokens": 30,
+                             "cache_read_input_tokens": 0,
+                             "cache_creation_input_tokens": 0}}),
+            &mut state,
+        )
+        .unwrap();
+        let end = ingest(json!({"type": "message_stop"}), &mut state).unwrap();
+        assert_eq!(end.usage.unwrap().input_tokens, Some(30));
+    }
+
+    /// Anthropic states a stream's totals whether or not anyone asked. The IR
+    /// says the field is present only when someone did, so this is the gate
+    /// that keeps an OpenAI caller from receiving a `usage` it never requested
+    /// on a protocol whose contract is that it is null.
+    #[test]
+    fn the_totals_stay_off_the_stream_when_nobody_asked() {
+        let (mut state, _) = started();
+        let end = ingest(
+            json!({"type": "message_delta", "delta": {"stop_reason": "end_turn"},
+                   "usage": {"output_tokens": 16}}),
+            &mut state,
+        )
+        .unwrap();
+        assert!(end.usage.is_none(), "unasked-for totals reached the caller");
+        assert!(
+            ingest(json!({"type": "message_stop"}), &mut state).is_none(),
+            "a chunk was invented for totals nobody asked for"
+        );
+    }
+
+    /// The totals arrive on a chunk of their own with no choices, which is
+    /// where chat completions puts them — not beside the stop reason, which is
+    /// where this protocol does.
+    #[test]
+    fn the_totals_ride_a_chunk_that_carries_nothing_else() {
+        let (mut state, _) = started_asking();
+        ingest(
+            json!({"type": "message_delta", "delta": {"stop_reason": "end_turn"},
+                   "usage": {"output_tokens": 16}}),
+            &mut state,
+        )
+        .unwrap();
+        let totals = ingest(json!({"type": "message_stop"}), &mut state).unwrap();
+        assert!(totals.completions.is_empty());
+        assert!(totals.usage.is_some());
+        assert_eq!(totals.id, "msg_1");
+        assert_eq!(totals.model, "claude-opus-5");
+        // Taken, not copied: a stream reports its totals once however many
+        // times the event that carries them arrives.
+        assert!(ingest(json!({"type": "message_stop"}), &mut state).is_none());
+    }
+
+    /// The gate costs the same-protocol round trip nothing, because the wire
+    /// counts are retained rather than promoted. Written from the state a
+    /// caller who asked for NOTHING produces, so the promotion cannot be what
+    /// makes it pass.
+    #[test]
+    fn a_message_delta_replays_its_usage_even_when_nobody_asked() {
+        let (mut state, _) = started();
+        let end = ingest(
+            json!({"type": "message_delta", "delta": {"stop_reason": "end_turn"},
+                   "usage": {"output_tokens": 16, "input_tokens": 30}}),
+            &mut state,
+        )
+        .unwrap();
+        assert!(end.usage.is_none());
+        let MessageStreamEvent::MessageDelta(rendered) =
+            render_event(&end, "anthropic").expect("a stop reason is an event")
+        else {
+            panic!("a message_delta chunk rendered as something else");
+        };
+        assert_eq!(rendered.usage.output_tokens, 16);
+        assert_eq!(rendered.usage.input_tokens, Some(Some(30)));
+    }
+
+    /// And the chunk the totals ride renders to nothing, because `message_stop`
+    /// says nothing this wire holds. Without it the stream would carry a second
+    /// `message_delta` reporting the same counts twice.
+    #[test]
+    fn the_chunk_the_totals_ride_is_not_an_event() {
+        let (mut state, _) = started_asking();
+        ingest(
+            json!({"type": "message_delta", "delta": {"stop_reason": "end_turn"},
+                   "usage": {"output_tokens": 16}}),
+            &mut state,
+        )
+        .unwrap();
+        let totals = ingest(json!({"type": "message_stop"}), &mut state).unwrap();
+        assert!(render_event(&totals, "anthropic").is_none());
+    }
+
+    /// The stop reason crosses through the same table the unstreamed reply
+    /// uses — one vocabulary, so the streamed and unstreamed forms of a request
+    /// cannot end differently.
+    #[test]
+    fn the_stop_reason_uses_the_unstreamed_table() {
+        let (mut state, _) = started();
+        for (raw, expected) in [
+            ("end_turn", FinishReason::Stop),
+            ("max_tokens", FinishReason::Length),
+            ("tool_use", FinishReason::ToolCalls),
+            ("refusal", FinishReason::ContentFilter),
+            ("pause_turn", FinishReason::Other),
+        ] {
+            let end = ingest(
+                json!({"type": "message_delta", "delta": {"stop_reason": raw},
+                       "usage": {"output_tokens": 1}}),
+                &mut state,
+            )
+            .unwrap();
+            assert_eq!(end.completions[0].finish_reason, Some(expected), "{raw}");
+            assert_eq!(end.completions[0].finish_reason_raw.as_deref(), Some(raw));
+        }
+    }
+
+    /// The three-state fields on a `message_delta`, every combination.
+    ///
+    /// An absent key, an explicit null and a value are three distinct states
+    /// and `Option<Option<_>>` exists to hold all three. Flattening
+    /// `stop_reason` reported an explicit null as absent, and retaining
+    /// `stop_sequence` unconditionally reported an absent key as an explicit
+    /// null — both silent, and both invisible to a round-trip test that
+    /// happens to pick the one combination that works.
+    #[test]
+    fn the_three_state_fields_on_a_message_delta_round_trip() {
+        let states = [None, Some(json!(null)), Some(json!("STOP"))];
+        for reason in &states {
+            for sequence in &states {
+                let mut delta = serde_json::Map::new();
+                if let Some(reason) = reason {
+                    delta.insert("stop_reason".into(), reason.clone());
+                }
+                if let Some(sequence) = sequence {
+                    delta.insert("stop_sequence".into(), sequence.clone());
+                }
+                let body = json!({
+                    "type": "message_delta",
+                    "delta": Value::Object(delta),
+                    "usage": {"output_tokens": 3}
+                });
+
+                let mut state = StreamState::default();
+                let chunk = ingest(body.clone(), &mut state).expect("carries content");
+                assert_eq!(
+                    plain(&render_event(&chunk, "anthropic").expect("renders back")),
+                    body,
+                    "reason={reason:?} sequence={sequence:?}"
+                );
+            }
+        }
+    }
+
+    /// A named event this gateway does not model keeps its whole payload, so a
+    /// same-protocol render puts it back unchanged.
+    #[test]
+    fn an_unmodelled_event_rides_the_envelope_and_renders_back() {
+        let (mut state, _) = started();
+        let body = json!({"type": "message_pause", "reason": "handoff"});
+        let chunk = ingest(body.clone(), &mut state).unwrap();
+        assert_eq!(chunk.id, "msg_1");
+        assert_eq!(plain(&render_event(&chunk, "anthropic").unwrap()), body);
+    }
+
+    /// The round trip this module CAN promise, event by event. Reassembly
+    /// equivalence is the transcript-level claim and lives in `reassembly.rs`;
+    /// this is the per-event half of it.
+    #[test]
+    fn every_content_bearing_event_round_trips() {
+        let (mut state, _) = started();
+        for body in [
+            json!({"type": "content_block_start", "index": 0,
+                   "content_block": {"type": "text", "text": ""}}),
+            json!({"type": "content_block_start", "index": 1,
+                   "content_block": {"type": "tool_use", "id": "tu_1",
+                                     "name": "weather", "input": {}}}),
+            json!({"type": "content_block_delta", "index": 0,
+                   "delta": {"type": "text_delta", "text": "hi"}}),
+            json!({"type": "content_block_delta", "index": 1,
+                   "delta": {"type": "input_json_delta", "partial_json": "{\"a\":"}}),
+            json!({"type": "content_block_delta", "index": 0,
+                   "delta": {"type": "thinking_delta", "thinking": "step"}}),
+            json!({"type": "content_block_delta", "index": 0,
+                   "delta": {"type": "signature_delta", "signature": "sig"}}),
+            json!({"type": "content_block_delta", "index": 0,
+                   "delta": {"type": "citations_delta", "citation": {"x": 1}}}),
+            json!({"type": "message_delta",
+                   "delta": {"stop_reason": "end_turn", "stop_sequence": null},
+                   "usage": {"output_tokens": 16}}),
+        ] {
+            let chunk = ingest(body.clone(), &mut state).expect("carries content");
+            assert_eq!(
+                plain(&render_event(&chunk, "anthropic").expect("renders back")),
+                body,
+                "round trip changed the event"
+            );
+        }
+    }
+
+    /// `message_start` carries a whole `Message`, so its round trip is the one
+    /// that exercises the retained envelope rather than a single block.
+    #[test]
+    fn message_start_round_trips_with_its_whole_envelope() {
+        let body = json!({
+            "type": "message_start",
+            "message": {
+                "id": "msg_1", "type": "message", "role": "assistant",
+                "model": "claude-opus-5", "content": [],
+                "stop_reason": null, "stop_sequence": null,
+                "usage": {"input_tokens": 21, "output_tokens": 0},
+                "vendor_tag": "vt"
+            }
+        });
+        let mut state = StreamState::default();
+        let chunk = ingest(body.clone(), &mut state).unwrap();
+        assert_eq!(plain(&render_event(&chunk, "anthropic").unwrap()), body);
+    }
+
+    /// The layer rule, on the streamed path. Another protocol's retained
+    /// fields must not reach this wire — and going through `merged_ext` rather
+    /// than `ext.get` is what enforces it, since `Protocol::may_read` denies
+    /// this renderer the openai_compat bag however the provider is named.
+    #[test]
+    fn another_protocols_residue_never_reaches_this_wire() {
+        let (mut state, _) = started();
+        let mut chunk = ingest(
+            json!({"type": "content_block_delta", "index": 0,
+                   "delta": {"type": "text_delta", "text": "hi"}}),
+            &mut state,
+        )
+        .unwrap();
+        chunk.completions[0].delta.ext.insert(
+            Protocol::OpenAiCompat.as_str().into(),
+            json!({"delta": {"type": "text_delta", "text": "SMUGGLED"}, "index": 99}),
+        );
+        let rendered = plain(&render_event(&chunk, Protocol::OpenAiCompat.as_str()).unwrap());
+        assert_eq!(rendered["delta"]["text"], json!("hi"));
+        assert_eq!(rendered["index"], json!(0));
+    }
+
+    /// A chunk carrying only a gateway form, as another protocol's would be.
+    fn foreign(
+        content: Vec<ContentDelta>,
+        usage: Option<types::Usage>,
+    ) -> types::ChatResponseChunk {
+        types::ChatResponseChunk {
+            id: "chatcmpl-1".into(),
+            model: "gpt-4o".into(),
+            created: Some(1),
+            completions: vec![types::CompletionDelta {
+                delta: types::MessageDelta {
+                    role: None,
+                    content,
+                    ext: types::ProviderExt::new(),
+                },
+                finish_reason: usage.as_ref().map(|_| FinishReason::Stop),
+                finish_reason_raw: usage.as_ref().map(|_| "stop".to_string()),
+                ext: types::ProviderExt::new(),
+            }],
+            usage,
+            ext: types::ProviderExt::new(),
+            source: None,
+        }
+    }
+
+    /// A tool call that names itself is an OPENER, and this protocol spells one
+    /// with `content_block_start`. Rendering it as an `input_json_delta` threw
+    /// away the `id` and the `name`, and since a chat-completions opener
+    /// carries no argument text, the whole event came back `None` — the one
+    /// event that names a tool call, rendered as silence.
+    #[test]
+    fn a_foreign_tool_call_opener_renders_as_a_block_start() {
+        let rendered = plain(
+            &render_event(
+                &foreign(
+                    vec![ContentDelta::ToolCall {
+                        index: 0,
+                        id: Some("call_abc".into()),
+                        kind: Some("function".into()),
+                        name: Some("get_weather".into()),
+                        arguments: None,
+                    }],
+                    None,
+                ),
+                "openai",
+            )
+            .expect("an opener is not silence"),
+        );
+        assert_eq!(rendered["type"], json!("content_block_start"));
+        assert_eq!(rendered["content_block"]["type"], json!("tool_use"));
+        assert_eq!(rendered["content_block"]["id"], json!("call_abc"));
+        assert_eq!(rendered["content_block"]["name"], json!("get_weather"));
+
+        // ...and a fragment that names nothing is still a fragment.
+        let fragment = plain(
+            &render_event(
+                &foreign(
+                    vec![ContentDelta::ToolCall {
+                        index: 0,
+                        id: None,
+                        kind: None,
+                        name: None,
+                        arguments: Some("{\"a\":".into()),
+                    }],
+                    None,
+                ),
+                "openai",
+            )
+            .unwrap(),
+        );
+        assert_eq!(fragment["delta"]["type"], json!("input_json_delta"));
+        assert_eq!(fragment["delta"]["partial_json"], json!("{\"a\":"));
+    }
+
+    /// A foreign chunk's totals live on the TYPED field, not in this protocol's
+    /// residue, and reading only the residue reported every one of them as
+    /// zero. The cache counts come back out of the input on the way, because
+    /// Anthropic's `input_tokens` excludes what the gateway's includes.
+    #[test]
+    fn a_foreign_chunks_usage_reaches_the_wire() {
+        let rendered = plain(
+            &render_event(
+                &foreign(
+                    Vec::new(),
+                    Some(types::Usage {
+                        input_tokens: Some(9237),
+                        output_tokens: Some(16),
+                        total_tokens: Some(9253),
+                        reasoning_tokens: None,
+                        cache_read_tokens: Some(8192),
+                        cache_write_tokens: Some(1024),
+                        ext: types::ProviderExt::new(),
+                    }),
+                ),
+                "openai",
+            )
+            .expect("a chunk with a stop reason is an event"),
+        );
+        assert_eq!(rendered["type"], json!("message_delta"));
+        assert_eq!(rendered["usage"]["output_tokens"], json!(16));
+        // 9237 total minus the 9216 that were cached.
+        assert_eq!(rendered["usage"]["input_tokens"], json!(21));
+        assert_eq!(rendered["usage"]["cache_read_input_tokens"], json!(8192));
+        assert_eq!(
+            rendered["usage"]["cache_creation_input_tokens"],
+            json!(1024)
+        );
+    }
+
+    /// A chunk from another protocol has no retained wire delta, so it renders
+    /// from the gateway form alone — which is the path an OpenAI-shaped stream
+    /// takes when it is forwarded to Anthropic.
+    #[test]
+    fn a_foreign_chunk_renders_from_the_gateway_form() {
+        let chunk = types::ChatResponseChunk {
+            id: "chatcmpl-1".into(),
+            model: "gpt-4o".into(),
+            created: Some(1),
+            completions: vec![types::CompletionDelta {
+                delta: types::MessageDelta {
+                    role: None,
+                    content: vec![ContentDelta::Text {
+                        text: "hello".into(),
+                    }],
+                    ext: types::ProviderExt::new(),
+                },
+                finish_reason: None,
+                finish_reason_raw: None,
+                ext: types::ProviderExt::new(),
+            }],
+            usage: None,
+            ext: types::ProviderExt::new(),
+            source: None,
+        };
+        assert_eq!(
+            plain(&render_event(&chunk, "openai").unwrap()),
+            json!({"type": "content_block_delta", "index": 0,
+                   "delta": {"type": "text_delta", "text": "hello"}})
+        );
+    }
+}

--- a/crates/warpllm/src/gateway/openai_compat/api/chat_completions/stream.rs
+++ b/crates/warpllm/src/gateway/openai_compat/api/chat_completions/stream.rs
@@ -296,6 +296,27 @@ fn render_delta_finish_reason(completion: &types::CompletionDelta) -> Option<Str
     ))
 }
 
+/// A tool call's `kind` in THIS protocol's vocabulary.
+///
+/// The same rule [`render_finish_reason`] states, applied to the other field
+/// where the two protocols disagree on a word: Anthropic calls a tool call
+/// `tool_use`, and this wire's `type` has no such value — every official SDK
+/// reads it as unrecognized, and a client matching on `"function"` silently
+/// drops the call.
+///
+/// `None` stays `None`, which is load-bearing rather than incidental: the type
+/// arrives on the fragment that OPENS a call and is absent on the rest, so a
+/// form that supplied a default here would put a key on the wire the provider
+/// never sent. An unrecognized word echoes — this protocol has `custom` tools
+/// too, and inventing `function` for a word that might be one is worse than
+/// passing through what a future SDK may well know.
+fn render_tool_call_kind(kind: Option<&str>) -> Option<String> {
+    Some(match kind? {
+        "tool_use" => "function".to_string(),
+        known => known.to_string(),
+    })
+}
+
 fn render_delta(delta: &types::MessageDelta, provider: &str) -> ChatCompletionStreamResponseDelta {
     let mut unknown_fields = merged_ext(&delta.ext, provider);
     let role = match unknown_fields.remove("role") {
@@ -321,7 +342,7 @@ fn render_delta(delta: &types::MessageDelta, provider: &str) -> ChatCompletionSt
                     name: name.clone(),
                     unknown_fields: UnknownFields::new(),
                 }),
-                r#type: kind.clone(),
+                r#type: render_tool_call_kind(kind.as_deref()),
                 unknown_fields: UnknownFields::new(),
             }),
             ContentDelta::Unknown(value) => {
@@ -566,6 +587,71 @@ mod tests {
             &empty.completions[0].delta.content[0],
             ContentDelta::Text { text } if text.is_empty()
         ));
+    }
+
+    /// The vocabulary rule [`render_finish_reason`] states, on the other field
+    /// the two protocols spell differently. Anthropic's `tool_use` has no
+    /// meaning in this wire's `type`, so echoing it hands a client a value its
+    /// own SDK reads as unrecognized and drops.
+    ///
+    /// The `None` row is the one that would be easiest to get wrong: a
+    /// continuation fragment carries no type, and supplying one here would put
+    /// a key on the wire the provider never sent.
+    /// Rendered through `render_chunk` rather than by calling the helper
+    /// directly: the bug this guards against was the CALL SITE echoing `kind`,
+    /// and a test of the helper alone passes while the call site ignores it.
+    #[test]
+    fn a_tool_calls_kind_is_translated_into_this_protocols_vocabulary() {
+        let rendered = |kind: Option<&str>| {
+            let chunk = types::ChatResponseChunk {
+                id: "msg_1".into(),
+                model: "claude-opus-5".into(),
+                created: None,
+                completions: vec![types::CompletionDelta {
+                    delta: types::MessageDelta {
+                        role: None,
+                        content: vec![ContentDelta::ToolCall {
+                            index: 0,
+                            id: Some("tu_1".into()),
+                            kind: kind.map(str::to_string),
+                            name: Some("get_weather".into()),
+                            arguments: None,
+                        }],
+                        ext: types::ProviderExt::new(),
+                    },
+                    finish_reason: None,
+                    finish_reason_raw: None,
+                    ext: types::ProviderExt::new(),
+                }],
+                usage: None,
+                ext: types::ProviderExt::new(),
+                source: None,
+            };
+            plain(&render_chunk(&chunk, "anthropic"))["choices"][0]["delta"]["tool_calls"][0]
+                ["type"]
+                .clone()
+        };
+
+        assert_eq!(
+            rendered(Some("tool_use")),
+            json!("function"),
+            "Anthropic's spelling reached an OpenAI caller, whose SDK has no such value"
+        );
+        assert_eq!(
+            rendered(Some("function")),
+            json!("function"),
+            "this protocol's own spelling must survive unchanged"
+        );
+        assert_eq!(
+            rendered(Some("custom")),
+            json!("custom"),
+            "a word this protocol has must not be rewritten to `function`"
+        );
+        assert_eq!(
+            rendered(None),
+            json!(null),
+            "a fragment that carried no type must not gain one"
+        );
     }
 
     /// The opener names the call and carries `type`; the fragments after it

--- a/crates/warpllm/src/protocol/anthropic/messages/transport.rs
+++ b/crates/warpllm/src/protocol/anthropic/messages/transport.rs
@@ -105,12 +105,6 @@ pub(crate) async fn post(
 
 // ---------------------------------------------------------------------------
 // Streaming.
-//
-// Everything below here is still unreachable: the conversions that call `post`
-// have landed, and the ones that read events have not. Each item carries its
-// own `allow` rather than the module carrying one, so that a NON-streaming item
-// going dead is still a warning — and so that deleting these is exactly the
-// change that wires the stream up.
 // ---------------------------------------------------------------------------
 
 /// [`Outcome`] for a streamed request. Same contract: a non-2xx is DATA, and
@@ -121,7 +115,6 @@ pub(crate) async fn post(
 /// past the headers, so the status decision is made before the first event and
 /// never again.
 #[derive(Debug)]
-#[allow(dead_code)] // staged: read once the stream conversions land
 pub(crate) enum StreamOutcome {
     Ok(EventStream),
     /// The status, raw body, and header evidence, verbatim — see
@@ -147,7 +140,6 @@ pub(crate) enum StreamOutcome {
 /// applied here rather than on the [`reqwest::Client`] because reqwest's own
 /// `read_timeout` is builder-scoped: setting it there would bind every
 /// non-streamed request too, or cost a second connection pool to avoid that.
-#[allow(dead_code)] // staged: read once the stream conversions land
 pub(crate) async fn post_stream(
     http: &reqwest::Client,
     provider: &'static str,
@@ -241,7 +233,6 @@ async fn send(
 /// caller here is a loop, and a loop needs no combinators, no pinning, and no
 /// dependency.
 #[derive(Debug)]
-#[allow(dead_code)] // staged: read once the stream conversions land
 pub(crate) struct EventStream {
     response: reqwest::Response,
     provider: &'static str,
@@ -272,7 +263,6 @@ pub(crate) struct EventStream {
 /// follows one. A reader that kept waiting would sit until the socket closed
 /// and then report a truncation, burying the reason the provider actually
 /// gave.
-#[allow(dead_code)] // staged: read once the stream conversions land
 fn ends_the_stream(event: &MessageStreamEvent) -> bool {
     matches!(
         event,
@@ -280,7 +270,6 @@ fn ends_the_stream(event: &MessageStreamEvent) -> bool {
     )
 }
 
-#[allow(dead_code)] // staged: read once the stream conversions land
 impl EventStream {
     /// The next event, or `None` once the stream ends.
     ///

--- a/crates/warpllm/tests/protocol/anthropic/messages/fixtures/transcript/doc-max-tokens.message.json
+++ b/crates/warpllm/tests/protocol/anthropic/messages/fixtures/transcript/doc-max-tokens.message.json
@@ -1,0 +1,18 @@
+{
+  "id": "msg_01MaxTok3nsQ9",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-opus-4-20250514",
+  "content": [
+    {
+      "type": "text",
+      "text": "Once upon a"
+    }
+  ],
+  "stop_reason": "max_tokens",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 11,
+    "output_tokens": 4
+  }
+}

--- a/crates/warpllm/tests/protocol/anthropic/messages/fixtures/transcript/doc-max-tokens.sse
+++ b/crates/warpllm/tests/protocol/anthropic/messages/fixtures/transcript/doc-max-tokens.sse
@@ -1,0 +1,18 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_01MaxTok3nsQ9","type":"message","role":"assistant","model":"claude-opus-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":11,"output_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Once upon a"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null},"usage":{"output_tokens":4}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/crates/warpllm/tests/protocol/anthropic/messages/fixtures/transcript/doc-text.message.json
+++ b/crates/warpllm/tests/protocol/anthropic/messages/fixtures/transcript/doc-text.message.json
@@ -1,0 +1,18 @@
+{
+  "id": "msg_014p7gG3wDgGV9EUtLvnow3U",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-opus-4-20250514",
+  "content": [
+    {
+      "type": "text",
+      "text": "Hello!"
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 25,
+    "output_tokens": 15
+  }
+}

--- a/crates/warpllm/tests/protocol/anthropic/messages/fixtures/transcript/doc-text.sse
+++ b/crates/warpllm/tests/protocol/anthropic/messages/fixtures/transcript/doc-text.sse
@@ -1,0 +1,24 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_014p7gG3wDgGV9EUtLvnow3U","type":"message","role":"assistant","model":"claude-opus-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":25,"output_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: ping
+data: {"type":"ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"!"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":15}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/crates/warpllm/tests/protocol/anthropic/messages/fixtures/transcript/doc-thinking.message.json
+++ b/crates/warpllm/tests/protocol/anthropic/messages/fixtures/transcript/doc-thinking.message.json
@@ -1,0 +1,24 @@
+{
+  "id": "msg_01Ty7fMH2xL9pQ3rK",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-opus-4-20250514",
+  "content": [
+    {
+      "type": "thinking",
+      "thinking": "Let me work through this.",
+      "signature": "EqQBCgIYAhIM1gbcDa9GJwZA2b3hIkfXAiVBg=="
+    },
+    {
+      "type": "text",
+      "text": "42."
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 40,
+    "output_tokens": 63,
+    "cache_read_input_tokens": 1024
+  }
+}

--- a/crates/warpllm/tests/protocol/anthropic/messages/fixtures/transcript/doc-thinking.sse
+++ b/crates/warpllm/tests/protocol/anthropic/messages/fixtures/transcript/doc-thinking.sse
@@ -1,0 +1,33 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_01Ty7fMH2xL9pQ3rK","type":"message","role":"assistant","model":"claude-opus-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":40,"output_tokens":1,"cache_read_input_tokens":1024}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me work"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":" through this."}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"EqQBCgIYAhIM1gbcDa9GJwZA2b3hIkfXAiVBg=="}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"42."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":63}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/crates/warpllm/tests/protocol/anthropic/messages/fixtures/transcript/doc-tool-call.message.json
+++ b/crates/warpllm/tests/protocol/anthropic/messages/fixtures/transcript/doc-tool-call.message.json
@@ -1,0 +1,26 @@
+{
+  "id": "msg_01Aq9w938a90dw8q",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-opus-4-20250514",
+  "content": [
+    {
+      "type": "text",
+      "text": "Let me check."
+    },
+    {
+      "type": "tool_use",
+      "id": "toolu_01T1x1fJ34qAmk2tNTrN7Up6",
+      "name": "get_weather",
+      "input": {
+        "location": "San Francisco, CA"
+      }
+    }
+  ],
+  "stop_reason": "tool_use",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 472,
+    "output_tokens": 89
+  }
+}

--- a/crates/warpllm/tests/protocol/anthropic/messages/fixtures/transcript/doc-tool-call.sse
+++ b/crates/warpllm/tests/protocol/anthropic/messages/fixtures/transcript/doc-tool-call.sse
@@ -1,0 +1,36 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_01Aq9w938a90dw8q","type":"message","role":"assistant","model":"claude-opus-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":472,"output_tokens":2}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Let me check."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01T1x1fJ34qAmk2tNTrN7Up6","name":"get_weather","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"location\":"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":" \"San Fran"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"cisco, CA\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":89}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/crates/warpllm/tests/protocol/anthropic/messages/mod.rs
+++ b/crates/warpllm/tests/protocol/anthropic/messages/mod.rs
@@ -31,6 +31,7 @@ use warpllm::protocol::anthropic::messages::types::{
 use crate::assert_fixtures_round_trip;
 
 mod losslessness;
+mod reassembly;
 
 fn fixtures(shape: &str) -> String {
     format!(

--- a/crates/warpllm/tests/protocol/anthropic/messages/reassembly.rs
+++ b/crates/warpllm/tests/protocol/anthropic/messages/reassembly.rs
@@ -1,0 +1,291 @@
+//! What a caller actually does with a stream: iterate the events and add them
+//! up. The shapes can be field-perfect and still be unusable, so this walks
+//! recorded transcripts the way a consumer would and checks the total.
+//!
+//! Two claims per transcript, and they fail for different reasons:
+//! - every event survives a deserialize → reserialize round trip, which is the
+//!   permissiveness claim, one event at a time;
+//! - the events add up to the [`Message`] the same request would have returned
+//!   unstreamed, which is the claim that the delta shapes carry enough to be
+//!   reassembled at all.
+//!
+//! **This is the contract the streaming half of this protocol actually makes.**
+//! Event-level losslessness is NOT claimed and cannot be: `content_block_stop`
+//! and `ping` carry nothing a gateway chunk holds, so no renderer can put them
+//! back where they were. Reassembly-equivalence is the promise a consumer
+//! depends on, and it is the one pinned here.
+//!
+//! `reassemble` below is a consumer's-eye reference rather than warpllm's own
+//! ingest, matching its openai_compat counterpart: it reads only the fields a
+//! client needs and makes no decision about how residue should merge. The
+//! gateway's own answer to that lives in `gateway/anthropic/.../stream.rs` and
+//! is tested there.
+//!
+//! Three things this protocol does that the openai_compat transcripts do not
+//! exercise, which is why these fixtures exist rather than being adapted:
+//! - **there is no `[DONE]` sentinel** — a stream ends with a `message_stop`
+//!   EVENT, so completion can only be recognized by decoding;
+//! - **the index counts ALL blocks**, so a tool call sitting after text is at
+//!   index 1 and a chat-completions reader would have called it 0;
+//! - **a signature arrives as its own delta**, just before the block closes,
+//!   and covers the whole thinking block rather than any fragment of it.
+//!
+//! PROVENANCE: hand-built from
+//! <https://platform.claude.com/docs/en/build-with-claude/streaming>, with ids
+//! and token counts kept as the docs print them. They prove warpllm reads what
+//! Anthropic DOCUMENTS; a live capture from `tests/live_stream.rs` is what
+//! would prove it reads what Anthropic sends, and drops in unchanged.
+
+use std::collections::BTreeMap;
+
+use warpllm::protocol::anthropic::messages::types::{
+    ContentBlock, ContentBlockDelta, Message, MessageStreamEvent, TextBlock, ThinkingBlock,
+    ToolUseBlock, Usage,
+};
+
+fn fixture(name: &str) -> String {
+    std::fs::read_to_string(format!(
+        "{}/tests/protocol/anthropic/messages/fixtures/transcript/{name}",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .unwrap_or_else(|e| panic!("{name}: {e}"))
+}
+
+/// The `data:` payloads of an SSE body.
+///
+/// The `event:` lines are deliberately ignored: Anthropic duplicates the name
+/// in the payload's own `type`, so the framing carries nothing the body does
+/// not. That is what lets the shared `SseFrames` reader be reused unchanged.
+fn payloads(sse: &str) -> Vec<&str> {
+    sse.lines()
+        .filter_map(|line| line.strip_prefix("data: "))
+        .collect()
+}
+
+fn events(sse: &str) -> Vec<MessageStreamEvent> {
+    payloads(sse)
+        .into_iter()
+        .map(|payload| {
+            serde_json::from_str(payload).unwrap_or_else(|e| panic!("{payload} failed: {e}"))
+        })
+        .collect()
+}
+
+/// A block being built, keyed by the index its events carry.
+#[derive(Default)]
+struct Accumulated {
+    /// The block as it opened, which is what says whether the fragments below
+    /// are text, arguments, or thinking.
+    opened: Option<ContentBlock>,
+    text: String,
+    signature: Option<String>,
+}
+
+/// Events in, the message they add up to out.
+fn reassemble(events: &[MessageStreamEvent]) -> Message {
+    let mut message = match events.first() {
+        Some(MessageStreamEvent::MessageStart(start)) => start.message.clone(),
+        other => panic!("a transcript opens with message_start, not {other:?}"),
+    };
+    let mut blocks: BTreeMap<u32, Accumulated> = BTreeMap::new();
+
+    for event in events {
+        match event {
+            MessageStreamEvent::ContentBlockStart(start) => {
+                blocks.entry(start.index).or_default().opened = Some(start.content_block.clone());
+            }
+            MessageStreamEvent::ContentBlockDelta(event) => {
+                let entry = blocks.entry(event.index).or_default();
+                match &event.delta {
+                    ContentBlockDelta::TextDelta(delta) => entry.text.push_str(&delta.text),
+                    ContentBlockDelta::ThinkingDelta(delta) => entry.text.push_str(&delta.thinking),
+                    ContentBlockDelta::InputJsonDelta(delta) => {
+                        entry.text.push_str(&delta.partial_json)
+                    }
+                    // Covers the whole block, so it replaces rather than
+                    // appends — and it is why a thinking block cannot be
+                    // rebuilt from its fragments alone.
+                    ContentBlockDelta::SignatureDelta(delta) => {
+                        entry.signature = Some(delta.signature.clone())
+                    }
+                    ContentBlockDelta::Unknown(_) => {}
+                }
+            }
+            MessageStreamEvent::MessageDelta(event) => {
+                // `Option<Option<_>>`: the outer says the key was there, the
+                // inner says whether it was null. Only a stated key overwrites.
+                if let Some(reason) = &event.delta.stop_reason {
+                    message.stop_reason = reason.clone();
+                }
+                if let Some(sequence) = &event.delta.stop_sequence {
+                    message.stop_sequence = sequence.clone();
+                }
+                // Cumulative, not per-event: the last one stated is the total.
+                message.usage.output_tokens = event.usage.output_tokens;
+            }
+            _ => {}
+        }
+    }
+
+    // BTreeMap, so the blocks come back in index order however the events
+    // interleaved — which is the whole job the index does.
+    message.content = blocks.into_values().map(close).collect();
+    message
+}
+
+/// One accumulated block as the block it opened as.
+fn close(block: Accumulated) -> ContentBlock {
+    let Accumulated {
+        opened,
+        text,
+        signature,
+    } = block;
+    match opened.expect("a block sends its fragments only after it opens") {
+        ContentBlock::Text(open) => ContentBlock::Text(TextBlock { text, ..open }),
+        ContentBlock::Thinking(open) => ContentBlock::Thinking(ThinkingBlock {
+            thinking: text,
+            signature,
+            ..open
+        }),
+        ContentBlock::ToolUse(open) => ContentBlock::ToolUse(ToolUseBlock {
+            // The fragments concatenate to JSON; no single one is valid on its
+            // own, which is exactly why a consumer must accumulate rather than
+            // parse per event.
+            input: serde_json::from_str(&text)
+                .unwrap_or_else(|e| panic!("tool arguments did not add up to JSON: {text:?}: {e}")),
+            ..open
+        }),
+        // Nothing else splits into fragments; it arrived whole on its start.
+        whole => whole,
+    }
+}
+
+fn transcripts() -> Vec<String> {
+    let dir = format!(
+        "{}/tests/protocol/anthropic/messages/fixtures/transcript",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let mut names: Vec<String> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("{dir}: {e}"))
+        .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+        .filter(|name| name.ends_with(".sse"))
+        .collect();
+    names.sort();
+    assert!(!names.is_empty(), "no transcripts in {dir}");
+    names
+}
+
+/// The permissiveness claim, event by event: anything Anthropic sends comes
+/// back out as itself. A field dropped, renamed, or mistyped fails the diff.
+#[test]
+fn every_streamed_event_round_trips_losslessly() {
+    for name in transcripts() {
+        let sse = fixture(&name);
+        for payload in payloads(&sse) {
+            let original: serde_json::Value = serde_json::from_str(payload).unwrap();
+            let parsed: MessageStreamEvent = serde_json::from_str(payload).unwrap();
+            assert_eq!(
+                serde_json::to_value(&parsed).unwrap(),
+                original,
+                "{name}: {payload}"
+            );
+        }
+    }
+}
+
+/// The claim this protocol's streaming half actually makes: the events add up
+/// to the reply the unstreamed call would have returned.
+#[test]
+fn a_transcript_adds_up_to_its_message() {
+    for name in transcripts() {
+        let golden = name.replace(".sse", ".message.json");
+        let expected: serde_json::Value = serde_json::from_str(&fixture(&golden)).unwrap();
+        let reassembled = reassemble(&events(&fixture(&name)));
+        assert_eq!(
+            serde_json::to_value(&reassembled).unwrap(),
+            expected,
+            "{name} did not add up to {golden}"
+        );
+    }
+}
+
+/// The index divergence, pinned rather than described. Anthropic counts ALL
+/// blocks, so the tool call in this transcript is at index 1 — a
+/// chat-completions reader would have called the first call 0, and a gateway
+/// that remapped would have to carry per-index state to do it.
+#[test]
+fn the_index_counts_every_block_not_just_tool_calls() {
+    let events = events(&fixture("doc-tool-call.sse"));
+    let call = events
+        .iter()
+        .find_map(|event| match event {
+            MessageStreamEvent::ContentBlockStart(start) => match &start.content_block {
+                ContentBlock::ToolUse(_) => Some(start.index),
+                _ => None,
+            },
+            _ => None,
+        })
+        .expect("the transcript opens a tool call");
+    assert_eq!(call, 1, "text is at 0, so the first tool call is at 1");
+}
+
+/// A stream ends with an EVENT, not a sentinel. Nothing in the body says
+/// "done" until it is decoded, which is why the reader cannot key completion on
+/// the framing the way an OpenAI-compatible one does.
+#[test]
+fn a_transcript_ends_with_message_stop_and_carries_no_sentinel() {
+    for name in transcripts() {
+        let sse = fixture(&name);
+        assert!(
+            !sse.contains("[DONE]"),
+            "{name} carries a sentinel this protocol does not send"
+        );
+        assert!(
+            matches!(
+                events(&sse).last(),
+                Some(MessageStreamEvent::MessageStop(_))
+            ),
+            "{name} does not end with message_stop"
+        );
+    }
+}
+
+/// A thinking block's signature is not a fragment of anything: it arrives once,
+/// covers the whole block, and is what Anthropic verifies when the block is
+/// sent back. Losing it silently is the failure that matters, so the golden
+/// carries it and this names it.
+#[test]
+fn a_thinking_block_reassembles_with_its_signature() {
+    let message = reassemble(&events(&fixture("doc-thinking.sse")));
+    let thinking = message
+        .content
+        .iter()
+        .find_map(|block| match block {
+            ContentBlock::Thinking(block) => Some(block),
+            _ => None,
+        })
+        .expect("the transcript opens a thinking block");
+    assert_eq!(thinking.thinking, "Let me work through this.");
+    assert!(
+        thinking.signature.as_deref().is_some_and(|s| !s.is_empty()),
+        "the signature was dropped in reassembly"
+    );
+}
+
+/// Usage is cumulative and split across two events: `message_start` states the
+/// input, `message_delta` restates the output as a running total. A reader that
+/// summed the output counts would over-report.
+#[test]
+fn usage_comes_from_both_ends_of_the_stream() {
+    let message = reassemble(&events(&fixture("doc-text.sse")));
+    let Usage {
+        input_tokens,
+        output_tokens,
+        ..
+    } = message.usage;
+    assert_eq!(input_tokens, 25, "the input count came from message_start");
+    assert_eq!(
+        output_tokens, 15,
+        "the output count is message_delta's total, not a sum of the events"
+    );
+}

--- a/docs/concepts/model-routing.mdx
+++ b/docs/concepts/model-routing.mdx
@@ -79,6 +79,15 @@ A model name may contain further slashes after the provider prefix —
 `openrouter/anthropic/claude-sonnet-4` is the OpenRouter provider serving the
 `anthropic/claude-sonnet-4` slug.
 
+<Note>
+  OpenRouter is the only route to Claude today. A direct `anthropic/` provider
+  is not yet registered, so `anthropic/claude-sonnet-4` fails the same way any
+  unknown string does. The protocol underneath it — translating your request
+  into Anthropic's `/messages` shape and its reply back — is on `main`;
+  routing to it is tracked in
+  [#23](https://github.com/warpllm/warpllm/issues/23).
+</Note>
+
 ## What the registry records
 
 The registry lives at

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -60,7 +60,17 @@ honest version of what you can build on.
 | Mistral | On `main`, unreleased |
 | OpenAI-compatible HTTP gateway | On `main`, unreleased |
 | Weighted load balancing (Rust only) | On `main`, unreleased |
+| Anthropic's Messages protocol | On `main`, not yet routable |
+| Claude direct on `api.anthropic.com` | Not yet — [#23](https://github.com/warpllm/warpllm/issues/23) |
 | Failover, retries, caching, metrics | Planned |
+
+<Note>
+  Those two Anthropic rows say different things. warpllm can now translate a
+  chat-completions request into Anthropic's `/messages` shape and read its
+  streamed reply back, but no model string routes there yet — so Claude is
+  still reached through OpenRouter. See
+  [Model routing](/concepts/model-routing).
+</Note>
 
 <Info>
   0.4.0 is **source-breaking for Rust only**: `ClientConfig` gained a

--- a/docs/models/overview.mdx
+++ b/docs/models/overview.mdx
@@ -78,6 +78,11 @@ models Google's own shape. None of those have an `api:` here yet, and
 registering them would hand back a model string that resolves and then fails
 upstream on every request.
 
+`anthropic_messages` is the closest to arriving: the surface is implemented on
+`main` and nothing routes to it, which is the last step of
+[#23](https://github.com/warpllm/warpllm/issues/23). Registering these entries
+is what that step unblocks.
+
 No entry carries `capabilities`: Zen publishes a price per model and no context
 window, output ceiling, or concurrency figure. Every model is re-hosted, so the
 original provider's numbers are not Zen's to promise.


### PR DESCRIPTION
Third slice of #23: the streaming half of the Anthropic Messages protocol. Branches off `main` at `c1187782`.

## What lands

- **`gateway/anthropic/api/messages/stream.rs`** — `ingest_event` / `render_event`, plus `StreamState`.
- **`exchange_stream` + `ChatChunkStream`** in `exchange.rs`.
- **`tests/protocol/anthropic/messages/reassembly.rs`** with four `.sse` / `.message.json` transcript pairs — text, a tool call with arguments split mid-JSON, extended thinking with a signature, and `max_tokens`.
- **The five staged `#[allow(dead_code)]` on the transport are gone.** Deleting them is what wiring the stream up means.

## The contract

**Reassembly-equivalence, not event-level losslessness**, and saying so is the honest version of the claim. `content_block_stop` and `ping` carry nothing a gateway chunk holds, so they ingest to `None` and no renderer can put them back where they were. What *is* promised is that a transcript ingested and reassembled equals the `Message` the unstreamed call would have returned.

## Decisions worth review

**An `error` event is not a chunk.** The transport hands it over as `Ok(event)` with the stream marked *complete* — to it, a well-formed event that ends the stream. A reader that skipped it the way it skips a `ping` would read the next event, get `None`, and report a half-written reply as a finished one, burying the provider's reason under a clean EOF. It becomes an `Err` at the one layer that can tell a failure from an absence, classified against the status that *was* sent (200) — which is exactly the case `error.rs`'s `type` table already existed for.

**`message_start` reports no usage.** Its counts are real but partial; output has not happened. A consumer summing per-chunk usage would double-count the input against `message_delta`, which restates the totals at the end.

**`StreamState` holds only `id`, `model`, and the input counts.** Every delta is self-describing, so no per-index block-type map is needed.

**The whole wire `Message` is retained on `message_start`.** My first attempt retained only the non-promoted fields and the round trip failed: `id`/`role`/`model` are required to rebuild a `Message`, and reassembling from promoted values plus partial residue would have to guess at `type`, at empty-versus-absent `content`, and at `stop_reason`'s three-state nullability.

**`finish_reason` is now shared** with `response.rs` rather than copied — the streamed and unstreamed forms of one request must not end differently.

## One bug fixed outside this protocol

A tool call's `kind` was echoed to chat completions verbatim, so Anthropic's `tool_use` reached a caller whose own `type` has no such value — every official SDK reads it as unrecognized. `render_tool_call_kind` applies the rule `render_finish_reason` already follows. `None` stays `None`: a continuation fragment carries no type, and supplying one would put a key on the wire the provider never sent.

## Recorded, not fixed — both are PR D blockers

- **A tool call's `index` means different things in the two protocols.** Anthropic's counts all blocks, so text at 0 puts the first call at 1; `openai_compat`'s `render_chunk` copies it straight into `tool_calls[].index`, where a client assembling by index sees a hole at 0. The IR field is documented as a *correlation key*, which is what this PR carries faithfully — the renderer is what assumes key == ordinal. The fix belongs in `openai_compat`'s renderer with a per-stream key→ordinal map, needs stream-scoped state `render_chunk` does not have, and cannot be tested end to end until dispatch exists.
- **Signed thinking does not survive to a caller in another protocol, on the streamed path too.** Same gap PR #62 recorded for whole replies. Whichever answer PR D picks has to cover both forms, or a request behaves differently depending on how it was called.

## Verification

404 lib tests, 20 protocol tests, `./scripts/test-all.sh` green.

Five mutations, each caught:

| mutation | caught by |
|---|---|
| `may_read` always true | the new stream isolation test, alongside #62's three |
| drop the cached-token normalization | `usage_is_reported_once_and_includes_the_cached_input` |
| map `signature_delta` to text | `the_content_event_table` **only** |
| skip the `error` event like a `ping` | `a_mid_stream_error_is_a_failure_and_not_a_clean_end` |
| echo `kind` verbatim | `a_tool_calls_kind_is_translated_into_this_protocols_vocabulary` |

Two of those are worth calling out. The `signature_delta` mutation **passed** the round-trip test — retention replayed the correct wire delta regardless — and only the table test caught it; that is the vacuous-pass hazard, and the reason every retained path here ships with a second test that does not benefit from retention. And my first version of the `kind` test asserted against the helper, which passed while the call site ignored it entirely; it now renders through `render_chunk`. Same mistake as the `error` event, which my `ingest_event` test caught in isolation while the seam swallowed it.
