### PR TITLE
Read a status and its error type together, so Zen's credit exhaustion is a bill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ Versions follow [semantic versioning](https://semver.org). While the project is
 pre-1.0, a breaking change bumps the MINOR number: `0.1.x` and `0.2.x` are
 incompatible, and `^0.1` will not upgrade you into one.
 
+## [Unreleased]
+
+### Fixed
+
+- **An OpenCode Zen account out of credit was reported as an authentication
+  failure**, sending the caller to check an API key that was fine. It now
+  classifies as `quota_exceeded`, which is what the failure is — and on the
+  OpenAI-compatible surface that means HTTP 429 `insufficient_quota` rather
+  than 401 `invalid_api_key`.
+
+  Zen reports credit exhaustion at **HTTP 401**, not the 402 that would have
+  been readable, with a family of its own and no `code` at all:
+
+  ```json
+  {"type":"error","error":{"type":"CreditsError","message":"No payment method. Add a payment method here: …/billing"}}
+  ```
+
+  The status cannot decide this on its own, because Zen answers a genuinely
+  bad key with that same 401 and a different family — `AuthError` — so a rule
+  reading 401 would be wrong in one direction or the other whichever way it
+  went. Only the two signals together separate them.
+
+  The classifier could not express that. It ranked every status above every
+  `type`, so `openai_compat`'s reading of a bare 401 answered first and no
+  provider rule written on a family was ever consulted. The two lookups are
+  now one, `ErrorMapper::from_status_and_type`, and which of the two signals
+  is stronger is each vocabulary's own call rather than a fixed order imposed
+  on all of them — `openai_compat` and `anthropic` both still read the status
+  first, and say why.
+
+  No other provider reclassifies: nothing on the roster mapped a `type` of its
+  own, so every existing failure resolves exactly as before. `ErrorMapper` is
+  internal, so no package's API changes.
+
 ## [0.4.0] - 2026-08-16
 
 Two additions and one source-break. A client can now declare the providers it

--- a/crates/warpllm/src/gateway/anthropic/error.rs
+++ b/crates/warpllm/src/gateway/anthropic/error.rs
@@ -8,19 +8,20 @@
 //! Sibling of [`api`](super::api) rather than a child of one of its surfaces:
 //! the envelope is protocol-wide, shared by every endpoint Anthropic serves.
 //!
-//! # Two signals, not three
+//! # One lookup, not two
 //!
-//! [`ErrorMapper`] offers `from_code`, `from_status` and `from_type`, and this
-//! protocol implements only the last two. Anthropic sends **no `code`** — the
+//! [`ErrorMapper`] offers `from_code` and `from_status_and_type`, and this
+//! protocol implements only the second. Anthropic sends **no `code`** — the
 //! envelope is `{type, message}` and nothing else — so a distinction OpenAI
 //! draws with a slug has to be drawn from the status here or not at all.
 //!
 //! That is not a gap to work around. `classify` asks the strongest signal
-//! first, and with the strongest one absent the ordering does more work than it
-//! does next door: `invalid_request_error` is Anthropic's documented catch-all
-//! for "other 4XX status codes not listed", so reading the family before the
-//! status would report a 402 billing failure as a malformed request. The status
-//! table below is deliberately the wider of the two.
+//! first, and with the strongest one absent everything rests on how the one
+//! lookup below orders its own arms: `invalid_request_error` is Anthropic's
+//! documented catch-all for "other 4XX status codes not listed", so reading the
+//! family before the status would report a 402 billing failure as a malformed
+//! request. The status arms come first for that reason, and they are
+//! deliberately the wider set.
 
 use std::time::Duration;
 
