### PR TITLE
fix(openai_compat): preserve explicit null on temperature, max_tokens, top_p

### DIFF
--- a/crates/warpllm/src/gateway/openai_compat/api/chat_completions/request.rs
+++ b/crates/warpllm/src/gateway/openai_compat/api/chat_completions/request.rs
@@ -83,6 +83,9 @@ pub(crate) fn ingest_request(
     } = request;
 
     let mut compat = unknown_fields;
+    retain(&mut compat, "temperature", temperature.as_ref());
+    retain(&mut compat, "max_tokens", max_tokens.as_ref());
+    retain(&mut compat, "top_p", top_p.as_ref());
     retain(&mut compat, "stop", stop.as_ref());
     retain(&mut compat, "stream_options", stream_options.as_ref());
     retain(&mut compat, "tools", tools.as_ref());
@@ -101,9 +104,12 @@ pub(crate) fn ingest_request(
             .collect(),
         tool_choice: tool_choice.as_ref().and_then(ingest_tool_choice),
         params: types::GenerationParams {
-            max_tokens,
-            temperature,
-            top_p,
+            // Both an absent field and an explicit `null` mean "no value" to
+            // the gateway IR; which one it was rides the residue above so
+            // rendering can restore it.
+            max_tokens: max_tokens.flatten(),
+            temperature: temperature.flatten(),
+            top_p: top_p.flatten(),
             // Both wire spellings mean the same list of sequences; the one
             // that arrived is retained above so rendering can restore it.
             stop: stop
@@ -402,9 +408,13 @@ pub(crate) fn render_request(
     Ok(CreateChatCompletionRequest {
         model: request.model.clone(),
         messages,
-        temperature: params.temperature,
-        max_tokens: params.max_tokens,
-        top_p: params.top_p,
+        // Each of these prefers what arrived over what the gateway IR can
+        // reconstruct: a null the caller sent survives the round trip.
+        temperature: take_typed(&mut unknown_fields, "temperature")
+            .or_else(|| params.temperature.map(Some)),
+        max_tokens: take_typed(&mut unknown_fields, "max_tokens")
+            .or_else(|| params.max_tokens.map(Some)),
+        top_p: take_typed(&mut unknown_fields, "top_p").or_else(|| params.top_p.map(Some)),
         stop: take_typed(&mut unknown_fields, "stop").or_else(|| {
             (!params.stop.is_empty()).then(|| Some(ChatCompletionStop::Many(params.stop.clone())))
         }),
@@ -865,9 +875,9 @@ mod tests {
                     ..Default::default()
                 },
             ],
-            temperature: Some(0.7),
-            max_tokens: Some(256),
-            top_p: Some(0.9),
+            temperature: Some(Some(0.7)),
+            max_tokens: Some(Some(256)),
+            top_p: Some(Some(0.9)),
             stop: Some(Some(ChatCompletionStop::Many(vec![
                 "END".into(),
                 "STOP".into(),
@@ -908,9 +918,9 @@ mod tests {
         // Message-level passthrough fields ride ext and come back verbatim.
         assert_eq!(wire.messages[1].unknown_fields["name"], json!("alice"));
         assert_eq!(wire.messages[1].unknown_fields["vendor_tag"], json!("vt"));
-        assert_eq!(wire.temperature, Some(0.7));
-        assert_eq!(wire.max_tokens, Some(256));
-        assert_eq!(wire.top_p, Some(0.9));
+        assert_eq!(wire.temperature, Some(Some(0.7)));
+        assert_eq!(wire.max_tokens, Some(Some(256)));
+        assert_eq!(wire.top_p, Some(Some(0.9)));
         assert_eq!(plain(&wire.stop), json!(["END", "STOP"]));
         assert_eq!(wire.stream, None);
         // Request-level passthrough fields ride ext and come back verbatim.
@@ -1668,6 +1678,9 @@ mod tests {
         let body = json!({
             "model": "openai/gpt-5.6",
             "messages": [],
+            "temperature": null,
+            "max_tokens": null,
+            "top_p": null,
             "stop": null,
             "stream_options": null,
             "reasoning_effort": null,

--- a/crates/warpllm/src/protocol/openai_compat/chat_completions/types.rs
+++ b/crates/warpllm/src/protocol/openai_compat/chat_completions/types.rs
@@ -631,15 +631,30 @@ pub struct CreateChatCompletionRequest {
     /// Model string in `provider/model` form, e.g. `"openai/gpt-5.6"`.
     pub model: String,
     pub messages: Vec<ChatCompletionRequestMessage>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "codegen", ts(optional = nullable))]
-    pub temperature: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "codegen", ts(optional = nullable))]
-    pub max_tokens: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "codegen", ts(optional = nullable))]
-    pub top_p: Option<f64>,
+    #[serde(
+        default,
+        deserialize_with = "present_or_null",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    #[cfg_attr(feature = "codegen", schemars(extend("x-nullable-when-present" = true)))]
+    pub temperature: Option<Option<f64>>,
+    #[serde(
+        default,
+        deserialize_with = "present_or_null",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    #[cfg_attr(feature = "codegen", schemars(extend("x-nullable-when-present" = true)))]
+    pub max_tokens: Option<Option<u32>>,
+    #[serde(
+        default,
+        deserialize_with = "present_or_null",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    #[cfg_attr(feature = "codegen", schemars(extend("x-nullable-when-present" = true)))]
+    pub top_p: Option<Option<f64>>,
     #[serde(
         default,
         deserialize_with = "present_or_null",

--- a/crates/warpllm/tests/providers/deepseek/chat_completions/mod.rs
+++ b/crates/warpllm/tests/providers/deepseek/chat_completions/mod.rs
@@ -92,7 +92,7 @@ fn deepseek_forwards_params_for_the_provider_to_judge() {
             .await;
 
         let mut req = request("deepseek/deepseek-v4-flash");
-        req.temperature = Some(3.0);
+        req.temperature = Some(Some(3.0));
         req.unknown_fields.insert("seed".into(), json!(7));
         client_for(&server).chat_completions(req).await.unwrap();
 

--- a/crates/warpllm/tests/providers/mistral/chat_completions/mod.rs
+++ b/crates/warpllm/tests/providers/mistral/chat_completions/mod.rs
@@ -47,7 +47,7 @@ fn mistral_forwards_params_for_the_provider_to_judge() {
             .await;
 
         let mut req = request("mistral/mistral-large-2411");
-        req.temperature = Some(0.5);
+        req.temperature = Some(Some(0.5));
         req.unknown_fields.insert("safe_prompt".into(), json!(true));
         client_for(&server).chat_completions(req).await.unwrap();
 

--- a/crates/warpllm/tests/providers/openrouter/chat_completions/mod.rs
+++ b/crates/warpllm/tests/providers/openrouter/chat_completions/mod.rs
@@ -101,7 +101,7 @@ fn openrouter_forwards_params_for_the_provider_to_judge() {
             .await;
 
         let mut req = request("openrouter/anthropic/claude-sonnet-4");
-        req.temperature = Some(3.0);
+        req.temperature = Some(Some(3.0));
         req.unknown_fields
             .insert("provider".into(), json!("StreamLake"));
         req.unknown_fields.insert("route".into(), json!("fallback"));


### PR DESCRIPTION
## Summary
- `temperature`, `max_tokens`, and `top_p` now forward an explicit null instead of dropping it. Fixes #51.
- Same-protocol round trips stay lossless. Cross-protocol renders keep working, since the IR stays `Option<T>`.

## The bug
OpenAI documents all three as nullable. A caller sends `{"temperature": null}`. warpllm forwarded `{}`. This occured on every OpenAI-compatible backend that reads a null differently from an absence.

## The fix
The types read three states now via `present_or_null`, matching `stop`, `stream_options`, and `reasoning_effort`. Ingest retains the arrived value under `ext["openai_compat"]`. Render prefers the retained value over the gateway IR, so a same-protocol round trip keeps the null the caller sent.

The IR itself stays plain `Option<T>`. A null and an absence look the same to a renderer for another protocol. Only the same-protocol residue carries the distinction, which is what it exists for.

## Test plan
- [x] `an_explicit_null_survives_on_every_nullable_field` extended with the three fields. It failed before the change, and passes now.
- [x] `cargo test -p warpllm --lib`: 393 passed, 0 failed.
- [x] Codegen regen was a noop. `Option<T>` with `ts(optional = nullable)` and `Option<Option<T>>` with `ts(optional) + x-nullable-when-present` render identical TS and Python bindings.