@@ -83,8 +84,9 @@ pub(super) struct Anthropic;
 
 impl ErrorMapper for Anthropic {
     /// Anthropic publishes one status per failure and a matching `type` for
-    /// each, so the status table is complete rather than the residue it is on a
-    /// protocol with per-failure codes.
+    /// each, so the status arms are a complete table rather than the residue
+    /// they are on a protocol with per-failure codes — and they are read
+    /// FIRST, for the reason this module's docs give.
     ///
     /// **529** is the one that has to be here. It is Anthropic's own overload
     /// status, outside any range `classify`'s residual reads — 5xx there stops
@@ -124,46 +126,44 @@ impl ErrorMapper for Anthropic {
     /// second look. Delineating them then means using what warpllm SENT — it
     /// knows whether the request carried a file reference — never what
     /// Anthropic wrote back.
-    fn from_status(&self, status: u16) -> Option<Classified> {
-        Some(match status {
-            401 => Error::Authentication,
-            402 => Error::QuotaExceeded,
-            403 => Error::PermissionDenied,
-            404 => Error::ModelNotFound,
-            413 => Error::ContextLengthExceeded,
-            429 => Error::RateLimited,
-            529 => Error::Overloaded,
-            _ => return None,
-        })
-    }
-
-    /// The `type` family — the weaker of the two signals this protocol has, and
-    /// the one that only decides a failure whose status said nothing.
+    ///
+    /// ---
+    ///
+    /// The `type` arms are the weaker of the two signals this protocol has,
+    /// and only decide a failure whose status said nothing.
     ///
     /// In practice that is a mid-stream `error` event, which arrives with no
     /// status at all because the HTTP exchange already answered 200. Every
-    /// family below is reachable that way, which is why the table mirrors the
-    /// status one rather than stopping at the families a 4xx can carry.
-    fn from_type(&self, error_type: &str) -> Option<Classified> {
-        Some(match error_type {
-            "authentication_error" => Error::Authentication,
-            "billing_error" => Error::QuotaExceeded,
-            "permission_error" => Error::PermissionDenied,
-            "not_found_error" => Error::ModelNotFound,
-            "request_too_large" => Error::ContextLengthExceeded,
-            "rate_limit_error" => Error::RateLimited,
-            "overloaded_error" => Error::Overloaded,
+    /// family below is reachable that way, which is why they mirror the status
+    /// arms rather than stopping at the families a 4xx can carry.
+    fn from_status_and_type(&self, status: u16, error_type: Option<&str>) -> Option<Classified> {
+        Some(match (status, error_type) {
+            (401, _) => Error::Authentication,
+            (402, _) => Error::QuotaExceeded,
+            (403, _) => Error::PermissionDenied,
+            (404, _) => Error::ModelNotFound,
+            (413, _) => Error::ContextLengthExceeded,
+            (429, _) => Error::RateLimited,
+            (529, _) => Error::Overloaded,
+
+            (_, Some("authentication_error")) => Error::Authentication,
+            (_, Some("billing_error")) => Error::QuotaExceeded,
+            (_, Some("permission_error")) => Error::PermissionDenied,
+            (_, Some("not_found_error")) => Error::ModelNotFound,
+            (_, Some("request_too_large")) => Error::ContextLengthExceeded,
+            (_, Some("rate_limit_error")) => Error::RateLimited,
+            (_, Some("overloaded_error")) => Error::Overloaded,
             // A 504 from Anthropic's own edge. NOT `Error::StreamStalled`,
             // however closely the words match: that variant is warpllm
             // reporting that IT stopped waiting, carries the timeout it
             // enforced, and holds no provider evidence — so it cannot even be
             // constructed here. An upstream that timed out and said so is an
             // unattributed 5xx, which is what `ServerError` means.
-            "api_error" | "timeout_error" => Error::ServerError,
+            (_, Some("api_error" | "timeout_error")) => Error::ServerError,
             // Anthropic's catch-all, and the reason it is read LAST: it is
             // documented as covering "other 4XX status codes not listed",
             // which makes it the family that means least.
-            "invalid_request_error" => Error::InvalidRequest,
+            (_, Some("invalid_request_error")) => Error::InvalidRequest,
             // `conflict_error` (409) is deliberately absent, and it is the one
             // family here that falls all the way through to `Error::Unknown` —
             // `classify`'s residual reads 400 and 422, not the whole 4xx range.

--- a/crates/warpllm/src/gateway/error.rs
+++ b/crates/warpllm/src/gateway/error.rs
@@ -31,21 +31,32 @@ use crate::gateway::types::ProviderError;
 /// be a second level reintroduced one module over.
 pub(crate) type Classified = fn(Box<ProviderError>) -> Error;
 
-/// What a set of error spellings MEANS, as three independent lookups.
+/// What a set of error spellings MEANS, as two lookups.
 ///
 /// Implemented twice over for any given exchange: once by the protocol, for
 /// the vocabulary its whole ecosystem shares, and once by the provider, for
 /// what only it does. [`classify`] interleaves them.
 ///
-/// THREE METHODS, NOT ONE, and that is the whole design. A single
-/// `classify`-shaped hook would let a provider's rule outrank every protocol
-/// rule regardless of strength — so a provider that maps a bare status would
-/// beat the protocol reading an explicit `code`, and a failure the provider
-/// NAMED would lose to a guess about its status. Splitting the hook by signal
-/// makes the strength ordering something [`classify`] enforces rather than
-/// something each implementor has to remember.
+/// TWO METHODS, NOT ONE, and the split that remains is the one [`classify`]
+/// can enforce without knowing any vocabulary. A `code` is the upstream NAMING
+/// its own failure, and no reading of the envelope around it — from the
+/// provider or from anyone — should outrank that. A single `classify`-shaped
+/// hook would lose exactly that guarantee: a provider mapping a bare status
+/// would beat the protocol reading an explicit slug.
 ///
-/// Every method defaults to `None`, so an implementor writes only the lookups
+/// TWO METHODS, NOT THREE, and that is the other half. Status and `type` were
+/// once separate hooks ranked status-over-type, which made the ranking
+/// [`classify`]'s to impose on every protocol at once — and made a provider's
+/// `type` structurally unable to outrank its protocol's status, however
+/// decisive that `type` was. OpenCode Zen is where that broke: it reports
+/// credit exhaustion as `CreditsError` at HTTP 401, the same status it uses
+/// for a genuinely bad key, so neither signal decides alone and no rule
+/// written on one of them could ever have been right. Which of the two is
+/// stronger is a property of a particular vocabulary, not of HTTP, so it
+/// belongs to the mapper holding both — where the arms of one `match` state it
+/// in reading order.
+///
+/// Both methods default to `None`, so an implementor writes only the lookups
 /// it actually has.
 // `from_*` taking `&self` trips `clippy::wrong_self_convention`, which reads
 // the prefix as a constructor. These are lookups on a mapper — "what does this
@@ -59,16 +70,14 @@ pub(crate) trait ErrorMapper: Sync {
         None
     }
 
-    /// An HTTP status that means one thing on this protocol or from this
-    /// provider. Weaker than a `code`: a status is warpllm reading a number,
-    /// a code is the upstream saying what happened.
-    fn from_status(&self, _status: u16) -> Option<Classified> {
-        None
-    }
-
-    /// The provider's `type` — a failure FAMILY. Weakest of the three,
-    /// because a family covers several failures that need different remedies.
-    fn from_type(&self, _error_type: &str) -> Option<Classified> {
+    /// The rest of the envelope: the HTTP status, and the `type` family the
+    /// body named beside it. Weaker than a `code`, which is why it is asked
+    /// second — but weaker only as a pair, because within it the two signals
+    /// have no fixed order to enforce.
+    ///
+    /// `error_type` is `Option` because plenty of backends send a bare status
+    /// with no envelope at all; the status is always there to read.
+    fn from_status_and_type(&self, _status: u16, _error_type: Option<&str>) -> Option<Classified> {
         None
     }
 }
@@ -81,12 +90,18 @@ impl ErrorMapper for MatchesProtocol {}
 /// Resolves one failure against a provider and the protocol it speaks,
 /// strongest signal first.
 ///
-/// The tier order lives HERE, once, rather than in each protocol: which
-/// signal outranks which is a property of HTTP error envelopes in general,
-/// not of any one wire format. Within a tier the provider is asked first,
-/// since it is the more specific authority on its own spellings — but a tier
-/// is never skipped, so a provider's status rule cannot outrank the
-/// protocol's reading of an explicit `code`.
+/// The tier order lives HERE, once, rather than in each protocol: that a
+/// named `code` outranks the envelope around it is a property of HTTP error
+/// envelopes in general, not of any one wire format. Within a tier the
+/// provider is asked first, since it is the more specific authority on its own
+/// spellings — but a tier is never skipped, so a provider's reading of a
+/// status or a family cannot outrank the protocol's reading of an explicit
+/// `code`.
+///
+/// Four lookups, and nothing finer. Ranking a status against a `type` needs to
+/// know what a particular vocabulary spells them with, which is precisely what
+/// this function refuses to know — so that call sits inside each
+/// [`ErrorMapper`] instead.
 ///
 /// The residual is pure HTTP semantics and belongs to no vocabulary: a 4xx
 /// nobody recognized is still a client error, and a 5xx is still the server's.
@@ -100,10 +115,8 @@ pub(crate) fn classify(
 ) -> Classified {
     code.and_then(|code| provider.from_code(code))
         .or_else(|| code.and_then(|code| protocol.from_code(code)))
-        .or_else(|| provider.from_status(status))
-        .or_else(|| protocol.from_status(status))
-        .or_else(|| error_type.and_then(|family| provider.from_type(family)))
-        .or_else(|| error_type.and_then(|family| protocol.from_type(family)))
+        .or_else(|| provider.from_status_and_type(status, error_type))
+        .or_else(|| protocol.from_status_and_type(status, error_type))
         .unwrap_or(match status {
             400 | 422 => Error::InvalidRequest,
             500..=599 => Error::ServerError,
@@ -115,27 +128,44 @@ pub(crate) fn classify(
 mod tests {
     use super::*;
 
-    /// A protocol that answers on every tier, so a provider rule can be shown
-    /// to win or lose against each one independently.
+    /// A protocol that answers on both tiers, and on each signal within the
+    /// second, so a provider rule can be shown to win or lose against each one
+    /// independently.
     struct Protocol;
 
     impl ErrorMapper for Protocol {
         fn from_code(&self, code: &str) -> Option<Classified> {
             (code == "known_code").then_some(Error::ContentFilter as Classified)
         }
-        fn from_status(&self, status: u16) -> Option<Classified> {
-            (status == 429).then_some(Error::RateLimited as Classified)
-        }
-        fn from_type(&self, error_type: &str) -> Option<Classified> {
-            (error_type == "known_type").then_some(Error::ServerError as Classified)
+        fn from_status_and_type(
+            &self,
+            status: u16,
+            error_type: Option<&str>,
+        ) -> Option<Classified> {
+            Some(match (status, error_type) {
+                (429, _) => Error::RateLimited,
+                (_, Some("known_type")) => Error::ServerError,
+                _ => return None,
+            })
         }
     }
 
-    struct ProviderStatus;
+    /// A provider that reads the envelope both ways: a status the protocol
+    /// says nothing about, and a family the protocol would otherwise never be
+    /// asked for because its own status rule fires first.
+    struct ProviderEnvelope;
 
-    impl ErrorMapper for ProviderStatus {
-        fn from_status(&self, status: u16) -> Option<Classified> {
-            (status == 402).then_some(Error::QuotaExceeded as Classified)
+    impl ErrorMapper for ProviderEnvelope {
+        fn from_status_and_type(
+            &self,
+            status: u16,
+            error_type: Option<&str>,
+        ) -> Option<Classified> {
+            Some(match (status, error_type) {
+                (402, _) => Error::QuotaExceeded,
+                (_, Some("provider_type")) => Error::ContextLengthExceeded,
+                _ => return None,
+            })
         }
     }
 
@@ -177,30 +207,42 @@ mod tests {
     /// Within a tier the provider is the more specific authority and wins.
     #[test]
     fn a_provider_rule_beats_the_protocol_at_the_same_tier() {
-        assert_eq!(code_of(&ProviderStatus, 402, None, None), "quota_exceeded");
+        assert_eq!(
+            code_of(&ProviderEnvelope, 402, None, None),
+            "quota_exceeded"
+        );
     }
 
-    /// THE case the split hook exists for. A provider status rule must NOT
-    /// outrank the protocol reading an explicit `code`: the upstream named
-    /// its own failure, and a rule about its status numbers is a weaker
-    /// signal than that. A single `classify` hook would get this backwards.
+    /// THE case the remaining split exists for. A provider's reading of the
+    /// envelope must NOT outrank the protocol reading an explicit `code`: the
+    /// upstream named its own failure, and a rule about status numbers or
+    /// families is a weaker signal than that. A single `classify` hook would
+    /// get this backwards.
     #[test]
-    fn a_provider_status_rule_does_not_outrank_a_protocol_code() {
+    fn a_provider_envelope_rule_does_not_outrank_a_protocol_code() {
         assert_eq!(
-            code_of(&ProviderStatus, 402, None, Some("known_code")),
+            code_of(&ProviderEnvelope, 402, None, Some("known_code")),
             "content_filter",
             "a status guess outranked the failure the provider named"
         );
     }
 
-    /// ...and it DOES outrank the protocol's weaker tiers, or a provider
-    /// could never correct a family its protocol reads differently.
+    /// What merging the two envelope lookups BOUGHT, and the shape issue #66
+    /// reported: a provider names a failure with a `type`, under a status its
+    /// protocol already claims. While status and family were separate tiers
+    /// this was unreachable — every status outranked every family, so the
+    /// protocol's reading of 429 answered and the provider's rule could not be
+    /// consulted no matter what it said.
     #[test]
-    fn a_provider_status_rule_outranks_a_protocol_type() {
+    fn a_provider_family_outranks_a_protocol_status() {
         assert_eq!(
-            code_of(&ProviderStatus, 402, Some("known_type"), None),
-            "quota_exceeded"
+            code_of(&ProviderEnvelope, 429, Some("provider_type"), None),
+            "context_length_exceeded",
+            "the protocol's status answered a failure the provider had named"
         );
+        // ...and with nothing from the provider to read, that same status is
+        // still the protocol's to answer.
+        assert_eq!(code_of(&ProviderEnvelope, 429, None, None), "rate_limited");
     }
 
     /// Nothing recognized anywhere: HTTP semantics answer, and only where

--- a/crates/warpllm/src/gateway/openai_compat/error.rs
+++ b/crates/warpllm/src/gateway/openai_compat/error.rs
@@ -108,37 +108,36 @@ impl ErrorMapper for OpenAiCompat {
         })
     }
 
-    /// Only the statuses that mean ONE thing on this protocol.
+    /// The envelope short of a `code`: a status, and the `type` family beside
+    /// it. ON THIS PROTOCOL the status is the stronger of the two, and the
+    /// arms below say so by being read first.
     ///
-    /// 404 is deliberately absent: it may name a model, a proxy route, or the
-    /// endpoint itself, so it needs envelope evidence before becoming
+    /// `invalid_request_error` is why. It is OpenAI's CATCH-ALL, sent for a
+    /// bad API key (401), an unknown model (404), and a genuinely malformed
+    /// body alike, so reading it over an unambiguous 401 would report a
+    /// credential failure as a bad request and send a caller to fix a payload
+    /// that was fine. Note that this is a claim about OPENAI'S FAMILIES, not
+    /// about HTTP — a provider whose `type` names one failure each is entitled
+    /// to the opposite order, and `opencode` next door takes it.
+    ///
+    /// Only the statuses that mean ONE thing on this protocol are listed. 404
+    /// is deliberately absent: it may name a model, a proxy route, or the
+    /// endpoint itself, so it needs the family below before becoming
     /// [`Error::ModelNotFound`]. 402 is absent because it is not this
     /// protocol's — DeepSeek documents it, and states it itself.
-    fn from_status(&self, status: u16) -> Option<Classified> {
-        Some(match status {
-            401 => Error::Authentication,
-            403 => Error::PermissionDenied,
-            429 => Error::RateLimited,
-            503 => Error::Overloaded,
-            _ => return None,
-        })
-    }
-
-    /// The `type` family, weakest of the three — and the tier that explains
-    /// why the split matters. `invalid_request_error` is OpenAI's CATCH-ALL,
-    /// sent for a bad API key (401), an unknown model (404), and a genuinely
-    /// malformed body alike. Reading it over an unambiguous 401 would report
-    /// a credential failure as a bad request and send a caller to fix their
-    /// payload, which is why a decisive status is asked first.
-    fn from_type(&self, error_type: &str) -> Option<Classified> {
-        Some(match error_type {
-            "rate_limit_error" => Error::RateLimited,
-            "overloaded_error" => Error::Overloaded,
-            "authentication_error" => Error::Authentication,
-            "permission_error" => Error::PermissionDenied,
-            "not_found_error" => Error::ModelNotFound,
-            "invalid_request_error" => Error::InvalidRequest,
-            "api_error" => Error::ServerError,
+    fn from_status_and_type(&self, status: u16, error_type: Option<&str>) -> Option<Classified> {
+        Some(match (status, error_type) {
+            (401, _) => Error::Authentication,
+            (403, _) => Error::PermissionDenied,
+            (429, _) => Error::RateLimited,
+            (503, _) => Error::Overloaded,
+            (_, Some("rate_limit_error")) => Error::RateLimited,
+            (_, Some("overloaded_error")) => Error::Overloaded,
+            (_, Some("authentication_error")) => Error::Authentication,
+            (_, Some("permission_error")) => Error::PermissionDenied,
+            (_, Some("not_found_error")) => Error::ModelNotFound,
+            (_, Some("invalid_request_error")) => Error::InvalidRequest,
+            (_, Some("api_error")) => Error::ServerError,
             _ => return None,
         })
     }

--- a/crates/warpllm/src/gateway/openai_compat/provider_overrides/deepseek/error.rs
+++ b/crates/warpllm/src/gateway/openai_compat/provider_overrides/deepseek/error.rs
@@ -17,7 +17,11 @@ impl ErrorMapper for DeepSeek {
     /// A status rule and not a `code` one because DeepSeek sends no code with
     /// it, which is exactly why the protocol baseline cannot classify this
     /// and DeepSeek has to say so itself.
-    fn from_status(&self, status: u16) -> Option<Classified> {
+    ///
+    /// The `type` half of this lookup is unused: DeepSeek documents its
+    /// failures as bare statuses and sends no family alongside them, so 402 is
+    /// genuinely the only signal there is to read.
+    fn from_status_and_type(&self, status: u16, _error_type: Option<&str>) -> Option<Classified> {
         (status == 402).then_some(Error::QuotaExceeded as Classified)
     }
 }
@@ -28,7 +32,9 @@ mod tests {
 
     #[test]
     fn a_402_is_an_exhausted_balance_not_a_bad_request() {
-        let classified = DeepSeek.from_status(402).expect("402 is DeepSeek's");
+        let classified = DeepSeek
+            .from_status_and_type(402, None)
+            .expect("402 is DeepSeek's");
         assert!(matches!(
             classified(Box::new(crate::gateway::types::ProviderError {
                 provider: "deepseek",
@@ -49,13 +55,17 @@ mod tests {
     #[test]
     fn no_other_status_is_claimed() {
         for status in [400, 401, 403, 404, 429, 500, 503] {
-            assert!(DeepSeek.from_status(status).is_none(), "{status}");
+            assert!(
+                DeepSeek.from_status_and_type(status, None).is_none(),
+                "{status}"
+            );
         }
     }
 
-    /// DeepSeek overrides ONE of the three tiers. `from_code` and `from_type`
-    /// are not implemented at all, so they take the trait's `None` default
-    /// and every spelling on those tiers falls through to the protocol.
+    /// DeepSeek claims a status and nothing else. `from_code` is not
+    /// implemented at all, so it takes the trait's `None` default — and the
+    /// `type` half of `from_status_and_type` is ignored, so every family falls
+    /// through to the protocol under a status DeepSeek does not claim.
     ///
     /// Asserted against the protocol's whole published vocabulary rather than
     /// a sample: an override added here later would fail this test loudly,
@@ -83,7 +93,14 @@ mod tests {
             "invalid_request_error",
             "api_error",
         ] {
-            assert!(DeepSeek.from_type(error_type).is_none(), "{error_type}");
+            // Under 400, which DeepSeek's own status rule does not claim, so
+            // the family is all there is left for it to answer on.
+            assert!(
+                DeepSeek
+                    .from_status_and_type(400, Some(error_type))
+                    .is_none(),
+                "{error_type}"
+            );
         }
     }
 

--- a/crates/warpllm/src/gateway/openai_compat/provider_overrides/mod.rs
+++ b/crates/warpllm/src/gateway/openai_compat/provider_overrides/mod.rs
@@ -7,9 +7,9 @@
 //! adding a faithful backend to the roster is a YAML edit and no Rust at all.
 //!
 //! One directory per provider, one module inside it per thing that provider
-//! does differently — `deepseek/error.rs` maps its error codes, statuses and
-//! types, and a second divergence would land beside it rather than widening
-//! it.
+//! does differently — `deepseek/error.rs` reads what a status of its own
+//! means, `opencode/error.rs` a family of its own, and a second divergence
+//! would land beside either rather than widening it.
 //!
 //! There is deliberately no `openai/`. OpenAI's spellings ARE the
 //! `openai_compat` baseline, so an empty impl for symmetry would be a
@@ -22,6 +22,7 @@
 //! does this spelling mean", never "where do I find it".
 
 mod deepseek;
+mod opencode;
 
 use std::collections::HashMap;
 use std::sync::LazyLock;
@@ -40,10 +41,16 @@ use crate::gateway::error::{ErrorMapper, MatchesProtocol};
 /// [`registry`](crate::registry) uses for the roster itself: built once on
 /// first use, read-only forever after.
 static OVERRIDES: LazyLock<HashMap<&'static str, &'static dyn ErrorMapper>> = LazyLock::new(|| {
-    HashMap::from([(
-        "deepseek",
-        &deepseek::error::DeepSeek as &'static dyn ErrorMapper,
-    )])
+    HashMap::from([
+        (
+            "deepseek",
+            &deepseek::error::DeepSeek as &'static dyn ErrorMapper,
+        ),
+        (
+            "opencode",
+            &opencode::error::OpenCode as &'static dyn ErrorMapper,
+        ),
+    ])
 });
 
 /// The provider's own error mapping, or [`MatchesProtocol`] if it has none.
@@ -81,7 +88,11 @@ mod tests {
     fn an_unlisted_provider_gets_nothing_of_its_own() {
         let mapper = error_mapper("openai");
         assert!(mapper.from_code("insufficient_quota").is_none());
-        assert!(mapper.from_status(402).is_none());
-        assert!(mapper.from_type("api_error").is_none());
+        assert!(mapper.from_status_and_type(402, None).is_none());
+        assert!(
+            mapper
+                .from_status_and_type(500, Some("api_error"))
+                .is_none()
+        );
     }
 }

--- a/crates/warpllm/src/gateway/openai_compat/provider_overrides/opencode/error.rs
+++ b/crates/warpllm/src/gateway/openai_compat/provider_overrides/opencode/error.rs
@@ -1,0 +1,170 @@
+//! OpenCode Zen's error mapping, where it differs from `openai_compat`.
+//!
+//! Zen wraps an OpenAI-shaped envelope around a vocabulary of its own: the
+//! body is `{"type":"error","error":{"type":…,"message":…}}` with **no
+//! `code`** anywhere, and the `type` is `PascalCase`-suffixed-`Error` rather
+//! than any spelling the baseline knows. Envelopes below are live responses,
+//! with the workspace id redacted (checked 2026-08-17).
+
+use crate::error::Error;
+use crate::gateway::error::{Classified, ErrorMapper};
+
+pub(crate) struct OpenCode;
+
+impl ErrorMapper for OpenCode {
+    /// `CreditsError` is an unpaid account, not a bad key — and Zen reports it
+    /// at **HTTP 401**:
+    ///
+    /// ```json
+    /// {"type":"error","error":{"type":"CreditsError","message":"No payment method. Add a payment method here: https://opencode.ai/workspace/wrk_…/billing"}}
+    /// ```
+    ///
+    /// That status is the whole difficulty. The baseline reads 401 as
+    /// [`Error::Authentication`] and is RIGHT to — Zen answers a genuinely bad
+    /// key with the same status and its own family for it:
+    ///
+    /// ```json
+    /// {"type":"error","error":{"type":"AuthError","message":"Invalid API key."}}
+    /// ```
+    ///
+    /// So a status rule here would be wrong in the other direction, telling
+    /// somebody with an expired key to go add a payment method. The family is
+    /// what separates them, and it is read ALONE rather than as a `(401,
+    /// "CreditsError")` pair: `CreditsError` names one failure and one remedy
+    /// wherever it appears, so pinning it to a status would only mean Zen
+    /// moving it to a 402 tomorrow — the status this failure ought to have —
+    /// silently restored the misclassification this rule exists to fix.
+    ///
+    /// Nothing else Zen sends is claimed. `AuthError` at 401 and
+    /// `FreeUsageLimitError` at 429 are already what the baseline says they
+    /// are, and restating them here would be a second copy to keep in sync;
+    /// `the_live_error_vocabulary_resolves_end_to_end` pins both against the
+    /// real classifier instead.
+    fn from_status_and_type(&self, _status: u16, error_type: Option<&str>) -> Option<Classified> {
+        (error_type == Some("CreditsError")).then_some(Error::QuotaExceeded as Classified)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gateway::openai_compat::error::error_from_body;
+
+    fn zen(error_type: &str, message: &str) -> String {
+        serde_json::json!({
+            "type": "error",
+            "error": {"type": error_type, "message": message},
+        })
+        .to_string()
+    }
+
+    fn coded(status: u16, error_type: &str) -> &'static str {
+        error_from_body("opencode", status, &zen(error_type, "m"), None, None).code()
+    }
+
+    /// Zen's whole live vocabulary, RESOLVED — what a caller actually
+    /// observes, rather than what this file alone answers.
+    ///
+    /// Two of the three are `None` above and still classify correctly, which
+    /// is the inheritance working. They are here because they are the same
+    /// "typed vocabulary the baseline cannot see" shape as the one that broke,
+    /// and a future change to `classify`'s ordering would otherwise be free to
+    /// move them without anything failing.
+    #[test]
+    fn the_live_error_vocabulary_resolves_end_to_end() {
+        // The delta: a 401 that is not an authentication failure.
+        assert_eq!(coded(401, "CreditsError"), "quota_exceeded");
+        // ...and a 401 that is, which the baseline already reads correctly.
+        assert_eq!(coded(401, "AuthError"), "authentication");
+        // The per-model free-tier limit. A real 429, and worth waiting out —
+        // unlike the credit exhaustion above, which never is.
+        assert_eq!(coded(429, "FreeUsageLimitError"), "rate_limited");
+    }
+
+    /// THE bug (#66), stated as the two envelopes that made it hard: one
+    /// status, two failures, opposite remedies. Neither signal decides alone,
+    /// so a rule written on either one would misclassify the other.
+    #[test]
+    fn one_401_separates_into_billing_and_credentials() {
+        assert_ne!(
+            coded(401, "CreditsError"),
+            coded(401, "AuthError"),
+            "an unpaid account and a bad key classified the same, and the \
+             caller is sent after the wrong fix for one of them"
+        );
+    }
+
+    /// The delta and NOTHING else. Every other spelling is the protocol's to
+    /// answer, including the two pinned above.
+    #[test]
+    fn nothing_but_the_credits_family_is_claimed() {
+        for error_type in ["AuthError", "FreeUsageLimitError", "ModelError"] {
+            assert!(
+                OpenCode
+                    .from_status_and_type(401, Some(error_type))
+                    .is_none(),
+                "{error_type}"
+            );
+        }
+        for status in [400, 401, 403, 404, 429, 500, 503] {
+            assert!(
+                OpenCode.from_status_and_type(status, None).is_none(),
+                "{status}"
+            );
+        }
+        for code in [
+            "insufficient_quota",
+            "invalid_api_key",
+            "rate_limit_exceeded",
+        ] {
+            assert!(OpenCode.from_code(code).is_none(), "{code}");
+        }
+    }
+
+    /// A `code` still outranks this — the tier split `classify` keeps. Zen
+    /// sends none today, but a proxy in front of it that adds one is naming
+    /// the failure outright, which beats any reading of the envelope around
+    /// it.
+    #[test]
+    fn a_code_still_outranks_the_credits_family() {
+        let body = r#"{"error":{"type":"CreditsError","message":"m","code":"invalid_api_key"}}"#;
+        assert_eq!(
+            error_from_body("opencode", 401, body, None, None).code(),
+            "authentication"
+        );
+    }
+
+    /// The rule is Zen's alone. Without this, a bug that applied it to every
+    /// provider would pass every test above.
+    #[test]
+    fn no_other_provider_reads_a_credits_family() {
+        let body = zen("CreditsError", "no payment method");
+        assert_eq!(
+            error_from_body("openai", 401, &body, None, None).code(),
+            "authentication"
+        );
+        assert_eq!(
+            error_from_body("deepseek", 401, &body, None, None).code(),
+            "authentication"
+        );
+    }
+
+    /// Classifying must never consume what Zen actually said — the variant is
+    /// what it MEANS, and the family and message are the evidence for it.
+    /// `CreditsError`'s message carries the billing URL, which is the one
+    /// thing that fixes the failure.
+    #[test]
+    fn the_billing_message_survives_the_classification() {
+        let body = zen(
+            "CreditsError",
+            "No payment method. Add a payment method here: \
+             https://opencode.ai/workspace/wrk_redacted/billing",
+        );
+        let error = error_from_body("opencode", 401, &body, None, None);
+        assert!(matches!(error, Error::QuotaExceeded(_)));
+        let detail = error.provider_error().expect("a provider failure");
+        assert_eq!(detail.error_type.as_deref(), Some("CreditsError"));
+        assert_eq!(detail.provider_code, None);
+        assert!(detail.message.contains("/billing"), "{}", detail.message);
+    }
+}

--- a/crates/warpllm/src/gateway/openai_compat/provider_overrides/opencode/mod.rs
+++ b/crates/warpllm/src/gateway/openai_compat/provider_overrides/opencode/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod error;

--- a/crates/warpllm/tests/providers.rs
+++ b/crates/warpllm/tests/providers.rs
@@ -13,6 +13,9 @@ mod deepseek_chat_completions;
 #[path = "providers/deepseek/config_env.rs"]
 mod deepseek_config_env;
 
+#[path = "providers/opencode/chat_completions/mod.rs"]
+mod opencode_chat_completions;
+
 #[path = "providers/opencode/config_env.rs"]
 mod opencode_config_env;
 

--- a/crates/warpllm/tests/providers/openai/common.rs
+++ b/crates/warpllm/tests/providers/openai/common.rs
@@ -12,6 +12,7 @@ use wiremock::MockServer;
 pub const OPENAI_KEY: &str = "sk-test-openai";
 pub const DEEPSEEK_KEY: &str = "sk-test-deepseek";
 pub const OPENROUTER_KEY: &str = "sk-test-openrouter";
+pub const OPENCODE_KEY: &str = "sk-test-opencode";
 
 /// Client with the base URL pointed at the mock server. It carries no key —
 /// the client reads the environment as it is BUILT, resolving every provider
@@ -57,6 +58,10 @@ pub fn with_deepseek_key<F: Future<Output = ()>>(body: F) {
 
 pub fn with_openrouter_key<F: Future<Output = ()>>(body: F) {
     with_env_key("OPENROUTER_API_KEY", OPENROUTER_KEY, body);
+}
+
+pub fn with_opencode_key<F: Future<Output = ()>>(body: F) {
+    with_env_key("OPENCODE_API_KEY", OPENCODE_KEY, body);
 }
 
 pub fn request(model: &str) -> CreateChatCompletionRequest {

--- a/crates/warpllm/tests/providers/opencode/chat_completions/mod.rs
+++ b/crates/warpllm/tests/providers/opencode/chat_completions/mod.rs
@@ -1,0 +1,113 @@
+use crate::openai_common::{client_for, request, with_opencode_key};
+use serde_json::json;
+use warpllm::Error;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Zen's error envelope, as the live API sends it: an OpenAI-shaped wrapper
+/// around a vocabulary of Zen's own, and no `code` anywhere.
+fn zen_error(error_type: &str, message: &str) -> serde_json::Value {
+    json!({"type": "error", "error": {"type": error_type, "message": message}})
+}
+
+/// Issue #66, at the level it was reported: an account with no payment method
+/// is a billing failure, not a bad key.
+///
+/// The unit tests beside the mapper prove the vocabulary; this proves the
+/// whole path a caller actually takes reaches it — routing under the
+/// `opencode` name, the override table, and the classifier's ordering, none of
+/// which the mapper's own tests exercise together.
+///
+/// Both envelopes arrive at **HTTP 401**, which is the entire difficulty: the
+/// status is identical and only the family separates a bill from a
+/// credential. Asserted in one test for that reason — they are one claim.
+#[test]
+fn one_401_separates_a_bill_from_a_bad_key() {
+    with_opencode_key(async {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(zen_error(
+                "CreditsError",
+                "No payment method. Add a payment method here: \
+                 https://opencode.ai/workspace/wrk_redacted/billing",
+            )))
+            .mount(&server)
+            .await;
+
+        let err = client_for(&server)
+            .chat_completions(request("opencode/kimi-k3"))
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, Error::QuotaExceeded(_)),
+            "an unpaid account was reported as {err:?}, sending the caller \
+             after an API key that is fine"
+        );
+        let upstream = err.provider_error().expect("a provider failure");
+        assert_eq!(upstream.provider, "opencode");
+        assert_eq!(upstream.status, 401);
+        // The remedy travels with the failure — it is the only thing that
+        // fixes this one, and Zen puts it in the message.
+        assert!(
+            upstream.message.contains("/billing"),
+            "{}",
+            upstream.message
+        );
+    });
+
+    with_opencode_key(async {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(401)
+                    .set_body_json(zen_error("AuthError", "Invalid API key.")),
+            )
+            .mount(&server)
+            .await;
+
+        let err = client_for(&server)
+            .chat_completions(request("opencode/kimi-k3"))
+            .await
+            .unwrap_err();
+
+        // The other half of the claim. A rule reading the 401 alone would get
+        // one of these two wrong whichever way it was written.
+        assert!(matches!(err, Error::Authentication(_)), "{err:?}");
+    });
+}
+
+/// Zen's per-model free-tier limit, which is a real rate limit and worth
+/// waiting out — unlike the credit exhaustion above, which never is.
+///
+/// Already correct through the protocol baseline's reading of 429, and pinned
+/// here because it is the same "typed vocabulary the baseline cannot see"
+/// shape: a later change to how families and statuses are ranked must not move
+/// it silently.
+#[test]
+fn a_free_tier_limit_is_a_rate_limit() {
+    with_opencode_key(async {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(429).set_body_json(zen_error(
+                "FreeUsageLimitError",
+                "Free usage limit reached for this model.",
+            )))
+            .mount(&server)
+            .await;
+
+        let err = client_for(&server)
+            .chat_completions(request("opencode/kimi-k3"))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, Error::RateLimited(_)), "{err:?}");
+        assert_eq!(
+            err.provider_error().expect("a provider failure").error_type,
+            Some("FreeUsageLimitError".to_string())
+        );
+    });
+}


### PR DESCRIPTION
Fixes #66.

An OpenCode Zen account with no payment method got `Error::Authentication` for every request, sending the caller after an API key that was fine. It is `Error::QuotaExceeded` now — HTTP 429 `insufficient_quota` on the OpenAI-compatible surface rather than 401 `invalid_api_key`.

## Why no provider override could fix it

Zen reports credit exhaustion at **HTTP 401**, with a family of its own and no `code` anywhere:

```json
{"type":"error","error":{"type":"CreditsError","message":"No payment method. Add a payment method here: …/billing"}}
```

The status cannot decide this alone, because Zen answers a genuinely bad key with that *same* 401 and a different family:

```json
{"type":"error","error":{"type":"AuthError","message":"Invalid API key."}}
```

So a rule reading 401 is wrong in one direction or the other whichever way it goes, and only the two signals together separate them.

`ErrorMapper` could not express that. It split the envelope across `from_status` and `from_type`, and `classify` ranked *every* status above *every* type — so `OpenAiCompat::from_status(401)` answered first and a provider rule written on a family was never reached. An `opencode` entry would have compiled, registered, passed `every_override_names_a_provider_the_roster_has`, and never fired.

## What changed

The two hooks become one, `from_status_and_type`. `classify` drops from six lookups to four:

```
provider.from_code → protocol.from_code
→ provider.from_status_and_type → protocol.from_status_and_type
→ HTTP residual
```

The fix falls out of the simplification: a provider reading its own family now outranks the protocol reading a status, because that is just the provider tier winning.

The split that remains is the one `classify` can enforce without knowing any vocabulary — a `code` is the upstream naming its own failure, and no reading of the envelope around it should outrank that. Ranking a status against a type needs the spellings, so it moved into each mapper, where it is the arm order of one `match`. `openai_compat` and `anthropic` both still read the status first and say why; `opencode` takes the opposite order and says why.

The OpenCode mapper claims one thing: `CreditsError` → `QuotaExceeded`, read on the family **alone** rather than as a `(401, "CreditsError")` pair — pinning it to a status would mean Zen moving it to the 402 it ought to have silently restores this bug. `AuthError` and `FreeUsageLimitError` are not restated, since the baseline already reads both correctly and an override is not a place to copy the protocol; both are pinned end-to-end so a later reordering cannot move them quietly.

## Verification

- `cargo test --workspace`: **476 passed, 1 ignored** (the pre-existing live-key test in `live_stream.rs`). Clippy and fmt clean.
- **The tests fail without the fix.** Dropping the `opencode` entry from `OVERRIDES` reproduces the issue verbatim — `Authentication(ProviderError { status: 401, error_type: Some("CreditsError"), … })`. Inverting provider/protocol at the merged tier fails the same way, confirming the fix depends precisely on the ordering the old split denied.
- **No other provider reclassifies.** `deepseek` was the only override and mapped only a status; `anthropic` passes `MatchesProtocol`; `mistral` is a roster-only entry with no override. Nothing on the roster maps a type of its own.
- `ErrorMapper` is `pub(crate)`, so no package's API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)