### PR TITLE
Route a chat-completions request to Claude and back

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ node_modules/
 
 # macOS
 .DS_Store
+
+# Tempest
+.tempest
+.tempest-pid

--- a/crates/warpllm/src/auth/mod.rs
+++ b/crates/warpllm/src/auth/mod.rs
@@ -91,13 +91,10 @@ impl Authenticator {
     /// `x-api-key: <secret>` — Anthropic's spelling, which deliberately does
     /// NOT also set `Authorization`.
     ///
-    /// Reads as dead outside tests, and is: nothing routes to Anthropic yet, so
-    /// [`crate::credentials`] never picks this scheme and the whole
-    /// `gateway::anthropic` tree that would reach it is staged behind the same
-    /// attribute. Both allows come off on the change that adds the roster entry
-    /// and the surface — the same change that drops the one at
-    /// `gateway/mod.rs`.
-    #[allow(dead_code)]
+    /// Picked by [`crate::credentials::Credentials::scheme`] for the
+    /// `anthropic` provider, and by nothing else: the scheme is a fact about a
+    /// provider rather than about the protocol it speaks, so a host re-hosting
+    /// Claude behind a bearer header still gets bearer.
     pub(crate) fn anthropic_api_key(secret: String) -> Self {
         Self::Header(Header::anthropic_api_key(secret))
     }

--- a/crates/warpllm/src/client.rs
+++ b/crates/warpllm/src/client.rs
@@ -4,16 +4,18 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use serde_json::Value;
+
 use crate::auth::Authenticator;
 use crate::config::{ClientConfig, DEFAULT_TIMEOUT_SECS};
 use crate::credentials::Credentials;
 use crate::error::{Error, Result};
-use crate::gateway::openai_compat;
+use crate::gateway::{anthropic, openai_compat};
 use crate::protocol::openai_compat::chat_completions::types::{
     CreateChatCompletionRequest, CreateChatCompletionResponse, CreateChatCompletionStreamResponse,
 };
 use crate::registry::{self, ModelSpec, ProviderSpec, Registry};
-use crate::types::Api;
+use crate::types::{Api, Protocol};
 
 /// Where a roster file is named when [`ClientConfig::specs_path`] does not name
 /// one. The last resort before the shipped roster alone.
@@ -35,10 +37,11 @@ pub struct Client {
 }
 
 /// Everything one validated request needs to reach its model: where to send it,
-/// what the model is called upstream, and what to authenticate with.
+/// what the model is called upstream, what to authenticate with, and which
+/// protocol to speak on the way out.
 ///
-/// A struct rather than a tuple, because both call sites read all three by
-/// name and a fourth would otherwise renumber them.
+/// A struct rather than a tuple, because both call sites read all four by
+/// name and a fifth would otherwise renumber them.
 struct ModelDefinition<'a> {
     provider: &'a ProviderSpec,
     model: &'a ModelSpec,
@@ -46,6 +49,100 @@ struct ModelDefinition<'a> {
     /// so the request goes out with no `Authorization` header rather than with
     /// an empty one.
     auth: Option<&'a Authenticator>,
+    egress: Egress,
+}
+
+/// Which protocol a routed request is spoken in UPSTREAM.
+///
+/// Not the protocol warpllm was called in — that is fixed by the entrypoint,
+/// and for both entrypoints here it is openai_compat by signature. This is the
+/// other half, and it is a property of the routed MODEL:
+/// `anthropic/claude-opus-5` serves `anthropic_messages` and nothing else, so a
+/// chat-completions request for it is translated on the way out and its reply
+/// on the way back.
+///
+/// A two-variant enum rather than dispatching on [`Api`] at the call site.
+/// `Api` has five variants and only two can reach either entrypoint, so a match
+/// on it would carry arms for cases the validation just ruled out — and the
+/// admission list already knows which module serves which surface. Pairing the
+/// two in [`Client::WHOLE_REPLY`] and [`Client::STREAMED`] makes those arms
+/// unrepresentable rather than unreachable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Egress {
+    OpenAiCompat,
+    Anthropic,
+}
+
+/// Refuses a request whose meaning the routed protocol has no way to carry.
+///
+/// SILENCE is the failure this exists to prevent. warpllm's contract everywhere
+/// else is passthrough — forward what the caller wrote, let the provider judge
+/// it — and that contract quietly loses its second half on a translated route:
+/// a field the provider never receives is a field the provider cannot reject.
+/// `n: 2` would come back as one choice, indistinguishable from a model that
+/// ignored the request.
+///
+/// It sits at DISPATCH rather than in the Anthropic renderer because of where
+/// the value lives. `n` rides `ext["openai_compat"]`, and
+/// [`Protocol::may_read`] forbids that renderer from ever seeing it — by
+/// design, since another protocol's bag is exactly what a renderer must not
+/// read. Dispatch is the one layer above both.
+///
+/// Only what CHANGES the answer is refused, and only when it cannot be
+/// translated. `top_k` and `parallel_tool_calls` have equivalents on the far
+/// side and are promoted at ingest and rendered, not refused.
+fn reject_untranslatable(request: &crate::gateway::types::ChatRequest) -> Result<()> {
+    let Some(bag) = request.ext.get(Protocol::OpenAiCompat.as_str()) else {
+        return Ok(());
+    };
+    for (field, means_it) in UNTRANSLATABLE {
+        if bag.get(field).is_some_and(means_it) {
+            return Err(Error::InvalidInput(format!(
+                "`{field}` has no equivalent on Anthropic's Messages API, which is what \
+                 serves this model; warpllm refuses it rather than answering as though \
+                 it were never written"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// The fields chat completions can state, Anthropic cannot, and that change the
+/// answer or its shape — each paired with the test for whether the caller
+/// actually MEANT it.
+///
+/// The predicate is what keeps the list from being blunt. Every one of these
+/// has a value meaning "no opinion" — zero penalties, `logprobs: false`, an
+/// empty bias map, one choice — and those are exactly what an SDK fills in by
+/// default. Rejecting on the KEY would turn away requests that ask for nothing,
+/// which is most of them.
+///
+/// A DENY list and not an allow list, deliberately. An allow list would also
+/// refuse every harmless field a caller or a future SDK sends (`user`, `store`,
+/// a provider's own extension), and warpllm's whole contract is that those ride
+/// through untouched. The cost is that this list has to be maintained: a field
+/// nobody adds here is still dropped in silence, which is the same failure this
+/// function exists to end.
+type MeansIt = fn(&Value) -> bool;
+const UNTRANSLATABLE: &[(&str, MeansIt)] = &[
+    ("n", |value| value.as_u64().is_some_and(|n| n > 1)),
+    ("frequency_penalty", nonzero),
+    ("presence_penalty", nonzero),
+    ("logprobs", |value| value == &Value::Bool(true)),
+    ("top_logprobs", |value| {
+        value.as_u64().is_some_and(|count| count > 0)
+    }),
+    ("logit_bias", |value| {
+        value.as_object().is_some_and(|bias| !bias.is_empty())
+    }),
+    // Unlike the rest, ANY value means it: `seed` exists only to ask for
+    // reproducibility, and a caller who believes they have it and does not is
+    // worse off than one told plainly that they cannot.
+    ("seed", Value::is_number),
+];
+
+fn nonzero(value: &Value) -> bool {
+    value.as_f64().is_some_and(|penalty| penalty != 0.0)
 }
 
 impl Client {
@@ -191,11 +288,39 @@ impl Client {
         Ok(())
     }
 
+    /// The surfaces a whole-reply request may be served by, each with the
+    /// protocol that serves it.
+    ///
+    /// Order is preference, and it only matters for a model that lists both —
+    /// nothing on the roster does, and a model that did would be one host
+    /// offering the same completion two ways. Chat completions first, because
+    /// it is the protocol the caller is already speaking and needs no
+    /// translation.
+    const WHOLE_REPLY: &'static [(Api, Egress)] = &[
+        (Api::OpenAiCompatChatCompletions, Egress::OpenAiCompat),
+        (Api::AnthropicMessages, Egress::Anthropic),
+    ];
+
+    /// The streamed counterpart of [`Client::WHOLE_REPLY`]. A separate list
+    /// rather than derived from it, because streaming is its own roster entry:
+    /// a model serving whole replies says nothing about whether it serves
+    /// streamed ones, and that is true per protocol.
+    const STREAMED: &'static [(Api, Egress)] = &[
+        (Api::OpenAiCompatChatCompletionsStream, Egress::OpenAiCompat),
+        (Api::AnthropicMessagesStream, Egress::Anthropic),
+    ];
+
     /// Serves one OpenAI-compatible chat completion.
     ///
     /// Validation is [`Client::validate`]'s, which is where the order of the
     /// checks and the reason for it are written down. This entrypoint differs
-    /// from the streaming one only in the surface it asks about.
+    /// from the streaming one only in the surfaces it admits.
+    ///
+    /// The request shape is OpenAI's whichever provider serves it. A model that
+    /// serves Anthropic's `/messages` and nothing else is reached by
+    /// translating on the way out and back, and the caller sees a
+    /// chat-completions reply either way — that is the whole point of the
+    /// gateway form in between.
     pub async fn chat_completions(
         &self,
         request: CreateChatCompletionRequest,
@@ -213,7 +338,8 @@ impl Client {
             provider,
             model,
             auth,
-        } = self.validate(&requested_model, Api::OpenAiCompatChatCompletions)?;
+            egress,
+        } = self.validate(&requested_model, Self::WHOLE_REPLY)?;
 
         // Ingest answers to the protocol warpllm was CALLED with, which is
         // openai_compat and only ever will be for this entrypoint. The ENTRY's
@@ -221,18 +347,38 @@ impl Client {
         // warpllm's routing alias differs from the provider's own name.
         let normalized =
             openai_compat::api::chat_completions::ingest_request(request, model.model());
-        // No dispatch to do: the surface above names its own protocol, so
-        // asking for `openai_compat_chat_completions` IS the choice of module.
-        // A second protocol arrives as a second entrypoint, not as an arm here
-        // — this one takes an OpenAI-shaped request by signature.
-        let response = openai_compat::api::chat_completions::exchange(
-            &normalized,
-            &self.http,
-            provider.name(),
-            self.base_url(provider),
-            auth,
-        )
-        .await?;
+        // Ingress by entrypoint, EGRESS by the routed model's surface. Both
+        // arms take and return gateway types, which is what keeps this a
+        // two-line choice rather than two request paths.
+        let response = match egress {
+            Egress::OpenAiCompat => {
+                openai_compat::api::chat_completions::exchange(
+                    &normalized,
+                    &self.http,
+                    provider.name(),
+                    self.base_url(provider),
+                    auth,
+                )
+                .await?
+            }
+            Egress::Anthropic => {
+                reject_untranslatable(&normalized)?;
+                anthropic::api::messages::exchange(
+                    &normalized,
+                    &self.http,
+                    provider.name(),
+                    self.base_url(provider),
+                    auth,
+                    // Anthropic REQUIRES a `max_tokens` and the gateway form's
+                    // is optional, so the roster's ceiling is the fallback. A
+                    // model documenting none and a caller naming none is a
+                    // refusal, not an invented default — see
+                    // `anthropic::…::request::resolve_max_tokens`.
+                    model.capabilities().max_output_tokens(),
+                )
+                .await?
+            }
+        };
         let mut completion =
             openai_compat::api::chat_completions::render_response(&response, provider.name());
         // Echo the caller's provider-prefixed string, not the upstream echo.
@@ -242,8 +388,8 @@ impl Client {
 
     /// Serves one OpenAI-compatible chat completion as a stream of chunks.
     ///
-    /// The same validation as [`Client::chat_completions`], against a DIFFERENT
-    /// surface: streaming is its own entry in the roster, so a model that
+    /// The same validation as [`Client::chat_completions`], against DIFFERENT
+    /// surfaces: streaming is its own entry in the roster, so a model that
     /// serves whole replies says nothing about whether it serves streamed ones.
     ///
     /// `stream` is set on the caller's behalf rather than required: the method
@@ -262,24 +408,48 @@ impl Client {
             provider,
             model,
             auth,
-        } = self.validate(&requested_model, Api::OpenAiCompatChatCompletionsStream)?;
+            egress,
+        } = self.validate(&requested_model, Self::STREAMED)?;
 
         let normalized =
             openai_compat::api::chat_completions::ingest_request(request, model.model());
+        let read_timeout = self
+            .config
+            .stream_read_timeout_secs
+            .map(Duration::from_secs);
+        let chunks = match egress {
+            Egress::OpenAiCompat => Chunks::OpenAiCompat(Box::new(
+                openai_compat::api::chat_completions::exchange_stream(
+                    &normalized,
+                    &self.http,
+                    provider.name(),
+                    self.base_url(provider),
+                    auth,
+                    read_timeout,
+                )
+                .await?,
+            )),
+            Egress::Anthropic => {
+                reject_untranslatable(&normalized)?;
+                Chunks::Anthropic(Box::new(
+                    anthropic::api::messages::exchange_stream(
+                        &normalized,
+                        &self.http,
+                        provider.name(),
+                        self.base_url(provider),
+                        auth,
+                        model.capabilities().max_output_tokens(),
+                        read_timeout,
+                    )
+                    .await?,
+                ))
+            }
+        };
         Ok(ChatCompletionStream {
-            chunks: openai_compat::api::chat_completions::exchange_stream(
-                &normalized,
-                &self.http,
-                provider.name(),
-                self.base_url(provider),
-                auth,
-                self.config
-                    .stream_read_timeout_secs
-                    .map(Duration::from_secs),
-            )
-            .await?,
+            chunks,
             provider: provider.name(),
             model: requested_model,
+            ordinals: openai_compat::api::chat_completions::ToolCallOrdinals::default(),
         })
     }
 
@@ -304,14 +474,15 @@ impl Client {
     /// One helper rather than the sequence written twice, because the two
     /// entrypoints differ in exactly one argument — and a fifth gate added to
     /// one copy and not the other is a hole nothing would catch.
-    fn validate(&self, requested: &str, api: Api) -> Result<ModelDefinition<'_>> {
+    fn validate(&self, requested: &str, admitted: &[(Api, Egress)]) -> Result<ModelDefinition<'_>> {
         let (provider, model) = self.fetch_model(requested)?;
         self.validate_declared(provider, requested)?;
-        Self::validate_api(model, api, provider, requested)?;
+        let egress = Self::validate_api(model, admitted, provider, requested)?;
         Ok(ModelDefinition {
             provider,
             model,
             auth: self.authenticator(provider)?,
+            egress,
         })
     }
 
@@ -385,27 +556,42 @@ impl Client {
     /// reuses this rather than copying it — and so the refusal cannot claim
     /// the wrong surface, which a hard-coded message eventually would.
     ///
-    /// `model` and `api` are the check; `provider` and `requested` only build
-    /// the message. Split out from [`Client::chat_completions`] so the refusal
-    /// can be tested at all: every model the roster ships today serves chat
-    /// completions, so the failing branch is otherwise unreachable from the
-    /// public entrypoint until one lands that does not.
+    /// `model` and `admitted` are the check; `provider` and `requested` only
+    /// build the message. Split out from [`Client::chat_completions`] so the
+    /// refusal can be tested at all: every model the roster ships today serves
+    /// one of the admitted surfaces, so the failing branch is otherwise
+    /// unreachable from the public entrypoint.
+    ///
+    /// Takes a LIST and returns what matched, which is the whole of the
+    /// dispatch decision: an entrypoint that serves two protocols has to say
+    /// which surfaces it will take, and then the answer to "which one did"
+    /// exists in exactly one place. Returning [`Egress`] rather than the [`Api`]
+    /// is what keeps the caller's match down to the protocols that can actually
+    /// have matched.
+    ///
+    /// The refusal names EVERY surface tried, in the roster's own spelling. A
+    /// model serving only `openai_compat_responses` is refused by both
+    /// entrypoints, and hearing about only one of them would send someone
+    /// looking for a roster line that is already right.
     fn validate_api(
         model: &ModelSpec,
-        api: Api,
+        admitted: &[(Api, Egress)],
         provider: &ProviderSpec,
         requested: &str,
-    ) -> Result<()> {
-        if model.supports_api(api) {
-            return Ok(());
+    ) -> Result<Egress> {
+        for &(api, egress) in admitted {
+            if model.supports_api(api) {
+                return Ok(egress);
+            }
         }
-        // The roster's own spelling for the surface, and the provider because
+        // The roster's own spelling for each surface, and the provider because
         // the roster is where what-is-served is recorded — between them they
         // name the line a reader would go and fix.
+        let tried: Vec<&str> = admitted.iter().map(|(api, _)| api.as_str()).collect();
         Err(Error::InvalidInput(format!(
-            "{}: {requested} does not serve {}",
+            "{}: {requested} serves none of {}",
             provider.name(),
-            api.as_str()
+            tried.join(", ")
         )))
     }
 
@@ -446,12 +632,36 @@ impl Client {
 /// that wrap this iterate it the same way.
 #[derive(Debug)]
 pub struct ChatCompletionStream {
-    chunks: openai_compat::api::chat_completions::ChatChunkStream,
+    chunks: Chunks,
     provider: &'static str,
     /// The caller's provider-prefixed string, echoed onto every chunk in place
     /// of the upstream's own — the streaming counterpart of the one
     /// [`Client::chat_completions`] performs on a whole reply.
     model: String,
+    /// A stream's tool-call numbering, which only a scope that outlives a chunk
+    /// can hold. See
+    /// [`ToolCallOrdinals`](openai_compat::api::chat_completions::ToolCallOrdinals)
+    /// for what it is correcting and why it is an identity on a same-protocol
+    /// stream.
+    ordinals: openai_compat::api::chat_completions::ToolCallOrdinals,
+}
+
+/// The protocol-specific half of an open stream.
+///
+/// The enum is here rather than behind a trait for the reason the crate gives
+/// everywhere else it makes this choice: the set of protocols warpllm speaks
+/// grows an issue at a time, and a closed match is what makes the next one fail
+/// to compile until every site handles it.
+///
+/// BOTH arms are boxed, not just the larger one. They are 248 and 464 bytes, so
+/// an unboxed enum is the size of its biggest member and every stream pays for
+/// the widest protocol; boxing only the larger one just inverts which arm clippy
+/// names. One allocation per STREAM, which lives for as many chunks as the reply
+/// has, against copying a half-kilobyte enum on every move.
+#[derive(Debug)]
+enum Chunks {
+    OpenAiCompat(Box<openai_compat::api::chat_completions::ChatChunkStream>),
+    Anthropic(Box<anthropic::api::messages::ChatChunkStream>),
 }
 
 impl ChatCompletionStream {
@@ -465,10 +675,19 @@ impl ChatCompletionStream {
     /// An error item is terminal: whatever produced it also ended the stream,
     /// so the next call returns `None`.
     pub async fn next(&mut self) -> Option<Result<CreateChatCompletionStreamResponse>> {
-        let chunk = self.chunks.next().await?;
+        // Gateway chunks in, whichever protocol produced them; ONE renderer
+        // out, because the caller asked in chat completions and gets chat
+        // completions back.
+        let chunk = match &mut self.chunks {
+            Chunks::OpenAiCompat(chunks) => chunks.next().await?,
+            Chunks::Anthropic(chunks) => chunks.next().await?,
+        };
         Some(chunk.map(|chunk| {
-            let mut rendered =
-                openai_compat::api::chat_completions::render_chunk(&chunk, self.provider);
+            let mut rendered = openai_compat::api::chat_completions::render_chunk(
+                &chunk,
+                self.provider,
+                &mut self.ordinals,
+            );
             rendered.model = self.model.clone();
             rendered
         }))
@@ -523,28 +742,35 @@ mod tests {
         }
     }
 
+    /// A provider standing in for any host, so the surface tests below read as
+    /// being about surfaces.
+    fn demo_host() -> ProviderSpec {
+        demo_provider("https://api.demo.test", Credential::EnvVar("DEMO_API_KEY"))
+    }
+
     /// The gate the whole model-level `supported_apis` split exists for. This
     /// model sits under a perfectly ordinary chat-serving provider and does
     /// not serve chat itself, which only the model's own list can say.
     #[test]
-    fn a_model_that_does_not_serve_the_api_is_refused() {
+    fn a_model_that_serves_none_of_the_admitted_surfaces_is_refused() {
         let err = Client::validate_api(
             &demo_model(vec![SupportedApi {
                 api: Api::OpenAiCompatResponses,
             }]),
-            Api::OpenAiCompatChatCompletions,
-            &demo_provider("https://api.demo.test", Credential::EnvVar("DEMO_API_KEY")),
+            Client::WHOLE_REPLY,
+            &demo_host(),
             "demo/embed",
         )
         .unwrap_err();
         let message = err.to_string();
         assert!(message.contains("demo/embed"), "{message}");
-        // The roster's spelling, not the variant's — this is the string a
-        // reader greps `specs.yaml` for.
-        assert!(
-            message.contains("does not serve openai_compat_chat_completions"),
-            "{message}"
-        );
+        // EVERY surface tried, in the roster's spelling rather than the
+        // variant's — these are the strings a reader greps `specs.yaml` for,
+        // and hearing about only one of two would send them after a line that
+        // is already right.
+        for tried in ["openai_compat_chat_completions", "anthropic_messages"] {
+            assert!(message.contains(tried), "missing `{tried}`: {message}");
+        }
 
         // A 400: the caller asked for something this model cannot do, which is
         // theirs to fix, not the provider's to fail.
@@ -552,73 +778,113 @@ mod tests {
         assert_eq!(wire["status"], 400);
     }
 
-    /// The other side of the same gate: a model that does serve the surface
-    /// passes, so the check cannot be one that refuses everything. Listing a
-    /// second surface alongside it changes nothing — each is its own claim.
+    /// The other side of the same gate, and the dispatch decision itself: which
+    /// surface a model serves is what picks the protocol it is reached over.
+    ///
+    /// Both directions in one test, because the risk is not that either answer
+    /// is wrong on its own — it is that the match returns a constant. A version
+    /// that always answered `OpenAiCompat` passes the first assertion and fails
+    /// the second.
     #[test]
-    fn a_model_that_serves_the_api_is_admitted() {
-        Client::validate_api(
-            &demo_model(vec![
-                SupportedApi {
-                    api: Api::OpenAiCompatChatCompletions,
-                },
-                SupportedApi {
-                    api: Api::OpenAiCompatResponses,
-                },
-            ]),
-            Api::OpenAiCompatChatCompletions,
-            &demo_provider("https://api.demo.test", Credential::EnvVar("DEMO_API_KEY")),
-            "demo/chat",
-        )
-        .unwrap();
-    }
-
-    /// The point of passing the surface in: one model, and the answer depends
-    /// on which surface is asked about. A check that ignored its argument
-    /// would pass both of the tests above and fail here.
-    #[test]
-    fn the_answer_depends_on_which_api_is_asked_about() {
-        let model = &demo_model(vec![SupportedApi {
-            api: Api::OpenAiCompatResponses,
-        }]);
-        let provider = &demo_provider("https://api.demo.test", Credential::EnvVar("DEMO_API_KEY"));
-
-        Client::validate_api(model, Api::OpenAiCompatResponses, provider, "demo/x").unwrap();
-        for refused in [
-            Api::OpenAiCompatChatCompletions,
-            Api::OpenAiCompatChatCompletionsStream,
+    fn the_matched_surface_picks_the_protocol_spoken_upstream() {
+        for (surface, expected) in [
+            (Api::OpenAiCompatChatCompletions, Egress::OpenAiCompat),
+            (Api::AnthropicMessages, Egress::Anthropic),
         ] {
-            let message = Client::validate_api(model, refused, provider, "demo/x")
-                .unwrap_err()
-                .to_string();
-            // Each refusal names the surface it was asked about, so a caller
-            // is never told the wrong thing is missing.
-            assert!(
-                message.contains(refused.as_str()),
-                "asked about `{}`: {message}",
-                refused.as_str()
-            );
+            let egress = Client::validate_api(
+                &demo_model(vec![
+                    SupportedApi { api: surface },
+                    // A second, unadmitted surface beside it changes nothing:
+                    // each listing is its own claim.
+                    SupportedApi {
+                        api: Api::OpenAiCompatResponses,
+                    },
+                ]),
+                Client::WHOLE_REPLY,
+                &demo_host(),
+                "demo/chat",
+            )
+            .unwrap();
+            assert_eq!(egress, expected, "{}", surface.as_str());
         }
     }
 
-    /// Streaming is its own surface, so serving chat completions says nothing
-    /// about it. The roster documents that; this is where it holds.
+    /// The point of passing the surfaces in: one model, and the answer depends
+    /// on which list is asked about. A check that ignored its argument would
+    /// pass both of the tests above and fail here.
     #[test]
-    fn chat_completions_does_not_imply_its_streaming_surface() {
-        let err = Client::validate_api(
-            &demo_model(vec![SupportedApi {
-                api: Api::OpenAiCompatChatCompletions,
-            }]),
-            Api::OpenAiCompatChatCompletionsStream,
-            &demo_provider("https://api.demo.test", Credential::EnvVar("DEMO_API_KEY")),
-            "demo/chat",
-        )
-        .unwrap_err()
-        .to_string();
-        assert!(
-            err.contains("does not serve openai_compat_chat_completions_stream"),
-            "{err}"
+    fn the_answer_depends_on_which_surfaces_are_admitted() {
+        let model = &demo_model(vec![SupportedApi {
+            api: Api::AnthropicMessages,
+        }]);
+        let provider = &demo_host();
+
+        assert_eq!(
+            Client::validate_api(model, Client::WHOLE_REPLY, provider, "demo/x").unwrap(),
+            Egress::Anthropic
         );
+        // The same model, against the STREAMED list: it serves the whole-reply
+        // surface of this protocol and not the streamed one, so admitting it
+        // here would route a stream at an endpoint the roster never claimed.
+        let message = Client::validate_api(model, Client::STREAMED, provider, "demo/x")
+            .unwrap_err()
+            .to_string();
+        for tried in [
+            "openai_compat_chat_completions_stream",
+            "anthropic_messages_stream",
+        ] {
+            assert!(message.contains(tried), "missing `{tried}`: {message}");
+        }
+    }
+
+    /// Streaming is its own surface, so serving whole replies says nothing
+    /// about it. The roster documents that; this is where it holds — and it
+    /// holds per PROTOCOL, which is why both are swept.
+    #[test]
+    fn a_whole_reply_surface_does_not_imply_its_streaming_one() {
+        for (whole, streamed) in [
+            (
+                Api::OpenAiCompatChatCompletions,
+                "openai_compat_chat_completions_stream",
+            ),
+            (Api::AnthropicMessages, "anthropic_messages_stream"),
+        ] {
+            let err = Client::validate_api(
+                &demo_model(vec![SupportedApi { api: whole }]),
+                Client::STREAMED,
+                &demo_host(),
+                "demo/chat",
+            )
+            .unwrap_err()
+            .to_string();
+            assert!(err.contains(streamed), "{err}");
+        }
+    }
+
+    /// The two admission lists must not overlap, and neither may admit a
+    /// surface warpllm cannot serve on it. A streamed surface in
+    /// [`Client::WHOLE_REPLY`] would have the non-streaming entrypoint open a
+    /// stream it has no return type for.
+    #[test]
+    fn the_admission_lists_are_disjoint_and_correctly_halved() {
+        let whole: Vec<&str> = Client::WHOLE_REPLY
+            .iter()
+            .map(|(api, _)| api.as_str())
+            .collect();
+        let streamed: Vec<&str> = Client::STREAMED
+            .iter()
+            .map(|(api, _)| api.as_str())
+            .collect();
+        for name in &whole {
+            assert!(!name.ends_with("_stream"), "`{name}` is a streamed surface");
+            assert!(!streamed.contains(name), "`{name}` is in both lists");
+        }
+        for name in &streamed {
+            assert!(name.ends_with("_stream"), "`{name}` is not streamed");
+        }
+        // One entry per protocol in each, so a protocol cannot be reachable
+        // for whole replies and silently unreachable for streams.
+        assert_eq!(whole.len(), streamed.len());
     }
 
     /// A provider that names no environment variable has no key source at all,
@@ -690,10 +956,7 @@ mod tests {
             || {
                 let client = Client::new(declaring(&["openai"])).unwrap();
                 let err = client
-                    .validate(
-                        "deepseek/deepseek-v4-flash",
-                        Api::OpenAiCompatChatCompletions,
-                    )
+                    .validate("deepseek/deepseek-v4-flash", Client::WHOLE_REPLY)
                     .err()
                     .expect("an undeclared provider is refused");
                 match &err {
@@ -709,7 +972,7 @@ mod tests {
                 // And the declared one still routes, so the gate is not one
                 // that refuses everything.
                 client
-                    .validate("openai/gpt-5.6", Api::OpenAiCompatChatCompletions)
+                    .validate("openai/gpt-5.6", Client::WHOLE_REPLY)
                     .unwrap();
             },
         );
@@ -723,10 +986,7 @@ mod tests {
         with_env(&[], || {
             let err = Client::new(declaring(&["openai"]))
                 .unwrap()
-                .validate(
-                    "deepseek/deepseek-v4-flash",
-                    Api::OpenAiCompatChatCompletions,
-                )
+                .validate("deepseek/deepseek-v4-flash", Client::WHOLE_REPLY)
                 .err()
                 .expect("an undeclared provider is refused");
             assert!(matches!(err, Error::ProviderNotDeclared { .. }), "{err:?}");
@@ -742,7 +1002,7 @@ mod tests {
             let client = Client::new(declaring(&["openai"])).unwrap();
             for typo in ["openai/nope", "deepseek/nope"] {
                 let err = client
-                    .validate(typo, Api::OpenAiCompatChatCompletions)
+                    .validate(typo, Client::WHOLE_REPLY)
                     .err()
                     .expect("validation refuses it");
                 assert!(
@@ -760,7 +1020,7 @@ mod tests {
         with_env(&[], || {
             let err = Client::new(declaring(&["openai"]))
                 .unwrap()
-                .validate("openai/gpt-5.6", Api::OpenAiCompatChatCompletions)
+                .validate("openai/gpt-5.6", Client::WHOLE_REPLY)
                 .err()
                 .expect("validation refuses it");
             assert!(
@@ -796,7 +1056,7 @@ mod tests {
             Client::new(config).unwrap()
         });
         let admitted = client
-            .validate("openai/gpt-5.6", Api::OpenAiCompatChatCompletions)
+            .validate("openai/gpt-5.6", Client::WHOLE_REPLY)
             .unwrap();
         assert_eq!(
             crate::auth::testing::applied(
@@ -823,9 +1083,7 @@ mod tests {
             || {
                 let client = Client::new(ClientConfig::default()).unwrap();
                 for model in ["openai/gpt-5.6", "deepseek/deepseek-v4-flash"] {
-                    client
-                        .validate(model, Api::OpenAiCompatChatCompletions)
-                        .unwrap();
+                    client.validate(model, Client::WHOLE_REPLY).unwrap();
                 }
             },
         );
@@ -838,7 +1096,7 @@ mod tests {
         with_env(&[("OPENAI_API_KEY", Some("sk-openai"))], || {
             let err = Client::new(declaring(&[]))
                 .unwrap()
-                .validate("openai/gpt-5.6", Api::OpenAiCompatChatCompletions)
+                .validate("openai/gpt-5.6", Client::WHOLE_REPLY)
                 .err()
                 .expect("validation refuses it");
             assert!(matches!(err, Error::ProviderNotDeclared { .. }), "{err:?}");

--- a/crates/warpllm/src/credentials.rs
+++ b/crates/warpllm/src/credentials.rs
@@ -59,12 +59,9 @@ impl Credentials {
     /// `Authorization: Bearer ` upstream and report back whatever the provider
     /// makes of it.
     ///
-    /// The scheme is chosen HERE, and it is [`Authenticator::bearer`] for
-    /// everything, because every provider on the roster is an OpenAI-compatible
-    /// host that reads `Authorization`. [`Self::key_for`] owns the source and
-    /// says nothing about presentation; this is the seam where the table that
-    /// makes the scheme a real choice goes, with the first provider that is not
-    /// bearer.
+    /// The scheme is chosen HERE, by [`Self::scheme`]. [`Self::key_for`] owns
+    /// the SOURCE and says nothing about presentation; the two are separate
+    /// because they vary independently.
     ///
     /// Reads against `registry` rather than the shipped roster, because that is
     /// per client now: a key for a provider only this client's roster file has
@@ -84,7 +81,7 @@ impl Credentials {
                 .filter_map(|provider| {
                     Some((
                         provider.name(),
-                        Authenticator::bearer(Self::key_for(provider, None)?),
+                        Self::scheme(provider, Self::key_for(provider, None)?),
                     ))
                 })
                 .collect(),
@@ -95,7 +92,7 @@ impl Credentials {
                         .expect("Client::new refuses a declaration the roster does not hold");
                     Some((
                         provider.name(),
-                        Authenticator::bearer(Self::key_for(provider, Some(entry))?),
+                        Self::scheme(provider, Self::key_for(provider, Some(entry))?),
                     ))
                 })
                 .collect(),
@@ -112,6 +109,36 @@ impl Credentials {
             tracing::info!(providers = ?credentials.names(), "providers available");
         }
         credentials
+    }
+
+    /// How this provider's secret goes on the wire.
+    ///
+    /// Keyed on the PROVIDER and not on the protocol it speaks, which the two
+    /// cases either side of Anthropic settle between them: OpenCode Zen
+    /// re-hosts Claude and reads a bearer header, and Vertex (#25) will serve
+    /// Anthropic's Messages surface and Google's own `generateContent` under
+    /// ONE OAuth token. A scheme filed under a protocol gets both wrong, and
+    /// would have to build Vertex's credential twice.
+    ///
+    /// Bearer is the fallback rather than an error, and that is a deliberate
+    /// exception to this crate's habit of refusing what it cannot name. Two
+    /// reasons: it is what an OpenAI-compatible host reads and all but one
+    /// provider on the roster is one, and a caller may bring a roster of their
+    /// own naming providers this table has never heard of — refusing those
+    /// would break the feature that exists to serve them.
+    ///
+    /// It is also the limitation worth knowing about. A host serving
+    /// Anthropic's surface under a name other than `anthropic` — a proxy, a
+    /// self-hosted box — is sent a bearer header and answered with a 401,
+    /// because the roster has no way to SAY which scheme it wants. Making it
+    /// declarable is a follow-up; the shipped roster has one Anthropic host
+    /// and it is called `anthropic`.
+    fn scheme(provider: &ProviderSpec, secret: String) -> Authenticator {
+        match provider.name() {
+            // Anthropic reads `x-api-key` and refuses `Authorization`.
+            "anthropic" => Authenticator::anthropic_api_key(secret),
+            _ => Authenticator::bearer(secret),
+        }
     }
 
     /// One provider's key, or `None` when no source held a non-empty one.

--- a/crates/warpllm/src/gateway/anthropic/api/messages/exchange.rs
+++ b/crates/warpllm/src/gateway/anthropic/api/messages/exchange.rs
@@ -34,7 +34,7 @@ pub(crate) async fn exchange(
     http: &reqwest::Client,
     provider: &'static str,
     base_url: &str,
-    auth: &Authenticator,
+    auth: Option<&Authenticator>,
     max_output_tokens: Option<u32>,
 ) -> Result<types::ChatResponse> {
     let wire = render_request(request, provider, max_output_tokens)?;
@@ -69,7 +69,7 @@ pub(crate) async fn exchange_stream(
     http: &reqwest::Client,
     provider: &'static str,
     base_url: &str,
-    auth: &Authenticator,
+    auth: Option<&Authenticator>,
     max_output_tokens: Option<u32>,
     read_timeout: Option<Duration>,
 ) -> Result<ChatChunkStream> {
@@ -243,7 +243,7 @@ mod tests {
             &reqwest::Client::new(),
             "anthropic",
             &server.uri(),
-            &Authenticator::anthropic_api_key("sk-ant-demo".into()),
+            Some(&Authenticator::anthropic_api_key("sk-ant-demo".into())),
             None,
             None,
         )

--- a/crates/warpllm/src/gateway/anthropic/api/messages/mod.rs
+++ b/crates/warpllm/src/gateway/anthropic/api/messages/mod.rs
@@ -13,12 +13,13 @@ mod request;
 mod response;
 mod stream;
 
-// Nothing calls these yet. warpllm is CALLED in another protocol and only
-// SPEAKS this one, so `ingest_request` and `render_response` wait on an
-// Anthropic-shaped ingress, and `exchange` waits on the client dispatch. The
-// barrel names the surface's whole vocabulary regardless — a re-export list
-// tracking today's callers would churn on every wiring change, and the two
-// unused halves are what the round-trip tests are written against.
+// `exchange` and `exchange_stream` are reached from `client.rs`; the rest are
+// not, and two of them cannot be yet. warpllm is CALLED in another protocol and
+// only SPEAKS this one, so `ingest_request` and `render_response` wait on an
+// Anthropic-shaped ingress — the direction that is out of scope. The barrel
+// names the surface's whole vocabulary regardless: a re-export list tracking
+// today's callers would churn on every wiring change, and those two halves are
+// what the round-trip tests are written against.
 #[allow(unused_imports)]
 pub(crate) use self::{
     exchange::{ChatChunkStream, exchange, exchange_stream},

--- a/crates/warpllm/src/gateway/anthropic/api/messages/request.rs
+++ b/crates/warpllm/src/gateway/anthropic/api/messages/request.rs
@@ -26,6 +26,7 @@
 //! | tool arguments | a string of JSON | a decoded object | [`render_block`], which can fail |
 //! | reasoning depth | `reasoning_effort` | `output_config.effort` | [`render_output_config`] |
 //! | structured output | `response_format` | `output_config.format` | [`render_output_format`] |
+//! | parallel tool calls | `parallel_tool_calls` | inverted, on `tool_choice` | [`render_tool_choice_for`] |
 //! | `max_tokens` | optional | REQUIRED | [`resolve_max_tokens`] |
 
 use serde_json::Value;
@@ -59,6 +60,17 @@ use super::response::{control_of, ingest_block, object, plain, render_reasoning,
 /// the wire request without mapping it here is a compile error. Everything
 /// without a typed wire field — `top_k`, `metadata`, `service_tier` — rides
 /// `ext["anthropic"]` verbatim.
+// Dead until an Anthropic-shaped INGRESS exists — a `client.messages()`
+// entrypoint and a `/v1/messages` route on the server — which is out of scope
+// for #23. warpllm is CALLED in chat completions and only SPEAKS this protocol,
+// so the reverse direction has no caller: this function, and the whole `ingest_*` tree beneath it, are the half of
+// `request.rs` with nothing above them.
+//
+// On the ENTRY POINT rather than on its helpers, and that is the whole reason
+// three attributes cover what were twenty-eight warnings: an allowed item counts
+// as a live root, so everything it reaches is reachable again. A helper that goes
+// dead for its OWN reason still warns.
+#[allow(dead_code)]
 pub(crate) fn ingest_request(request: CreateMessageRequest, model: &str) -> types::ChatRequest {
     // Wire structs are plain serde data; serialization cannot fail.
     let body = plain(&request);
@@ -106,10 +118,18 @@ pub(crate) fn ingest_request(request: CreateMessageRequest, model: &str) -> type
             .map(ingest_tool)
             .collect(),
         tool_choice: tool_choice.as_ref().and_then(ingest_tool_choice),
+        parallel_tool_calls: tool_choice.as_ref().and_then(ingest_parallel_tool_calls),
         params: types::GenerationParams {
             max_tokens: Some(max_tokens),
             temperature,
             top_p,
+            // Typed on neither wire but promoted on both, so the two protocols
+            // agree about where it lives. Retained in the bag above as well,
+            // which is what keeps a same-protocol round trip byte-exact.
+            top_k: anthropic
+                .get("top_k")
+                .and_then(Value::as_u64)
+                .and_then(|value| u32::try_from(value).ok()),
             stop: stop_sequences.unwrap_or_default(),
         },
         response_format: output_config
@@ -248,6 +268,25 @@ fn ingest_tool(tool: &Tool) -> types::ToolDef {
     }
 }
 
+/// The caller's parallel-call setting, in the gateway's spelling.
+///
+/// INVERTED, which is the whole reason it is worth a function: this protocol
+/// disables, the gateway permits. Absent stays absent — writing a default here
+/// would claim the caller asked for something they left alone, and the flag
+/// only means anything when someone set it.
+fn ingest_parallel_tool_calls(choice: &ToolChoice) -> Option<bool> {
+    let disabled = match choice {
+        ToolChoice::Auto(mode) | ToolChoice::Any(mode) | ToolChoice::None(mode) => {
+            mode.disable_parallel_tool_use
+        }
+        ToolChoice::Tool(tool) => tool.disable_parallel_tool_use,
+        // An unknown tag keeps whatever it arrived with; its shape is not this
+        // crate's to interpret.
+        ToolChoice::Unknown(_) => None,
+    }?;
+    Some(!disabled)
+}
+
 fn ingest_tool_choice(choice: &ToolChoice) -> Option<types::ToolChoice> {
     match choice {
         ToolChoice::Auto(_) => Some(types::ToolChoice::Auto),
@@ -355,6 +394,15 @@ pub(crate) fn render_request(
                 .collect::<Result<Vec<_>>>()?,
         ),
     };
+    // This protocol takes `top_k` natively but warpllm gives it no typed wire
+    // field, so it goes back the way everything untyped here does — through
+    // the residue. What arrived wins, per this module's rule; the IR copy is
+    // what a caller on the OTHER protocol left, and there is no residue then.
+    if let Some(top_k) = params.top_k {
+        unknown_fields
+            .entry("top_k".to_string())
+            .or_insert_with(|| Value::from(top_k));
+    }
     Ok(CreateMessageRequest {
         model: request.model.clone(),
         max_tokens: resolve_max_tokens(request, max_output_tokens)?,
@@ -368,8 +416,7 @@ pub(crate) fn render_request(
             .or_else(|| (!params.stop.is_empty()).then(|| params.stop.clone())),
         stream: request.stream.then_some(true),
         tools,
-        tool_choice: take_typed(&mut unknown_fields, "tool_choice")
-            .or_else(|| request.tool_choice.as_ref().map(render_tool_choice)),
+        tool_choice: render_tool_choice_for(request, &mut unknown_fields),
         thinking: take_typed(&mut unknown_fields, "thinking")
             .or_else(|| request.reasoning.as_ref().and_then(render_thinking)),
         output_config: render_output_config(request, &mut unknown_fields)?,
@@ -410,6 +457,41 @@ fn resolve_max_tokens(request: &types::ChatRequest, max_output_tokens: Option<u3
 /// Per-value refusals are not here — a tool with no schema, an unparseable
 /// argument string, a JSON mode with no schema — because each is decided where
 /// the value is converted and would have to be found twice to be checked here.
+/// Whether this request was INGESTED on this protocol rather than translated
+/// onto it.
+///
+/// The distinction is what separates a caller who holds Anthropic's retained
+/// residue — signed thinking blocks and all — from one who was handed a
+/// chat-completions reply with nothing to echo. A request with no recorded
+/// source was assembled rather than ingested, and cannot be shown to hold the
+/// residue, so it is treated as the caller who does not.
+fn arrived_on_this_protocol(request: &types::ChatRequest) -> bool {
+    request
+        .source
+        .as_ref()
+        .is_some_and(|source| source.protocol == Protocol::Anthropic)
+}
+
+/// Whether this request turns extended thinking ON.
+///
+/// Asked once so that a refusal cannot disagree with what would actually be
+/// sent: the two spellings [`thinking_arm`] and [`render_output_config`]
+/// render between them are both thinking, and either one obliges the caller to
+/// return the signed blocks.
+///
+/// An explicit off is not thinking, and neither is a config carrying nothing
+/// renderable — refusing those would turn away callers who said the opposite
+/// of the thing being refused.
+fn thinks(request: &types::ChatRequest) -> bool {
+    let Some(reasoning) = &request.reasoning else {
+        return false;
+    };
+    reasoning.enabled != Some(false)
+        && (reasoning.enabled.is_some()
+            || reasoning.budget_tokens.is_some()
+            || reasoning.effort.is_some())
+}
+
 fn ensure_renderable(request: &types::ChatRequest) -> Result<()> {
     // No audio block exists on this protocol, in any shape. Dropping one would
     // send a request that reads as if the caller never attached the audio, and
@@ -426,6 +508,36 @@ fn ensure_renderable(request: &types::ChatRequest) -> Result<()> {
     if request.cache.is_some() {
         return Err(Error::NotImplemented(
             "a request-level cache hint on the anthropic renderer",
+        ));
+    }
+    // Anthropic requires its own signed `thinking` blocks to come back
+    // UNTOUCHED in the assistant turn that carries a `tool_use` — the turn must
+    // START with one — and a chat-completions caller has nowhere to keep them.
+    // The openai_compat renderer drops the block, and `Protocol::may_read`
+    // correctly denies it the `anthropic` bag the signature was retained in, so
+    // nothing a caller can echo ever reaches them.
+    //
+    // Which means the conversation cannot COMPLETE. The first exchange looks
+    // fine and answers with tool calls; the request carrying the results back
+    // has no thinking block to put before them and Anthropic rejects it. So the
+    // refusal is here, at the first request, rather than at the second: a
+    // caller told now loses only a turn they could not have used, and a caller
+    // told later has already built the loop around it.
+    //
+    // The counterpart comment in `openai_compat::…::response` records the other
+    // half of this and says dropping silently is the one option not available.
+    // This is that promise being kept. Carrying the blocks in a caller-visible,
+    // round-trippable form is the larger fix that would lift the refusal.
+    //
+    // And ONLY for a caller who cannot carry them. A request that ARRIVED on
+    // this protocol keeps its signed blocks in the retained residue and hands
+    // them straight back untouched, so the loop was never broken for them —
+    // refusing it would turn away the one caller this all works for.
+    if !arrived_on_this_protocol(request) && !request.tools.is_empty() && thinks(request) {
+        return Err(Error::NotImplemented(
+            "extended thinking with tools on the anthropic renderer: Anthropic \
+             wants its signed thinking blocks back alongside the tool results \
+             and chat completions has no field to carry them",
         ));
     }
     // Anthropic's base64 source REQUIRES a media type — `application/pdf`,
@@ -822,6 +934,55 @@ fn render_tool(tool: &types::ToolDef) -> Result<Tool> {
     }))
 }
 
+/// This protocol's tool choice, carrying the caller's parallel-call setting.
+///
+/// `parallel_tool_calls: false` has an exact equivalent here, but it is not a
+/// field of its own: Anthropic spells it inverted, as
+/// `disable_parallel_tool_use` hanging off `tool_choice`. So a caller who
+/// forbade parallel calls without naming a choice needs one synthesized, and
+/// `auto` is the honest synthesis — it IS this protocol's default, so writing
+/// it changes nothing except giving the flag somewhere to sit.
+///
+/// A retained residue choice wins untouched, per this module's prefer-what-
+/// arrived rule: it arrived on this protocol and already carries the flag in
+/// this protocol's own spelling.
+fn render_tool_choice_for(
+    request: &types::ChatRequest,
+    unknown_fields: &mut UnknownFields,
+) -> Option<ToolChoice> {
+    if let Some(retained) = take_typed(unknown_fields, "tool_choice") {
+        return Some(retained);
+    }
+    let mut choice = match &request.tool_choice {
+        Some(choice) => render_tool_choice(choice),
+        // Nothing to say about parallelism, or nothing to say it ABOUT.
+        // Synthesizing a choice for a caller who declared no tools would hand
+        // Anthropic a `tool_choice` with nothing to apply it to — a shape it
+        // refuses, and one this request did not have before it was translated.
+        None if request.parallel_tool_calls != Some(false) || request.tools.is_empty() => {
+            return None;
+        }
+        None => ToolChoice::Auto(ToolChoiceMode::default()),
+    };
+    if request.parallel_tool_calls == Some(false) {
+        match &mut choice {
+            ToolChoice::Auto(mode) | ToolChoice::Any(mode) => {
+                mode.disable_parallel_tool_use = Some(true);
+            }
+            ToolChoice::Tool(tool) => tool.disable_parallel_tool_use = Some(true),
+            // `none` forbids tool calls outright, so "not several at once" has
+            // nothing left to constrain, and Anthropic's `none` documents no
+            // such field. Writing it anyway risks a refusal for a request that
+            // already means everything the caller asked for.
+            ToolChoice::None(_) => {}
+            // A tag this crate does not know keeps the shape it arrived with;
+            // reaching into it would be guessing at a field nobody documented.
+            ToolChoice::Unknown(_) => {}
+        }
+    }
+    Some(choice)
+}
+
 fn render_tool_choice(choice: &types::ToolChoice) -> ToolChoice {
     match choice {
         types::ToolChoice::Auto => ToolChoice::Auto(ToolChoiceMode::default()),
@@ -1150,8 +1311,7 @@ mod tests {
                         "parameters": {"type": "object", "properties": {"city": {"type": "string"}}}
                     }
                 }],
-                "tool_choice": "auto",
-                "reasoning_effort": "medium"
+                "tool_choice": "auto"
             }))
             .unwrap(),
             "claude-opus-5",
@@ -1193,10 +1353,84 @@ mod tests {
                     "description": "current weather",
                     "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}}
                 }],
-                "tool_choice": {"type": "auto"},
-                "output_config": {"effort": "medium"}
+                "tool_choice": {"type": "auto"}
             })
         );
+    }
+
+    /// Thinking and tools cannot round trip on this route, so the pair is
+    /// refused rather than sent.
+    ///
+    /// Anthropic wants the assistant turn holding a `tool_use` to START with
+    /// its own signed `thinking` block, and a chat-completions caller is never
+    /// given one to return — the reply renderer drops it and `may_read` denies
+    /// it the bag the signature was kept in. Sent anyway, the FIRST exchange
+    /// succeeds and the second is rejected upstream, which is the shape this
+    /// fixture used to have: it asked for `reasoning_effort` alongside tools
+    /// and asserted the result was a valid Anthropic body. It was not.
+    #[test]
+    fn thinking_with_tools_is_refused_rather_than_sent_to_be_rejected() {
+        let mut request = openai_tool_conversation();
+        request.reasoning = Some(types::ReasoningConfig {
+            effort: Some("medium".into()),
+            ..Default::default()
+        });
+        assert!(matches!(
+            render_request(&request, "anthropic", None),
+            Err(Error::NotImplemented(_))
+        ));
+
+        // Either spelling of thinking, since either obliges the caller to
+        // return blocks they were never handed.
+        request.reasoning = Some(types::ReasoningConfig {
+            budget_tokens: Some(4096),
+            ..Default::default()
+        });
+        assert!(matches!(
+            render_request(&request, "anthropic", None),
+            Err(Error::NotImplemented(_))
+        ));
+    }
+
+    /// The refusal is about the PAIR. Tools without thinking is the ordinary
+    /// tool call this whole path exists to serve, and thinking without tools
+    /// has no blocks to hand back, so neither is turned away.
+    #[test]
+    fn thinking_and_tools_are_each_fine_alone() {
+        assert!(render_request(&openai_tool_conversation(), "anthropic", None).is_ok());
+
+        let mut thinking_only = openai_tool_conversation();
+        thinking_only.tools.clear();
+        thinking_only.tool_choice = None;
+        thinking_only.reasoning = Some(types::ReasoningConfig {
+            effort: Some("medium".into()),
+            ..Default::default()
+        });
+        assert!(render_request(&thinking_only, "anthropic", None).is_ok());
+    }
+
+    /// The refusal is for callers who were TRANSLATED onto this protocol. One
+    /// who arrived on it keeps Anthropic's signed blocks in the retained
+    /// residue and hands them back untouched, so the loop this guards has never
+    /// been broken for them — and `maximal_body` is exactly that caller, with
+    /// `thinking` and `tools` together in one request.
+    #[test]
+    fn thinking_with_tools_is_fine_for_a_caller_who_arrived_on_this_protocol() {
+        let native = ingest_request(wire(maximal_body()), "claude-opus-5");
+        assert!(!native.tools.is_empty() && thinks(&native), "the fixture");
+        assert!(render_request(&native, "anthropic", None).is_ok());
+    }
+
+    /// An explicit "don't think" is not thinking. Refusing it would turn away a
+    /// caller who asked for exactly the thing that makes the pair safe.
+    #[test]
+    fn thinking_switched_off_does_not_block_tools() {
+        let mut request = openai_tool_conversation();
+        request.reasoning = Some(types::ReasoningConfig {
+            enabled: Some(false),
+            ..Default::default()
+        });
+        assert!(render_request(&request, "anthropic", None).is_ok());
     }
 
     /// The other direction, closing the loop: Anthropic's reply renders back as
@@ -1326,6 +1560,136 @@ mod tests {
         assert_eq!(body["top_k"], json!(40));
         assert!(body.get("seed").is_none(), "{body}");
         assert!(body.get("logit_bias").is_none(), "{body}");
+    }
+
+    // -----------------------------------------------------------------------
+    // Controls the caller wrote in the OTHER protocol's spelling.
+    //
+    // The seam these guard is the one `ext` cannot cross: a value left in
+    // `ext["openai_compat"]` is a value `merged_ext` here is forbidden to read,
+    // so anything not promoted at ingest reaches Anthropic as if the caller
+    // never wrote it — silently, since the provider never sees it to reject it.
+    // -----------------------------------------------------------------------
+
+    /// An OpenAI-shaped request routed to Anthropic, with `extra` merged in at
+    /// the top level, rendered onto this protocol's wire.
+    fn rendered_from_openai(extra: Value) -> Value {
+        let mut body = json!({
+            "model": "anthropic/claude-opus-5",
+            "max_tokens": 512,
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{
+                "type": "function",
+                "function": {"name": "weather", "parameters": {"type": "object"}}
+            }]
+        });
+        let object = body.as_object_mut().unwrap();
+        for (key, value) in extra.as_object().unwrap() {
+            object.insert(key.clone(), value.clone());
+        }
+        rendered(&ingest_openai(
+            serde_json::from_value(body).unwrap(),
+            "claude-opus-5",
+        ))
+    }
+
+    /// `parallel_tool_calls: false` is a REFUSAL, and Anthropic can honor it —
+    /// inverted, and hanging off `tool_choice` rather than standing alone.
+    /// Dropped, the model is free to open several calls at once for a caller
+    /// who explicitly forbade it, and nothing on the wire says so.
+    #[test]
+    fn forbidding_parallel_calls_crosses_the_protocol_seam() {
+        let body = rendered_from_openai(json!({
+            "parallel_tool_calls": false,
+            "tool_choice": "required"
+        }));
+        assert_eq!(body["tool_choice"]["type"], json!("any"), "{body}");
+        assert_eq!(
+            body["tool_choice"]["disable_parallel_tool_use"],
+            json!(true),
+            "{body}"
+        );
+    }
+
+    /// The flag has nowhere to sit when the caller named no choice, so one is
+    /// synthesized — and `auto` is the honest synthesis, since it is what
+    /// Anthropic does with no `tool_choice` at all.
+    #[test]
+    fn forbidding_parallel_calls_synthesizes_a_choice_to_carry_it() {
+        let body = rendered_from_openai(json!({"parallel_tool_calls": false}));
+        assert_eq!(body["tool_choice"]["type"], json!("auto"), "{body}");
+        assert_eq!(
+            body["tool_choice"]["disable_parallel_tool_use"],
+            json!(true),
+            "{body}"
+        );
+    }
+
+    /// `true` is what Anthropic already does, so it writes nothing. A request
+    /// that grew a `tool_choice` nobody asked for would be a different request.
+    #[test]
+    fn permitting_parallel_calls_says_nothing() {
+        let body = rendered_from_openai(json!({"parallel_tool_calls": true}));
+        assert!(body.get("tool_choice").is_none(), "{body}");
+    }
+
+    /// `none` forbids every tool call, so there is no parallelism left to
+    /// forbid — and Anthropic's `none` takes no such field. A renderer that
+    /// stamped the flag onto whichever choice it happened to be holding turns
+    /// a request the caller was allowed to write into an upstream refusal.
+    #[test]
+    fn forbidding_parallel_calls_adds_nothing_to_a_choice_of_none() {
+        let body = rendered_from_openai(json!({
+            "parallel_tool_calls": false,
+            "tool_choice": "none"
+        }));
+        assert_eq!(body["tool_choice"]["type"], json!("none"), "{body}");
+        assert!(
+            body["tool_choice"]
+                .get("disable_parallel_tool_use")
+                .is_none(),
+            "{body}"
+        );
+    }
+
+    /// A choice is synthesized to CARRY the flag, so there has to be something
+    /// for it to govern. With no tools declared there is not, and inventing a
+    /// `tool_choice` anyway would attach one to a request that has nothing to
+    /// choose between — a shape Anthropic refuses, and one this request did not
+    /// have until warpllm translated it.
+    #[test]
+    fn no_choice_is_synthesized_for_a_request_that_declares_no_tools() {
+        let mut body = json!({
+            "model": "anthropic/claude-opus-5",
+            "max_tokens": 512,
+            "messages": [{"role": "user", "content": "hi"}],
+            "parallel_tool_calls": false
+        });
+        // Deliberately NOT `rendered_from_openai`, which always declares a tool.
+        let rendered = rendered(&ingest_openai(
+            serde_json::from_value(body.take()).unwrap(),
+            "claude-opus-5",
+        ));
+        assert!(rendered.get("tool_choice").is_none(), "{rendered}");
+    }
+
+    /// `top_k` is typed on NEITHER wire — a provider extension over there, an
+    /// untyped native field here — which is exactly why it has to be promoted
+    /// to cross. Left in the openai bag it would be dropped on the floor.
+    #[test]
+    fn top_k_crosses_the_protocol_seam() {
+        assert_eq!(
+            rendered_from_openai(json!({"top_k": 40}))["top_k"],
+            json!(40)
+        );
+    }
+
+    /// Promotion reads a number, not a shape. Anything else stays where it was
+    /// — this promotes a value, it does not coerce one.
+    #[test]
+    fn a_non_numeric_top_k_is_not_promoted() {
+        let body = rendered_from_openai(json!({"top_k": "40"}));
+        assert!(body.get("top_k").is_none(), "{body}");
     }
 
     // -----------------------------------------------------------------------

--- a/crates/warpllm/src/gateway/anthropic/api/messages/response.rs
+++ b/crates/warpllm/src/gateway/anthropic/api/messages/response.rs
@@ -385,6 +385,17 @@ fn restore_count(
 
 /// Infallible: wire fields restore from ext, and anything corrupted past its
 /// wire type falls back to dropping that field rather than failing a render.
+// Dead until an Anthropic-shaped INGRESS exists — a `client.messages()`
+// entrypoint and a `/v1/messages` route on the server — which is out of scope
+// for #23. warpllm is CALLED in chat completions and only SPEAKS this protocol,
+// so the reverse direction has no caller: this function is the inverse of the `ingest_response` that `exchange`
+// does call.
+//
+// On the ENTRY POINT rather than on its helpers, and that is the whole reason
+// three attributes cover what were twenty-eight warnings: an allowed item counts
+// as a live root, so everything it reaches is reachable again. A helper that goes
+// dead for its OWN reason still warns.
+#[allow(dead_code)]
 pub(crate) fn render_response(response: &types::ChatResponse, provider: &str) -> Message {
     let mut unknown_fields = merged_ext(&response.ext, provider);
     // One reply, one completion — see this module's docs. A response carrying

--- a/crates/warpllm/src/gateway/anthropic/api/messages/stream.rs
+++ b/crates/warpllm/src/gateway/anthropic/api/messages/stream.rs
@@ -508,6 +508,17 @@ fn delta_usage(usage: &MessageDeltaUsage, state: &StreamState) -> types::Usage {
 /// Reads only this protocol's namespace, through [`merged_ext`] — never
 /// `ext.get`, which would bypass [`Protocol::may_read`] and let another
 /// protocol's retained fields onto this wire.
+// Dead until an Anthropic-shaped INGRESS exists — a `client.messages()`
+// entrypoint and a `/v1/messages` route on the server — which is out of scope
+// for #23. warpllm is CALLED in chat completions and only SPEAKS this protocol,
+// so the reverse direction has no caller: this function is the inverse of the `ingest_event` that `ChatChunkStream`
+// does call, and is additionally what the round-trip tests are written against.
+//
+// On the ENTRY POINT rather than on its helpers, and that is the whole reason
+// three attributes cover what were twenty-eight warnings: an allowed item counts
+// as a live root, so everything it reaches is reachable again. A helper that goes
+// dead for its OWN reason still warns.
+#[allow(dead_code)]
 pub(crate) fn render_event(
     chunk: &types::ChatResponseChunk,
     provider: &str,

--- a/crates/warpllm/src/gateway/mod.rs
+++ b/crates/warpllm/src/gateway/mod.rs
@@ -22,13 +22,6 @@
 //! the wire shapes instead would make `protocol` depend on the gateway and
 //! leave a per-provider adapter nowhere clean to sit.
 
-// Nothing routes to Anthropic yet: `client.rs` picks an exchange by the routed
-// model's surface, and no surface names this protocol until the registry and
-// the dispatch land. Being unreachable is what makes these conversions safe to
-// land ahead of that — but it also means every item here reads as dead. Drop
-// this attribute on the change that wires the client; it should stop being
-// needed there.
-#[allow(dead_code)]
 pub(crate) mod anthropic;
 pub(crate) mod error;
 pub(crate) mod openai_compat;

--- a/crates/warpllm/src/gateway/openai_compat/api/chat_completions/mod.rs
+++ b/crates/warpllm/src/gateway/openai_compat/api/chat_completions/mod.rs
@@ -10,4 +10,4 @@ mod stream;
 pub(crate) use exchange::{ChatChunkStream, exchange, exchange_stream};
 pub(crate) use request::{ingest_request, render_request};
 pub(crate) use response::{ingest_response, render_response};
-pub(crate) use stream::{ingest_chunk, render_chunk};
+pub(crate) use stream::{ToolCallOrdinals, ingest_chunk, render_chunk};

--- a/crates/warpllm/src/gateway/openai_compat/api/chat_completions/request.rs
+++ b/crates/warpllm/src/gateway/openai_compat/api/chat_completions/request.rs
@@ -103,13 +103,36 @@ pub(crate) fn ingest_request(
             .map(ingest_tool)
             .collect(),
         tool_choice: tool_choice.as_ref().and_then(ingest_tool_choice),
+        // Promoted but retained, like `top_k` below: this protocol's own
+        // renderer restores it from the residue, and the promotion exists so
+        // Anthropic's renderer can spell it `disable_parallel_tool_use`.
+        // Anything but a bool is left for the provider to judge.
+        parallel_tool_calls: compat.get("parallel_tool_calls").and_then(Value::as_bool),
         params: types::GenerationParams {
             // Both an absent field and an explicit `null` mean "no value" to
             // the gateway IR; which one it was rides the residue above so
             // rendering can restore it.
-            max_tokens: max_tokens.flatten(),
+            //
+            // `max_completion_tokens` is the OTHER spelling of this, and it is
+            // read from the residue rather than from a typed field because
+            // warpllm does not model it — OpenAI's newer families REQUIRE it
+            // and reject `max_tokens`, so a caller on those writes only this
+            // one. It has to be lifted here, at ingest, because a renderer for
+            // another protocol may not read this protocol's bag: leaving it
+            // there meant a request capped at 16 tokens reached Claude with the
+            // roster's ceiling instead, which for `claude-opus-5` is 128,000.
+            //
+            // It WINS over `max_tokens` when both are present, matching
+            // OpenAI's own deprecation of the older spelling. Both stay in the
+            // residue, so a same-protocol round trip is unchanged.
+            max_tokens: max_completion_tokens(&compat).or_else(|| max_tokens.flatten()),
             temperature: temperature.flatten(),
             top_p: top_p.flatten(),
+            // Lifted from the residue for the same reason as
+            // `max_completion_tokens`, and it stays there too: Anthropic takes
+            // `top_k` natively, and a renderer for that protocol may not read
+            // this one's bag.
+            top_k: extension_u32(&compat, "top_k"),
             // Both wire spellings mean the same list of sequences; the one
             // that arrived is retained above so rendering can restore it.
             stop: stop
@@ -138,6 +161,37 @@ pub(crate) fn ingest_request(
         }),
         ..Default::default()
     }
+}
+
+/// The cap under OpenAI's newer spelling, if the caller wrote one.
+///
+/// A free function rather than inline, because the shape is worth naming: this
+/// reads a field warpllm does not MODEL and promotes it anyway. The rule for
+/// what gets typed is "what the IR has a home for", and the IR's home here is
+/// `GenerationParams::max_tokens` — already occupied by the older spelling.
+/// Two wire names for one gateway field is exactly the case `ext` cannot serve,
+/// because `ext` is same-protocol only.
+///
+/// Anything but a number is left alone. A caller who wrote `"512"` or `null`
+/// gets it forwarded verbatim for OpenAI to judge, which is the passthrough
+/// rule everywhere else here — this promotes a value, it does not validate one.
+fn max_completion_tokens(compat: &UnknownFields) -> Option<u32> {
+    extension_u32(compat, "max_completion_tokens")
+}
+
+/// A whole-number field warpllm does not MODEL on this wire, read from the
+/// residue so a renderer for another protocol can see it.
+///
+/// Anything but a number in range is left alone, which is the passthrough rule
+/// everywhere else here: this promotes a value, it does not validate one. A
+/// caller who wrote `"40"` gets it forwarded verbatim for the provider to
+/// judge — and on a cross-protocol route, forwarded is exactly what it is not,
+/// which is the tradeoff of promoting only what this protocol can read.
+fn extension_u32(compat: &UnknownFields, key: &str) -> Option<u32> {
+    compat
+        .get(key)?
+        .as_u64()
+        .and_then(|value| u32::try_from(value).ok())
 }
 
 /// Keeps a typed field's wire value under this protocol's namespace, so
@@ -412,8 +466,16 @@ pub(crate) fn render_request(
         // reconstruct: a null the caller sent survives the round trip.
         temperature: take_typed(&mut unknown_fields, "temperature")
             .or_else(|| params.temperature.map(Some)),
-        max_tokens: take_typed(&mut unknown_fields, "max_tokens")
-            .or_else(|| params.max_tokens.map(Some)),
+        max_tokens: take_typed(&mut unknown_fields, "max_tokens").or_else(|| {
+            // Not reconstructed when the cap arrived under the OTHER spelling:
+            // `max_completion_tokens` is still in the residue about to be
+            // emitted, so writing `max_tokens` here would hand the caller back
+            // a field they never sent, in the spelling OpenAI deprecated — and
+            // to a model that rejects it.
+            (!unknown_fields.contains_key("max_completion_tokens"))
+                .then(|| params.max_tokens.map(Some))
+                .flatten()
+        }),
         top_p: take_typed(&mut unknown_fields, "top_p").or_else(|| params.top_p.map(Some)),
         stop: take_typed(&mut unknown_fields, "stop").or_else(|| {
             (!params.stop.is_empty()).then(|| Some(ChatCompletionStop::Many(params.stop.clone())))
@@ -897,6 +959,63 @@ mod tests {
             .unknown_fields
             .insert("vendor_tag".into(), json!("vt"));
         request
+    }
+
+    /// Promoting a field warpllm does not MODEL must not change what a
+    /// same-protocol caller gets back. Both spellings stay in the residue, so
+    /// the request that comes out is the request that went in.
+    ///
+    /// The failure mode this pins is specific and would be easy to introduce:
+    /// once `max_completion_tokens` fills `params.max_tokens`, a renderer that
+    /// reconstructs `max_tokens` from the gateway form hands the caller a field
+    /// they never wrote — in the spelling OpenAI deprecated, to a model that
+    /// rejects it.
+    #[test]
+    fn the_newer_cap_spelling_round_trips_without_gaining_the_older_one() {
+        for body in [
+            json!({"model": "gpt-5-nano", "messages": [{"role": "user", "content": "hi"}],
+                   "max_completion_tokens": 16}),
+            json!({"model": "gpt-5-nano", "messages": [{"role": "user", "content": "hi"}],
+                   "max_tokens": 4096, "max_completion_tokens": 16}),
+        ] {
+            let normalized = ingest_request(wire(body.clone()), "gpt-5-nano");
+            // Promoted, whichever spellings arrived: the newer one wins.
+            assert_eq!(normalized.params.max_tokens, Some(16), "{body}");
+            assert_eq!(
+                plain(&render_request(&normalized, "openai").unwrap()),
+                body,
+                "{body}"
+            );
+        }
+    }
+
+    /// A value that is not a number is forwarded for OpenAI to judge rather
+    /// than promoted or refused, which is the passthrough rule the rest of this
+    /// module follows. Promotion reads a value; it does not validate one.
+    #[test]
+    fn a_cap_that_is_not_a_number_is_left_for_the_provider() {
+        let body = json!({"model": "gpt-5-nano", "messages": [{"role": "user", "content": "hi"}],
+                          "max_completion_tokens": "512"});
+        let normalized = ingest_request(wire(body.clone()), "gpt-5-nano");
+        assert_eq!(normalized.params.max_tokens, None);
+        assert_eq!(plain(&render_request(&normalized, "openai").unwrap()), body);
+    }
+
+    /// `developer` normalizes to `Role::System` and comes back out spelled
+    /// `developer`. The gateway role is what a second protocol reads; the raw
+    /// spelling is what makes this round trip.
+    #[test]
+    fn a_developer_message_is_a_system_role_that_still_says_developer() {
+        let body = json!({
+            "model": "gpt-5-nano",
+            "messages": [
+                {"role": "developer", "content": "Answer in French."},
+                {"role": "user", "content": "hi"}
+            ]
+        });
+        let normalized = ingest_request(wire(body.clone()), "gpt-5-nano");
+        assert_eq!(normalized.messages[0].role, Role::System);
+        assert_eq!(plain(&render_request(&normalized, "openai").unwrap()), body);
     }
 
     /// An OpenAI-compatible request must survive normalization and come

--- a/crates/warpllm/src/gateway/openai_compat/api/chat_completions/response.rs
+++ b/crates/warpllm/src/gateway/openai_compat/api/chat_completions/response.rs
@@ -359,19 +359,24 @@ fn render_message(message: &types::Message, provider: &str) -> ChatCompletionRes
             // no rendering on this protocol at all; they can only arise
             // cross-protocol, which warpllm does not do yet.
             //
-            // THAT LAST SENTENCE EXPIRES WITH THE ANTHROPIC DISPATCH, and the
-            // casualty is specific enough to name: Anthropic requires a run of
-            // its own signed `thinking` blocks to come back UNTOUCHED alongside
-            // tool results. Ingest preserves the signature and the retained
-            // wire content, but neither reaches a caller here — the block is
-            // dropped, and `Protocol::may_read` correctly denies this renderer
-            // the `anthropic` bag — so a caller has nothing to echo, and the
-            // next request renders a `tool_use` turn with no `thinking` before
-            // it. Anthropic rejects that. Whoever wires the dispatch either
-            // carries the blocks in a caller-visible form that round trips with
-            // the signature intact, or refuses thinking for cross-protocol tool
-            // conversations. Dropping silently is the one option that is not
-            // available.
+            // THAT LAST SENTENCE HAS NOW EXPIRED — the dispatch is wired — and
+            // the casualty is specific enough to name: Anthropic requires a run
+            // of its own signed `thinking` blocks to come back UNTOUCHED
+            // alongside tool results. Ingest preserves the signature and the
+            // retained wire content, but neither reaches a caller here: the
+            // block is dropped, and `Protocol::may_read` correctly denies this
+            // renderer the `anthropic` bag. So a caller has nothing to echo,
+            // and the request carrying the results back would render a
+            // `tool_use` turn with no `thinking` before it, which Anthropic
+            // rejects.
+            //
+            // Of the two ways out that comment named, the SECOND is taken:
+            // `anthropic::…::request::ensure_renderable` refuses thinking
+            // paired with tools, at the first request rather than the second.
+            // Dropping silently was the option that was not available, and it
+            // is not what happens. Carrying the blocks in a caller-visible form
+            // that round trips with the signature intact is still the larger
+            // fix, and it is what would lift that refusal.
             _ => {}
         }
     }

--- a/crates/warpllm/src/gateway/openai_compat/api/chat_completions/stream.rs
+++ b/crates/warpllm/src/gateway/openai_compat/api/chat_completions/stream.rs
@@ -223,9 +223,72 @@ fn ingest_tool_call_chunk(call: ChatCompletionMessageToolCallChunk) -> ContentDe
 
 /// Infallible: protocol fields restore from ext (a hook that corrupted a
 /// stashed value beyond its wire type falls back to dropping that field).
+/// One stream's map from the IR's tool-call correlation key to the ordinal
+/// this protocol requires.
+///
+/// The two are not the same number, and that is the whole reason this exists.
+/// [`ContentDelta::ToolCall::index`](types::ContentDelta) is documented as a
+/// stable CORRELATION KEY — it says which call a fragment belongs to and
+/// nothing more — while chat completions' `tool_calls[].index` is a 0-based
+/// index INTO the array a client assembles. Anthropic numbers every content
+/// block, so a reply that opens with text puts its first tool call at key 1;
+/// copying that through leaves a hole at 0, and openai-python's own streaming
+/// accumulator indexes `tool_calls` by that value — an out-of-range failure,
+/// not a cosmetic mismatch.
+///
+/// Scoped per CHOICE as well as per stream, because `tool_calls[].index` is
+/// numbered within one choice: two choices each opening a call would otherwise
+/// have the second one renumbered to 1. Anthropic has no multi-choice concept
+/// so its path never exercises that, but this renderer also serves `n > 1` on
+/// its own protocol, where it would be wrong.
+///
+/// On a same-protocol stream this is the IDENTITY, which is what makes it safe
+/// to apply everywhere rather than only on a translated path. Chat completions'
+/// own indices are already dense and 0-based in first-seen order, so mapping
+/// first-seen to position returns them unchanged.
+///
+/// Lives here rather than in the Anthropic gateway because the number being
+/// computed is THIS protocol's — the same seam `render_finish_reason` and
+/// `render_tool_call_kind` sit on. It is owned by
+/// [`ChatCompletionStream`](crate::ChatCompletionStream), the only scope that
+/// outlives a chunk.
+#[derive(Debug, Default)]
+pub(crate) struct ToolCallOrdinals {
+    /// `(choice, correlation key)` in first-seen order. An entry's POSITION
+    /// among the entries of its own choice IS the ordinal, so nothing is
+    /// counted or stored twice.
+    ///
+    /// A `Vec` rather than a `HashMap`: one reply holds a handful of tool
+    /// calls, so the scan is over that handful, and the length is bounded by
+    /// the reply rather than accumulating across them. A map would still need
+    /// a per-choice counter beside it to answer the same question.
+    seen: Vec<(u32, u32)>,
+}
+
+impl ToolCallOrdinals {
+    /// This key's ordinal within `choice`, assigning the next one if the key
+    /// is new. One pass, because finding the entry and counting the entries
+    /// before it are the same walk.
+    fn ordinal(&mut self, choice: u32, key: u32) -> u32 {
+        let mut ordinal = 0;
+        for &(seen_choice, seen_key) in &self.seen {
+            if seen_choice != choice {
+                continue;
+            }
+            if seen_key == key {
+                return ordinal;
+            }
+            ordinal += 1;
+        }
+        self.seen.push((choice, key));
+        ordinal
+    }
+}
+
 pub(crate) fn render_chunk(
     chunk: &types::ChatResponseChunk,
     provider: &str,
+    ordinals: &mut ToolCallOrdinals,
 ) -> CreateChatCompletionStreamResponse {
     let mut unknown_fields = merged_ext(&chunk.ext, provider);
     let object = take_string(&mut unknown_fields, "object")
@@ -244,7 +307,9 @@ pub(crate) fn render_chunk(
             .completions
             .iter()
             .enumerate()
-            .map(|(position, completion)| render_stream_choice(completion, position, provider))
+            .map(|(position, completion)| {
+                render_stream_choice(completion, position, provider, ordinals)
+            })
             .collect(),
         created: chunk.created.unwrap_or(0),
         model: chunk.model.clone(),
@@ -261,6 +326,7 @@ fn render_stream_choice(
     completion: &types::CompletionDelta,
     position: usize,
     provider: &str,
+    ordinals: &mut ToolCallOrdinals,
 ) -> StreamChoice {
     let mut unknown_fields = merged_ext(&completion.ext, provider);
     let index = unknown_fields
@@ -268,7 +334,10 @@ fn render_stream_choice(
         .and_then(|v| v.as_u64())
         .unwrap_or(position as u64) as u32;
     StreamChoice {
-        delta: render_delta(&completion.delta, provider),
+        // The choice index goes DOWN into the delta as well as onto the wire:
+        // a tool call's ordinal is numbered within its own choice. See
+        // [`ToolCallOrdinals`].
+        delta: render_delta(&completion.delta, provider, index, ordinals),
         finish_reason: render_delta_finish_reason(completion),
         index,
         logprobs: take_typed(&mut unknown_fields, "logprobs"),
@@ -317,7 +386,12 @@ fn render_tool_call_kind(kind: Option<&str>) -> Option<String> {
     })
 }
 
-fn render_delta(delta: &types::MessageDelta, provider: &str) -> ChatCompletionStreamResponseDelta {
+fn render_delta(
+    delta: &types::MessageDelta,
+    provider: &str,
+    choice: u32,
+    ordinals: &mut ToolCallOrdinals,
+) -> ChatCompletionStreamResponseDelta {
     let mut unknown_fields = merged_ext(&delta.ext, provider);
     let role = match unknown_fields.remove("role") {
         Some(Value::String(raw)) => Some(raw),
@@ -335,7 +409,10 @@ fn render_delta(delta: &types::MessageDelta, provider: &str) -> ChatCompletionSt
                 name,
                 arguments,
             } => tool_calls.push(ChatCompletionMessageToolCallChunk {
-                index: *index,
+                // The IR's value is a correlation key; this protocol's field is
+                // an ordinal. See [`ToolCallOrdinals`] for why they differ and
+                // why translating is an identity on a same-protocol stream.
+                index: ordinals.ordinal(choice, *index),
                 id: id.clone(),
                 function: Some(ToolCallChunkFunction {
                     arguments: arguments.clone(),
@@ -345,8 +422,23 @@ fn render_delta(delta: &types::MessageDelta, provider: &str) -> ChatCompletionSt
                 r#type: render_tool_call_kind(kind.as_deref()),
                 unknown_fields: UnknownFields::new(),
             }),
+            // Retained residue from THIS protocol, replayed verbatim — its
+            // `index` was already an ordinal when it arrived, and
+            // `Protocol::may_read` is what guarantees another protocol's
+            // residue never reaches here to be mistaken for one.
+            //
+            // It still has to CLAIM that ordinal. A passthrough call that took
+            // slot 0 without registering it left the slot free, so the next
+            // typed call was numbered 0 as well and the client merged two
+            // distinct calls into one array element. Registering is the
+            // identity for residue — first-seen order on a same-protocol
+            // stream is the order the indices already have — so this reserves
+            // the slot without renumbering anything.
             ContentDelta::Unknown(value) => {
-                if let Ok(call) = serde_json::from_value(value.clone()) {
+                if let Ok(mut call) =
+                    serde_json::from_value::<ChatCompletionMessageToolCallChunk>(value.clone())
+                {
+                    call.index = ordinals.ordinal(choice, call.index);
                     tool_calls.push(call);
                 }
             }
@@ -418,7 +510,11 @@ mod tests {
             ("refusal", FinishReason::ContentFilter, "content_filter"),
         ];
         for (raw, reason, expected) in rows {
-            let wire = render_chunk(&ending_chunk(raw, reason), "anthropic");
+            let wire = render_chunk(
+                &ending_chunk(raw, reason),
+                "anthropic",
+                &mut ToolCallOrdinals::default(),
+            );
             assert_eq!(
                 wire.choices[0].finish_reason.as_deref(),
                 Some(expected),
@@ -438,7 +534,11 @@ mod tests {
             ("stop", FinishReason::Stop),
             ("function_call", FinishReason::Other),
         ] {
-            let chunk = render_chunk(&ending_chunk(raw, reason), "anthropic");
+            let chunk = render_chunk(
+                &ending_chunk(raw, reason),
+                "anthropic",
+                &mut ToolCallOrdinals::default(),
+            );
             assert_eq!(
                 chunk.choices[0].finish_reason,
                 Some(super::super::response::render_finish_reason(raw, reason)),
@@ -455,14 +555,15 @@ mod tests {
         chunk.completions[0].finish_reason = None;
         chunk.completions[0].finish_reason_raw = None;
         assert_eq!(
-            render_chunk(&chunk, "anthropic").choices[0].finish_reason,
+            render_chunk(&chunk, "anthropic", &mut ToolCallOrdinals::default()).choices[0]
+                .finish_reason,
             None
         );
     }
 
     fn round_trip(body: Value, provider: &str) {
         let normalized = ingest_chunk(parse(body.clone()));
-        let rendered = render_chunk(&normalized, provider);
+        let rendered = render_chunk(&normalized, provider, &mut ToolCallOrdinals::default());
         assert_eq!(serde_json::to_value(&rendered).unwrap(), body);
     }
 
@@ -511,6 +612,199 @@ mod tests {
             },
             "obfuscation": "8Xk2p"
         })
+    }
+
+    /// A chunk carrying one tool-call fragment per `(choice, key)` pair given.
+    fn call_chunk(fragments: &[(u32, u32)]) -> types::ChatResponseChunk {
+        types::ChatResponseChunk {
+            id: "msg_1".into(),
+            model: "claude-opus-5".into(),
+            created: None,
+            completions: fragments
+                .iter()
+                .map(|&(choice, key)| {
+                    let mut ext = UnknownFields::new();
+                    ext.insert("index".into(), json!(choice));
+                    types::CompletionDelta {
+                        delta: types::MessageDelta {
+                            role: None,
+                            content: vec![ContentDelta::ToolCall {
+                                index: key,
+                                id: Some(format!("tu_{key}")),
+                                kind: Some("tool_use".into()),
+                                name: Some("get_weather".into()),
+                                arguments: None,
+                            }],
+                            ext: types::ProviderExt::new(),
+                        },
+                        finish_reason: None,
+                        finish_reason_raw: None,
+                        ext: namespaced(ext),
+                    }
+                })
+                .collect(),
+            usage: None,
+            ext: types::ProviderExt::new(),
+            source: None,
+        }
+    }
+
+    /// The wire `tool_calls[].index` of every fragment in one rendered chunk.
+    fn wire_indices(fragments: &[(u32, u32)], ordinals: &mut ToolCallOrdinals) -> Vec<Option<u32>> {
+        render_chunk(&call_chunk(fragments), "anthropic", ordinals)
+            .choices
+            .iter()
+            .map(|choice| choice.delta.tool_calls.as_ref().unwrap()[0].index.into())
+            .collect()
+    }
+
+    /// THE bug this whole map exists for. Anthropic numbers every content
+    /// block, so a reply that opens with text puts its first tool call at
+    /// key 1 — and `tool_calls[].index` is an index INTO the array a client
+    /// assembles, so copying 1 through leaves a hole at 0. openai-python's own
+    /// streaming accumulator indexes `tool_calls` by that value, which makes it
+    /// an out-of-range failure rather than a cosmetic mismatch.
+    #[test]
+    fn a_tool_calls_index_is_an_ordinal_not_the_correlation_key() {
+        let mut ordinals = ToolCallOrdinals::default();
+        assert_eq!(
+            wire_indices(&[(0, 1)], &mut ordinals),
+            vec![Some(0)],
+            "Anthropic's block index reached an OpenAI caller as an array index"
+        );
+    }
+
+    /// Every fragment of ONE call answers with the same ordinal, which is what
+    /// makes the ordinal usable as the array slot it claims to be. The opener
+    /// and its argument fragments arrive as separate chunks.
+    #[test]
+    fn every_fragment_of_one_call_keeps_its_ordinal() {
+        let mut ordinals = ToolCallOrdinals::default();
+        for _ in 0..3 {
+            assert_eq!(wire_indices(&[(0, 1)], &mut ordinals), vec![Some(0)]);
+        }
+    }
+
+    /// A second call takes the next slot, in the order the calls were first
+    /// seen rather than in the order of their keys.
+    #[test]
+    fn each_new_call_takes_the_next_slot() {
+        let mut ordinals = ToolCallOrdinals::default();
+        // Keys 5 then 2, deliberately not ascending: first-seen is the rule,
+        // so a version that sorted or subtracted a base would answer 3 and 0.
+        assert_eq!(wire_indices(&[(0, 5)], &mut ordinals), vec![Some(0)]);
+        assert_eq!(wire_indices(&[(0, 2)], &mut ordinals), vec![Some(1)]);
+        assert_eq!(wire_indices(&[(0, 5)], &mut ordinals), vec![Some(0)]);
+    }
+
+    /// On a SAME-protocol stream the map is the identity, which is what makes
+    /// it safe to apply on every path rather than only on a translated one.
+    /// This protocol's own indices are already dense and 0-based in first-seen
+    /// order, so first-seen-to-position returns them unchanged.
+    #[test]
+    fn a_same_protocol_streams_indices_are_unchanged() {
+        let mut ordinals = ToolCallOrdinals::default();
+        for key in 0..4 {
+            assert_eq!(
+                wire_indices(&[(0, key)], &mut ordinals),
+                vec![Some(key)],
+                "key {key} was renumbered on a stream that needed no remap"
+            );
+        }
+    }
+
+    /// One tool-call fragment on choice 0, as it arrives on the wire.
+    fn tool_call_chunk(call: Value) -> Value {
+        json!({
+            "id": "chatcmpl_1",
+            "created": 1_700_000_000,
+            "model": "gpt-5.6",
+            "object": "chat.completion.chunk",
+            "choices": [{"index": 0, "delta": {"tool_calls": [call]}}]
+        })
+    }
+
+    /// The wire index a chunk's single tool call is rendered at, through the
+    /// REAL ingest path rather than a hand-built IR delta — which is the point
+    /// here, since the bug is about which path ingest chooses.
+    fn round_tripped_index(call: Value, ordinals: &mut ToolCallOrdinals) -> u32 {
+        render_chunk(
+            &ingest_chunk(parse(tool_call_chunk(call))),
+            "openai",
+            ordinals,
+        )
+        .choices[0]
+            .delta
+            .tool_calls
+            .as_ref()
+            .expect("the chunk carried a tool call")[0]
+            .index
+    }
+
+    /// A passthrough tool call OCCUPIES the slot it is replayed into.
+    ///
+    /// A `custom` tool is a `type` this protocol has but `ContentDelta::ToolCall`
+    /// cannot express, so ingest sends it down the verbatim path — and sent
+    /// whole in one chunk, NO fragment of that call ever takes the typed path
+    /// to register its key. A version that replayed it without claiming index 0
+    /// left the slot free, and the next typed call was numbered 0 as well:
+    /// two distinct calls merged into one element of the client's array.
+    #[test]
+    fn a_passthrough_tool_call_claims_its_ordinal() {
+        let mut ordinals = ToolCallOrdinals::default();
+        assert_eq!(
+            round_tripped_index(
+                json!({
+                    "index": 0,
+                    "id": "call_a",
+                    "type": "custom",
+                    "function": {"name": "run", "arguments": "{}"}
+                }),
+                &mut ordinals
+            ),
+            0,
+            "a verbatim replay renumbered the index it arrived with"
+        );
+        assert_eq!(
+            round_tripped_index(
+                json!({
+                    "index": 1,
+                    "id": "call_b",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": ""}
+                }),
+                &mut ordinals
+            ),
+            1,
+            "a typed call took the slot a passthrough call already held"
+        );
+    }
+
+    /// `tool_calls[].index` is numbered within ONE choice, so two choices each
+    /// opening a call are both slot 0. A map scoped per stream alone would
+    /// renumber the second choice's call to 1 and put it in a slot its own
+    /// array does not have.
+    ///
+    /// Anthropic has no multi-choice concept so its path never reaches this,
+    /// but the same renderer serves `n > 1` on its own protocol.
+    #[test]
+    fn ordinals_are_numbered_within_a_choice() {
+        let mut ordinals = ToolCallOrdinals::default();
+        // DIFFERENT keys per choice, and that is the whole design of this test.
+        // With the same key in both, a map that ignored the choice entirely
+        // would still answer 0 twice — the second lookup would find the first
+        // entry by key alone — and this would pass while proving nothing.
+        // Distinct keys are what force the scoping to be real.
+        assert_eq!(
+            wire_indices(&[(0, 5), (1, 9)], &mut ordinals),
+            vec![Some(0), Some(0)],
+            "a per-stream map renumbered a call that belongs to another choice"
+        );
+        // And within each of those choices, numbering still advances.
+        assert_eq!(
+            wire_indices(&[(0, 6), (1, 5)], &mut ordinals),
+            vec![Some(1), Some(1)]
+        );
     }
 
     /// The mandated test, chunk-side: an OpenAI-compatible chunk must survive
@@ -627,8 +921,11 @@ mod tests {
                 ext: types::ProviderExt::new(),
                 source: None,
             };
-            plain(&render_chunk(&chunk, "anthropic"))["choices"][0]["delta"]["tool_calls"][0]
-                ["type"]
+            plain(&render_chunk(
+                &chunk,
+                "anthropic",
+                &mut ToolCallOrdinals::default(),
+            ))["choices"][0]["delta"]["tool_calls"][0]["type"]
                 .clone()
         };
 
@@ -766,7 +1063,12 @@ mod tests {
         assert!(normalized.usage.is_none());
         assert_eq!(normalized.ext["openai_compat"]["usage"], Value::Null);
         assert_eq!(
-            serde_json::to_value(render_chunk(&normalized, "openai")).unwrap(),
+            serde_json::to_value(render_chunk(
+                &normalized,
+                "openai",
+                &mut ToolCallOrdinals::default()
+            ))
+            .unwrap(),
             nulled
         );
     }
@@ -812,7 +1114,7 @@ mod tests {
             "the answer must still follow the reasoning: {content:?}"
         );
 
-        let rendered = render_chunk(&normalized, "deepseek");
+        let rendered = render_chunk(&normalized, "deepseek", &mut ToolCallOrdinals::default());
         assert_eq!(
             rendered.choices[0].delta.unknown_fields["reasoning_content"],
             json!("step by step")
@@ -928,7 +1230,12 @@ mod tests {
                 let body: Value = serde_json::from_str(payload).unwrap();
                 let normalized = ingest_chunk(parse(body.clone()));
                 assert_eq!(
-                    serde_json::to_value(render_chunk(&normalized, provider)).unwrap(),
+                    serde_json::to_value(render_chunk(
+                        &normalized,
+                        provider,
+                        &mut ToolCallOrdinals::default()
+                    ))
+                    .unwrap(),
                     body,
                     "{name} lost something on the way through the IR"
                 );

--- a/crates/warpllm/src/gateway/openai_compat/mod.rs
+++ b/crates/warpllm/src/gateway/openai_compat/mod.rs
@@ -72,6 +72,20 @@ pub(crate) fn namespaced(fields: UnknownFields) -> ProviderExt {
 pub(crate) fn role_from_wire(role: String) -> (Role, Option<String>) {
     match role.as_str() {
         "system" => (Role::System, None),
+        // OpenAI's newer spelling for a system instruction, and the ONLY
+        // non-identity arm here. It lands on `Role::System` because that is
+        // what it means and what `Role::System`'s own doc has always claimed;
+        // the raw spelling rides the residue, so a same-protocol round trip
+        // still says `developer`.
+        //
+        // It used to fall through to the catch-all and land on `Role::User`,
+        // which was invisible for exactly as long as one protocol existed —
+        // the raw spelling was restored either way. A second protocol is what
+        // made it observable: the Anthropic renderer may not read this
+        // protocol's bag, so all it saw was a user turn, and a developer
+        // instruction reached Claude as an ordinary message instead of a
+        // top-level `system`.
+        "developer" => (Role::System, Some(role)),
         "user" => (Role::User, None),
         "assistant" => (Role::Assistant, None),
         "tool" => (Role::Tool, None),
@@ -201,15 +215,29 @@ mod tests {
     /// it and render can restore it — which is what makes a same-protocol round
     /// trip lossless whatever role it lands on.
     ///
-    /// NOTE: it lands on [`Role::User`], while `Role::System`'s own doc claims
-    /// System "covers OpenAI `system` AND `developer`". The two disagree. This
-    /// test pins the CODE's behaviour, not the doc's claim; nothing observable
-    /// differs until a second protocol renders this message, since the raw
-    /// spelling is restored verbatim for openai_compat either way.
     #[test]
     fn an_unknown_wire_role_returns_its_raw_spelling() {
-        let (role, raw) = role_from_wire("developer".into());
+        let (role, raw) = role_from_wire("captain".into());
         assert_eq!(role, Role::User);
+        assert_eq!(raw.as_deref(), Some("captain"));
+    }
+
+    /// `developer` is a SYSTEM instruction, which is what `Role::System`'s doc
+    /// has always claimed and what the code did not do.
+    ///
+    /// The note this test used to carry called its own shot: nothing
+    /// observable differed "until a second protocol renders this message",
+    /// because the raw spelling was restored verbatim either way. Anthropic is
+    /// that second protocol, and it may not read this one's bag — so all it saw
+    /// was `Role::User`, and a developer instruction reached Claude as an
+    /// ordinary user turn rather than a top-level `system`.
+    ///
+    /// The raw spelling still rides along, which is what keeps the
+    /// same-protocol round trip saying `developer` rather than `system`.
+    #[test]
+    fn a_developer_message_is_a_system_instruction() {
+        let (role, raw) = role_from_wire("developer".into());
+        assert_eq!(role, Role::System);
         assert_eq!(raw.as_deref(), Some("developer"));
     }
 }

--- a/crates/warpllm/src/gateway/types/request.rs
+++ b/crates/warpllm/src/gateway/types/request.rs
@@ -18,6 +18,18 @@ pub(crate) struct ChatRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<ToolChoice>,
 
+    /// Whether the model may open more than one tool call in a turn.
+    ///
+    /// Typed on neither wire — chat completions spells it `parallel_tool_calls`
+    /// among its unknown fields, Anthropic spells it inverted as
+    /// `disable_parallel_tool_use` hanging off `tool_choice` — and promoted
+    /// anyway, for the reason [`GenerationParams`] gives: `ext` is
+    /// same-protocol only, so a value left there is a value the OTHER
+    /// protocol's renderer is forbidden to see. Left there, a caller who
+    /// forbade parallel calls got them anyway.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parallel_tool_calls: Option<bool>,
+
     #[serde(default)]
     pub params: GenerationParams,
 
@@ -42,8 +54,12 @@ pub(crate) struct ChatRequest {
     pub ext: ProviderExt,
 
     /// Where this request came from; see [`IngestSource`].
+    ///
+    /// Read by the Anthropic renderer to tell a caller who arrived on that
+    /// protocol — and therefore still holds its retained residue — from one
+    /// who was translated onto it and holds nothing. The passthrough fast path
+    /// is the other reader this was staged for.
     #[serde(skip)]
-    #[allow(dead_code)] // staged: read once the passthrough fast path lands
     pub source: Option<IngestSource>,
 }
 
@@ -75,15 +91,23 @@ pub(crate) enum ToolChoice {
     Tool { name: String },
 }
 
-/// Store what the caller sent, unconverted. Only the params with a typed
-/// home on every supported wire live here; everything else (seed, top_k,
-/// penalties, ...) rides the namespaced ext bags untouched until a second
-/// protocol needs to render them differently.
+/// Store what the caller sent, unconverted. A param lives here when a renderer
+/// for ANOTHER protocol has to read it; everything else (seed, penalties, ...)
+/// rides the namespaced ext bags untouched until that becomes true of it too.
+///
+/// A typed wire field is the usual reason, but not the test — `top_k` is typed
+/// on neither wire and still belongs here, because `ext` is same-protocol only
+/// and [`Protocol::may_read`](crate::types::Protocol::may_read) forbids the
+/// other protocol's renderer from reaching into this one's bag. That is the
+/// same rule that promotes `max_completion_tokens` at ingest.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(crate) struct GenerationParams {
     pub max_tokens: Option<u32>,
     pub temperature: Option<f64>,
     pub top_p: Option<f64>,
+    /// Anthropic takes this natively; chat completions carries it as a
+    /// provider extension. Promoted so the routed protocol can honor it.
+    pub top_k: Option<u32>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub stop: Vec<String>,
 }

--- a/crates/warpllm/src/protocol/anthropic/messages/transport.rs
+++ b/crates/warpllm/src/protocol/anthropic/messages/transport.rs
@@ -75,7 +75,7 @@ pub(crate) async fn post(
     http: &reqwest::Client,
     provider: &'static str,
     base_url: &str,
-    auth: &Authenticator,
+    auth: Option<&Authenticator>,
     body: &CreateMessageRequest,
 ) -> Result<Outcome> {
     if body.stream == Some(true) {
@@ -144,7 +144,7 @@ pub(crate) async fn post_stream(
     http: &reqwest::Client,
     provider: &'static str,
     base_url: &str,
-    auth: &Authenticator,
+    auth: Option<&Authenticator>,
     body: &CreateMessageRequest,
     read_timeout: Option<Duration>,
 ) -> Result<StreamOutcome> {
@@ -203,11 +203,18 @@ pub(crate) async fn post_stream(
 /// body it has to sign; `reqwest`'s own `send` would have executed the request
 /// before anything could touch it. `anthropic-version` stays here, because that
 /// one IS a fact about this wire format.
+///
+/// `auth` is an [`Option`] for the same reason `openai_compat`'s is: the
+/// roster's `auth: none`, which a self-hosted box on a private network
+/// declares. `None` sends the request exactly as built, with no `x-api-key`
+/// rather than an empty one — the two are different requests, and a host that
+/// wants no credential should be sent none. Nothing on the shipped roster uses
+/// it for this protocol; a caller's own roster is what reaches it.
 async fn send(
     http: &reqwest::Client,
     provider: &'static str,
     base_url: &str,
-    auth: &Authenticator,
+    auth: Option<&Authenticator>,
     body: &CreateMessageRequest,
 ) -> Result<reqwest::Response> {
     let request = http
@@ -220,7 +227,11 @@ async fn send(
         // looking at the provider's status page.
         .build()
         .map_err(|e| Error::Internal(format!("could not build the {provider} request: {e}")))?;
-    http.execute(auth.authenticate(request).await?)
+    let request = match auth {
+        Some(auth) => auth.authenticate(request).await?,
+        None => request,
+    };
+    http.execute(request)
         .await
         .map_err(|e| network_error(provider, e))
 }
@@ -416,7 +427,7 @@ mod tests {
             &reqwest::Client::new(),
             "anthropic",
             &server.uri(),
-            &key(),
+            Some(&key()),
             &CreateMessageRequest::default(),
         )
         .await
@@ -510,7 +521,7 @@ mod tests {
             &reqwest::Client::new(),
             "anthropic",
             &format!("{}/", server.uri()),
-            &key(),
+            Some(&key()),
             &CreateMessageRequest::default(),
         )
         .await;
@@ -556,7 +567,7 @@ mod tests {
             &reqwest::Client::new(),
             "anthropic",
             &server.uri(),
-            &key(),
+            Some(&key()),
             &streamed(),
             // Unbounded, which is the default and what every test but the
             // stall one below wants: a mock answers instantly, so a limit
@@ -841,7 +852,7 @@ mod tests {
             &reqwest::Client::new(),
             "anthropic",
             &format!("http://{addr}"),
-            &key(),
+            Some(&key()),
             &streamed(),
             Some(LIMIT),
         )
@@ -887,7 +898,7 @@ mod tests {
             &reqwest::Client::new(),
             "anthropic",
             &server.uri(),
-            &key(),
+            Some(&key()),
             &CreateMessageRequest {
                 model: "claude-opus-5".to_string(),
                 max_tokens: 7,
@@ -923,7 +934,7 @@ mod tests {
                 &reqwest::Client::new(),
                 "anthropic",
                 &server.uri(),
-                &key(),
+                Some(&key()),
                 &CreateMessageRequest {
                     stream,
                     ..Default::default()
@@ -953,7 +964,7 @@ mod tests {
             &reqwest::Client::new(),
             "anthropic",
             &server.uri(),
-            &key(),
+            Some(&key()),
             &CreateMessageRequest {
                 stream: Some(true),
                 ..Default::default()

--- a/crates/warpllm/src/protocol/anthropic/messages/types.rs
+++ b/crates/warpllm/src/protocol/anthropic/messages/types.rs
@@ -553,7 +553,9 @@ unknown_means_an_unknown_tag!(ToolChoice {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ToolChoiceMode {
     /// Anthropic's inverted spelling of chat completions'
-    /// `parallel_tool_calls`. Neither has a gateway home, so both ride `ext`.
+    /// `parallel_tool_calls`. Typed on neither wire, but the two meet at
+    /// [`ChatRequest::parallel_tool_calls`](crate::gateway::types::ChatRequest),
+    /// which is what lets a caller forbid parallel calls across the seam.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_parallel_tool_use: Option<bool>,
     #[serde(flatten)]

--- a/crates/warpllm/src/registry/lint.rs
+++ b/crates/warpllm/src/registry/lint.rs
@@ -411,19 +411,26 @@ mod tests {
     /// contributor fix the line without opening `protocol/types.rs`.
     #[test]
     fn an_api_outside_the_vocabulary_fails_to_load() {
+        // `anthropic_messages` until that surface landed. A name warpllm has
+        // SINCE implemented would go on passing here only because it is a
+        // prefix of nothing, and then this test checks nothing — so the
+        // replacement is Anthropic's Message Batches API: a real surface, and
+        // not one on the way.
         let yaml = with(&model("demo/plain")).replace(
             "api: openai_compat_chat_completions",
-            "api: anthropic_messages",
+            "api: anthropic_messages_batches",
         );
         let err = load(&yaml).unwrap_err();
         assert!(
-            err.contains("unknown variant `anthropic_messages`"),
+            err.contains("unknown variant `anthropic_messages_batches`"),
             "{err}"
         );
         for known in [
             "openai_compat_chat_completions",
             "openai_compat_chat_completions_stream",
             "openai_compat_responses",
+            "anthropic_messages",
+            "anthropic_messages_stream",
         ] {
             assert!(err.contains(known), "vocabulary missing {known}: {err}");
         }

--- a/crates/warpllm/src/registry/mod.rs
+++ b/crates/warpllm/src/registry/mod.rs
@@ -351,6 +351,7 @@ mod tests {
         assert_eq!(
             providers(&registry),
             vec![
+                "anthropic",
                 "deepseek",
                 "kimi",
                 "mistral",
@@ -362,6 +363,16 @@ mod tests {
         assert_eq!(
             keys(&registry),
             vec![
+                "anthropic/claude-fable-5",
+                "anthropic/claude-haiku-4-5",
+                "anthropic/claude-opus-4-5",
+                "anthropic/claude-opus-4-6",
+                "anthropic/claude-opus-4-7",
+                "anthropic/claude-opus-4-8",
+                "anthropic/claude-opus-5",
+                "anthropic/claude-sonnet-4-5",
+                "anthropic/claude-sonnet-4-6",
+                "anthropic/claude-sonnet-5",
                 "deepseek/deepseek-v4-flash",
                 "deepseek/deepseek-v4-pro",
                 "kimi/kimi-k2.6",
@@ -526,31 +537,44 @@ mod tests {
     /// capability nothing can act on. This is what catches it being added
     /// early.
     ///
-    /// Both implemented surfaces are listed for every model because every
-    /// provider on the roster documents `stream` on the chat-completions
-    /// endpoint rather than per model — `specs.yaml` cites each one. A provider
-    /// whose models genuinely differ belongs in an exclusion here, the same way
-    /// a non-chat model would.
+    /// Both halves of a protocol's pair are listed for every model because
+    /// every provider on the roster documents `stream` on the ENDPOINT rather
+    /// than per model — `specs.yaml` cites each one. A provider whose models
+    /// genuinely differ belongs in an exclusion here, the same way a non-chat
+    /// model would.
     ///
     /// It also means the shipped roster can no longer show two models of one
     /// provider differing. That is proved over fixtures instead, by
     /// `load::tests::two_models_of_one_provider_serve_different_surfaces`.
+    ///
+    /// A whitelist of PAIRS rather than one fixed pair, now that warpllm
+    /// implements two protocols — and it checks strictly more than the single
+    /// pair did. A MIXED listing, `openai_compat_chat_completions` beside
+    /// `anthropic_messages_stream`, is in neither pair, so an entry that
+    /// straddled two protocols fails here too; that entry would otherwise load,
+    /// lint, and then send its streamed requests to a wire format the
+    /// non-streamed half does not speak. Nothing on a model says which protocol
+    /// it belongs to except these names, so the expected pair cannot be derived
+    /// from the entry without asserting the entry equals itself.
     #[test]
     fn every_shipped_model_serves_exactly_the_implemented_surfaces() {
+        let pairs = [
+            [
+                Api::OpenAiCompatChatCompletions,
+                Api::OpenAiCompatChatCompletionsStream,
+            ],
+            [Api::AnthropicMessages, Api::AnthropicMessagesStream],
+        ]
+        .map(|apis| apis.map(|api| SupportedApi { api }));
+
         assert!(!REGISTRY.models.is_empty(), "the registry is empty");
         for (model_str, spec) in &REGISTRY.models {
-            assert_eq!(
-                spec.supported_apis(),
-                [
-                    SupportedApi {
-                        api: Api::OpenAiCompatChatCompletions
-                    },
-                    SupportedApi {
-                        api: Api::OpenAiCompatChatCompletionsStream
-                    }
-                ],
-                "`{model_str}` lists a surface warpllm does not implement, or \
-                 omits one it does"
+            assert!(
+                pairs.iter().any(|pair| pair == spec.supported_apis()),
+                "`{model_str}` lists {:?}, which is not one of the implemented \
+                 protocol pairs: a surface warpllm does not implement, a missing \
+                 streamed half, or two protocols in one entry",
+                spec.supported_apis()
             );
         }
     }

--- a/crates/warpllm/src/registry/specs.yaml
+++ b/crates/warpllm/src/registry/specs.yaml
@@ -131,6 +131,21 @@
 #                                          2026-08-16).
 #   openai_compat_responses                OpenAI's Responses API. Not
 #                                          implemented yet.
+#   anthropic_messages                     Anthropic's own `/messages`: one
+#                                          request, one whole reply.
+#                                          IMPLEMENTED. A different PROTOCOL
+#                                          from the three above rather than
+#                                          another endpoint in the same one, so
+#                                          a chat-completions request routed
+#                                          here is translated both ways.
+#   anthropic_messages_stream              The same, streamed as server-sent
+#                                          events. IMPLEMENTED. Anthropic
+#                                          documents `stream` on the endpoint
+#                                          rather than per model, so it is
+#                                          listed for every model that serves
+#                                          `/messages` at all:
+#                                          <https://platform.claude.com/docs/en/api/messages-streaming>
+#                                          (checked 2026-08-24).
 #
 # Rules EVERY roster is held to
 # -----------------------------
@@ -204,6 +219,136 @@
 # See `examples/warpllm.yaml` for a worked one.
 
 providers:
+  # <https://platform.claude.com/docs/en/about-claude/models/overview> and
+  # <https://platform.claude.com/docs/en/about-claude/model-deprecations>
+  # (both checked 2026-08-24). Every figure below is from the first; every
+  # judgement about a model's lifecycle is from the second.
+  #
+  # The first provider here that is NOT an OpenAI-compatible host. It speaks
+  # Anthropic's own `/messages`, so a chat-completions request is translated on
+  # the way out and its reply on the way back, and its credential goes in
+  # `x-api-key` rather than `Authorization` — see `Credentials::scheme`.
+  #
+  # `deprecation_date` is absent on EVERY entry, and that is a reading of
+  # Anthropic's table rather than an oversight. What it publishes for an active
+  # model is "Tentative retirement date: not sooner than <date>" with
+  # "Deprecated: N/A" — a FLOOR on when retirement could be announced, not an
+  # announcement. This field records "the day the provider stops serving this
+  # model, when one has been announced", so a floor written here would read as
+  # a schedule that does not exist. Every model below is state Active.
+  #
+  # Windows and output ceilings are the published figures verbatim: 1M and 128k
+  # for the Fable/Opus 5/Sonnet 5 generation and for Opus 4.8/4.7/4.6 and
+  # Sonnet 4.6; 200k and 64k for Haiku 4.5, Opus 4.5 and Sonnet 4.5. The
+  # `max_output` column is the SYNCHRONOUS Messages API figure, which is the
+  # surface registered here — the Batches API reaches 300k behind a beta
+  # header on some of these, and that is a different surface warpllm does not
+  # serve.
+  #
+  # No `max_concurrent_requests` on any entry: Anthropic publishes rate limits
+  # per usage tier and per model in requests and tokens per minute, not a
+  # concurrency figure. <https://platform.claude.com/docs/en/api/rate-limits>
+  #
+  # `model:` appears only on the three pre-4.6 entries. Anthropic's aliases for
+  # those resolve to ONE dated snapshot each and are stable pointers rather
+  # than moving ones, so the alias is what callers name and the dated id is
+  # what ships upstream. From the 4.6 generation on, the id is dateless AND
+  # pinned, so there is no second name to record.
+  #
+  # WORTH KNOWING, and deliberately not enforced: `temperature`, `top_p` and
+  # `top_k` are deprecated on Claude Opus 4.7 and later, and a non-default
+  # value returns a 400. warpllm passes them through — capabilities describe a
+  # model and never reshape a request, and dropping a parameter the caller
+  # wrote would change the request rather than translate it. An OpenAI-shaped
+  # request carrying `temperature` therefore fails against those models, by
+  # the provider's decision and with the provider's message.
+  #
+  # Deliberately absent, checked 2026-08-24:
+  # - claude-mythos-5 and claude-mythos-preview: invitation-only under Project
+  #   Glasswing with no self-serve sign-up, so a registered name would resolve
+  #   and then 403 for almost everyone. The preview is additionally deprecated.
+  # - Every retired model: the whole claude-3 family, claude-opus-4,
+  #   claude-sonnet-4, claude-opus-4-1. Requests to them fail upstream.
+  # - The dated ids of the three aliased models, per the roster's rule that
+  #   aliases are what callers name.
+  anthropic:
+    base_url: "https://api.anthropic.com/v1"
+    env_api_key: ANTHROPIC_API_KEY
+    models:
+      anthropic/claude-fable-5:
+        supported_apis:
+          - {api: anthropic_messages}
+          - {api: anthropic_messages_stream}
+        capabilities:
+          max_input_tokens: 1000000
+          max_output_tokens: 128000
+      anthropic/claude-haiku-4-5:
+        supported_apis:
+          - {api: anthropic_messages}
+          - {api: anthropic_messages_stream}
+        model: claude-haiku-4-5-20251001
+        capabilities:
+          max_input_tokens: 200000
+          max_output_tokens: 64000
+      anthropic/claude-opus-4-5:
+        supported_apis:
+          - {api: anthropic_messages}
+          - {api: anthropic_messages_stream}
+        model: claude-opus-4-5-20251101
+        capabilities:
+          max_input_tokens: 200000
+          max_output_tokens: 64000
+      anthropic/claude-opus-4-6:
+        supported_apis:
+          - {api: anthropic_messages}
+          - {api: anthropic_messages_stream}
+        capabilities:
+          max_input_tokens: 1000000
+          max_output_tokens: 128000
+      anthropic/claude-opus-4-7:
+        supported_apis:
+          - {api: anthropic_messages}
+          - {api: anthropic_messages_stream}
+        capabilities:
+          max_input_tokens: 1000000
+          max_output_tokens: 128000
+      anthropic/claude-opus-4-8:
+        supported_apis:
+          - {api: anthropic_messages}
+          - {api: anthropic_messages_stream}
+        capabilities:
+          max_input_tokens: 1000000
+          max_output_tokens: 128000
+      anthropic/claude-opus-5:
+        supported_apis:
+          - {api: anthropic_messages}
+          - {api: anthropic_messages_stream}
+        capabilities:
+          max_input_tokens: 1000000
+          max_output_tokens: 128000
+      anthropic/claude-sonnet-4-5:
+        supported_apis:
+          - {api: anthropic_messages}
+          - {api: anthropic_messages_stream}
+        model: claude-sonnet-4-5-20250929
+        capabilities:
+          max_input_tokens: 200000
+          max_output_tokens: 64000
+      anthropic/claude-sonnet-4-6:
+        supported_apis:
+          - {api: anthropic_messages}
+          - {api: anthropic_messages_stream}
+        capabilities:
+          max_input_tokens: 1000000
+          max_output_tokens: 128000
+      anthropic/claude-sonnet-5:
+        supported_apis:
+          - {api: anthropic_messages}
+          - {api: anthropic_messages_stream}
+        capabilities:
+          max_input_tokens: 1000000
+          max_output_tokens: 128000
+
   # <https://api-docs.deepseek.com/api/create-chat-completion> (checked
   # 2026-07-24). The legacy `deepseek-chat` / `deepseek-reasoner` names were
   # discontinued 2026-07-24 and map to V4-Flash modes.

--- a/crates/warpllm/src/types.rs
+++ b/crates/warpllm/src/types.rs
@@ -150,6 +150,22 @@ pub enum Api {
     /// OpenAI's newer, stateful successor to chat completions.
     #[serde(rename = "openai_compat_responses")]
     OpenAiCompatResponses,
+    /// Anthropic's `/messages`: one request, one whole reply.
+    ///
+    /// A different PROTOCOL from the surfaces above, not another endpoint in
+    /// the same one — which is what makes it the first surface a caller can
+    /// reach without warpllm speaking the caller's protocol upstream. A
+    /// chat-completions request routed to a model serving this is translated
+    /// on the way out and back; see [`crate::Client::chat_completions`].
+    #[serde(rename = "anthropic_messages")]
+    AnthropicMessages,
+    /// The same request asked to stream, delivered as incremental chunks.
+    ///
+    /// Separate for the same reason the chat-completions pair is: a model can
+    /// serve one without the other, so declaring that one never implies this
+    /// one.
+    #[serde(rename = "anthropic_messages_stream")]
+    AnthropicMessagesStream,
 }
 
 impl Api {
@@ -166,6 +182,8 @@ impl Api {
             Api::OpenAiCompatChatCompletions => "openai_compat_chat_completions",
             Api::OpenAiCompatChatCompletionsStream => "openai_compat_chat_completions_stream",
             Api::OpenAiCompatResponses => "openai_compat_responses",
+            Api::AnthropicMessages => "anthropic_messages",
+            Api::AnthropicMessagesStream => "anthropic_messages_stream",
         }
     }
 }
@@ -236,6 +254,16 @@ mod tests {
             Api::OpenAiCompatResponses,
             Protocol::OpenAiCompat,
         ),
+        (
+            "anthropic_messages",
+            Api::AnthropicMessages,
+            Protocol::Anthropic,
+        ),
+        (
+            "anthropic_messages_stream",
+            Api::AnthropicMessagesStream,
+            Protocol::Anthropic,
+        ),
     ];
 
     /// The roster spells these by hand, and so do the `serde(rename)` on each
@@ -273,9 +301,16 @@ mod tests {
     /// A surface warpllm has never heard of fails to parse, which is what
     /// keeps a misspelling out of the roster. The message names the whole
     /// vocabulary so the line can be fixed without opening this file.
+    ///
+    /// The name here was `anthropic_messages` until that surface landed, which
+    /// is the hazard this comment exists for: the test goes on passing against
+    /// a name warpllm has SINCE implemented only because it also matches the
+    /// prefix of a longer unknown one, and then it is checking nothing.
+    /// Anthropic's Message Batches API is the replacement — a real surface,
+    /// and not one on the way.
     #[test]
     fn an_unknown_surface_is_rejected() {
-        let err = serde_json::from_value::<Api>(serde_json::json!("anthropic_messages"))
+        let err = serde_json::from_value::<Api>(serde_json::json!("anthropic_messages_batches"))
             .unwrap_err()
             .to_string();
         assert!(err.contains("unknown variant"), "{err}");

--- a/crates/warpllm/tests/live_stream.rs
+++ b/crates/warpllm/tests/live_stream.rs
@@ -54,15 +54,39 @@ use warpllm::{
 /// succession can 429, and Zen may withdraw a free model when its evaluation
 /// window closes. Both surface as this test naming the model it failed on,
 /// which is why the name is printed rather than only asserted.
-const MODELS: [(&str, &str); 4] = [
-    ("openai/gpt-5-nano", "max_completion_tokens"),
-    ("deepseek/deepseek-v4-flash", "max_tokens"),
-    ("opencode/laguna-s-2.1-free", "max_tokens"),
+/// `anthropic` earns its row for the reason `opencode` does not: it is the only
+/// one here reached over a protocol that is not chat completions, so this is the
+/// only place the translation meets a real socket. Haiku 4.5 is the cheapest
+/// Claude on the roster, which is the whole basis for the pick.
+const MODELS: [(&str, Cap); 5] = [
+    (
+        "openai/gpt-5-nano",
+        Cap::Unmodelled("max_completion_tokens"),
+    ),
+    ("deepseek/deepseek-v4-flash", Cap::Unmodelled("max_tokens")),
+    ("opencode/laguna-s-2.1-free", Cap::Unmodelled("max_tokens")),
     (
         "openrouter/~deepseek/deepseek-v4-flash-latest",
-        "max_tokens",
+        Cap::Unmodelled("max_tokens"),
     ),
+    ("anthropic/claude-haiku-4-5", Cap::Typed),
 ];
+
+/// How a row's cap is written onto the request, which is a different question
+/// from what the cap is.
+enum Cap {
+    /// A spelling to insert verbatim, through the catch-all. Fine for every
+    /// chat-completions provider, because a renderer replays its OWN
+    /// protocol's residue — and useless across a protocol boundary, because
+    /// `Protocol::may_read` correctly refuses the Anthropic renderer a bag
+    /// keyed `openai_compat`. A cap parked there would be silently dropped and
+    /// the roster's ceiling used instead.
+    Unmodelled(&'static str),
+    /// The MODELED `max_tokens` field, which crosses protocols because warpllm
+    /// translates it. The only way to cap a reply from a provider that does not
+    /// speak the caller's protocol.
+    Typed,
+}
 
 #[tokio::test]
 #[ignore = "needs live provider API keys; run with --ignored"]
@@ -89,20 +113,25 @@ async fn every_configured_provider_streams_chunks_warpllm_can_hold() {
             )],
             ..Default::default()
         };
-        // Both go through the catch-all — the job it exists for, on a request
-        // rather than a reply. `max_completion_tokens` is genuinely unmodeled;
-        // `max_tokens` is a modeled field, but naming it here keeps the two
-        // spellings side by side instead of branching on which one this model
-        // wants.
+        // Most rows go through the catch-all — the job it exists for, on a
+        // request rather than a reply. `max_completion_tokens` is genuinely
+        // unmodeled; `max_tokens` is a modeled field, but naming it there keeps
+        // the two spellings side by side. Anthropic is the exception and
+        // [`Cap`] says why.
         //
         // The cap is generous rather than tight, because it exists to bound a
         // runaway and not to shape the answer. 16 does not survive a reasoning
         // model: the budget covers reasoning tokens too, so gpt-5-nano spent
         // all of it thinking and finished on `length` with nothing to show.
         // The prompt is what keeps the reply short.
-        request
-            .unknown_fields
-            .insert(cap.into(), serde_json::json!(512));
+        match cap {
+            Cap::Unmodelled(spelling) => {
+                request
+                    .unknown_fields
+                    .insert(spelling.into(), serde_json::json!(512));
+            }
+            Cap::Typed => request.max_tokens = Some(Some(512)),
+        }
         request.unknown_fields.insert(
             "stream_options".into(),
             serde_json::json!({"include_usage": true}),

--- a/crates/warpllm/tests/providers.rs
+++ b/crates/warpllm/tests/providers.rs
@@ -27,3 +27,9 @@ mod openrouter_chat_completions;
 
 #[path = "providers/mistral/chat_completions/mod.rs"]
 mod mistral_chat_completions;
+
+#[path = "providers/anthropic/messages/mod.rs"]
+mod anthropic_messages;
+
+#[path = "providers/anthropic/config_env.rs"]
+mod anthropic_config_env;

--- a/crates/warpllm/tests/providers/anthropic/config_env.rs
+++ b/crates/warpllm/tests/providers/anthropic/config_env.rs
@@ -1,0 +1,121 @@
+//! Anthropic's credential, which is the one on the roster that is not a bearer
+//! token.
+
+use crate::openai_common::{
+    ANTHROPIC_KEY, anthropic_message_body, client_for, request, with_anthropic_key,
+};
+use warpllm::{Client, ClientConfig, Error};
+use wiremock::matchers::{header, header_exists, method};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// The header, and the header that must NOT also be set.
+///
+/// Anthropic reads `x-api-key` and nothing else, and an `Authorization` header
+/// alongside it is not merely redundant: a proxy in front of Anthropic may read
+/// one and be answered by the other. The scheme is picked per PROVIDER in
+/// `Credentials::scheme`, so this is the end-to-end proof that the table is
+/// reached from a real request rather than only unit-tested.
+#[test]
+fn an_anthropic_request_authenticates_with_x_api_key() {
+    with_anthropic_key(async {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(header("x-api-key", ANTHROPIC_KEY))
+            .respond_with(ResponseTemplate::new(200).set_body_json(anthropic_message_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        client_for(&server)
+            .chat_completions(request("anthropic/claude-opus-5"))
+            .await
+            .unwrap();
+
+        let sent = &server.received_requests().await.unwrap()[0];
+        assert!(
+            sent.headers.get("authorization").is_none(),
+            "the key also went out as a bearer token"
+        );
+    });
+}
+
+/// An OpenAI key does not satisfy Anthropic, and the refusal names the variable
+/// to set.
+///
+/// The model IS registered, so the roster admits it and only the credential gate
+/// can reject it. The mock would answer 200 to anything, so a request reaching
+/// it means the gate opened on a provider warpllm holds no key for.
+#[test]
+fn another_providers_key_does_not_reach_anthropic() {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    temp_env::with_vars(
+        [
+            ("OPENAI_API_KEY", Some("sk-openai-env")),
+            ("ANTHROPIC_API_KEY", None),
+            ("WARPLLM_SPECS", None),
+        ],
+        || {
+            runtime.block_on(async {
+                let server = MockServer::start().await;
+                Mock::given(method("POST"))
+                    .respond_with(
+                        ResponseTemplate::new(200).set_body_json(anthropic_message_body()),
+                    )
+                    .mount(&server)
+                    .await;
+                let client = Client::new(ClientConfig {
+                    base_url: Some(server.uri()),
+                    ..Default::default()
+                })
+                .unwrap();
+
+                let err = client
+                    .chat_completions(request("anthropic/claude-opus-5"))
+                    .await
+                    .unwrap_err();
+                match err {
+                    Error::MissingApiKey { provider, env_var } => {
+                        assert_eq!(provider, "anthropic");
+                        assert_eq!(env_var, Some("ANTHROPIC_API_KEY"));
+                    }
+                    other => panic!("expected MissingApiKey, got {other:?}"),
+                }
+                assert!(
+                    server.received_requests().await.unwrap().is_empty(),
+                    "a provider with no key was still sent a request"
+                );
+            });
+        },
+    );
+}
+
+/// The version header is a fact about this WIRE FORMAT rather than about the
+/// provider, so it rides every request whatever the credential is. Asserted
+/// separately from the happy path because the two go wrong for different
+/// reasons: this one breaks when the transport is edited, not when the roster
+/// is.
+#[test]
+fn every_anthropic_request_names_the_api_version() {
+    with_anthropic_key(async {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(header_exists("anthropic-version"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(anthropic_message_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        client_for(&server)
+            .chat_completions(request("anthropic/claude-opus-5"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            server.received_requests().await.unwrap()[0]
+                .headers
+                .get("anthropic-version")
+                .unwrap(),
+            "2023-06-01"
+        );
+    });
+}

--- a/crates/warpllm/tests/providers/anthropic/messages/mod.rs
+++ b/crates/warpllm/tests/providers/anthropic/messages/mod.rs
@@ -1,0 +1,679 @@
+//! Claude reached over its own protocol, end to end.
+//!
+//! Every other provider suite here proves ROUTING: the same openai_compat
+//! endpoint serves it, so a test only has to show the prefix was stripped and
+//! the key went out. This one proves TRANSLATION. The caller writes a
+//! chat-completions request and reads a chat-completions reply, and in between
+//! warpllm speaks a wire format the caller never sees — so what these tests
+//! watch is the body that went out and the body that came back, not just the
+//! fact that something did.
+//!
+//! Requests are built by deserializing JSON rather than by assembling typed
+//! structs. That is the shape a caller's request actually arrives in through
+//! both bindings and the server, and it keeps a tool-call fixture readable.
+
+use crate::openai_common::{
+    ANTHROPIC_KEY, anthropic_message_body, client_for, request, with_anthropic_key,
+};
+use serde_json::{Value, json};
+use warpllm::{CreateChatCompletionRequest, Error};
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// A caller's request as JSON, which is how one really arrives.
+fn from_json(body: Value) -> CreateChatCompletionRequest {
+    serde_json::from_value(body).expect("the fixture is a valid chat-completions request")
+}
+
+/// A mock serving one Anthropic reply, and the body warpllm sent to get it.
+async fn exchange(request: CreateChatCompletionRequest, reply: Value) -> (Value, Value) {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/messages"))
+        .and(header("x-api-key", ANTHROPIC_KEY))
+        .respond_with(ResponseTemplate::new(200).set_body_json(reply))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let completion = client_for(&server)
+        .chat_completions(request)
+        .await
+        .expect("a 200 is a completion");
+
+    let sent = serde_json::from_slice(&server.received_requests().await.unwrap()[0].body).unwrap();
+    // Serialized rather than inspected field by field: what a caller receives is
+    // the JSON, and several of the claims below are about keys that must be
+    // ABSENT — which a struct-level assertion cannot see.
+    (sent, serde_json::to_value(completion).unwrap())
+}
+
+/// The whole point of #23, in one test. An OpenAI-shaped request reaches
+/// `api.anthropic.com` as an Anthropic-shaped body, and its reply comes back
+/// OpenAI-shaped.
+#[test]
+fn a_chat_completions_request_reaches_claude_and_returns_chat_completions() {
+    with_anthropic_key(async {
+        let (sent, got) =
+            exchange(request("anthropic/claude-opus-5"), anthropic_message_body()).await;
+
+        // OUT: Anthropic's shape. `messages` without the system turn, and no
+        // `stream` on a whole-reply request.
+        assert_eq!(
+            sent["model"], "claude-opus-5",
+            "the prefix reached upstream"
+        );
+        assert_eq!(sent["messages"][0]["role"], "user");
+        assert!(sent["stream"].is_null());
+
+        // BACK: chat completions' shape, and the caller's own model string
+        // rather than the upstream echo.
+        assert_eq!(got["model"], "anthropic/claude-opus-5");
+        assert_eq!(got["object"], "chat.completion");
+        assert_eq!(got["choices"][0]["message"]["content"], "Hello there!");
+        assert_eq!(got["choices"][0]["message"]["role"], "assistant");
+        assert_eq!(got["choices"][0]["finish_reason"], "stop");
+
+        // Anthropic reports no creation time and warpllm invents none.
+        assert_eq!(got["created"], 0);
+
+        // Usage in OpenAI's names, with the cache counts folded into the input
+        // the way the gateway form defines them.
+        assert_eq!(got["usage"]["prompt_tokens"], 14);
+        assert_eq!(got["usage"]["completion_tokens"], 12);
+        assert_eq!(got["usage"]["total_tokens"], 26);
+    });
+}
+
+/// The namespace collision, closed. `anthropic` is both a PROTOCOL and a
+/// PROVIDER, so a bag keyed `"anthropic"` holds either Anthropic's retained
+/// wire fields or provider passthrough — and until dispatch existed there was
+/// no live path on which the openai_compat renderer could be handed the first
+/// kind. `Protocol::may_read` is what refuses it.
+///
+/// Asserted on the SERIALIZED reply, and that is load-bearing: serde emits
+/// duplicate keys without complaint, so a renderer that flattened Anthropic's
+/// retained `content` block array in beside its own typed `content` string
+/// would produce a body with two `content` keys and a struct-level check would
+/// see nothing wrong.
+#[test]
+fn an_anthropic_reply_leaks_no_residue_to_an_openai_caller() {
+    with_anthropic_key(async {
+        let (_, got) = exchange(request("anthropic/claude-opus-5"), anthropic_message_body()).await;
+
+        let text = serde_json::to_string(&got).unwrap();
+        assert_eq!(
+            text.matches("\"content\"").count(),
+            1,
+            "two `content` keys in one reply: {text}"
+        );
+        for leaked in ["\"type\"", "\"stop_sequence\"", "\"input_tokens\""] {
+            assert!(
+                !text.contains(leaked),
+                "Anthropic's {leaked} reached an OpenAI caller: {text}"
+            );
+        }
+        // And no `ext` bag is emitted under this protocol's name. The KEY
+        // rather than the substring: the reply legitimately says
+        // `"model": "anthropic/claude-opus-5"`, because echoing the caller's
+        // own prefixed string is the one place that word belongs.
+        assert!(
+            !text.contains("\"anthropic\":"),
+            "a namespaced bag reached the caller: {text}"
+        );
+    });
+}
+
+/// Anthropic REQUIRES a `max_tokens` and chat completions does not, so the
+/// roster's ceiling is the fallback — and the caller's own value outranks it.
+///
+/// Both directions in one test: a version that always sent the roster's figure
+/// passes the first assertion and silently overrides every caller who named
+/// one.
+#[test]
+fn the_roster_supplies_the_max_tokens_anthropic_requires() {
+    with_anthropic_key(async {
+        let (sent, _) =
+            exchange(request("anthropic/claude-opus-5"), anthropic_message_body()).await;
+        // claude-opus-5's documented output ceiling, from `specs.yaml`.
+        assert_eq!(sent["max_tokens"], 128_000);
+
+        let mut asked = request("anthropic/claude-opus-5");
+        asked.max_tokens = Some(Some(64));
+        let (sent, _) = exchange(asked, anthropic_message_body()).await;
+        assert_eq!(
+            sent["max_tokens"], 64,
+            "the caller's ceiling was overridden"
+        );
+    });
+}
+
+/// A `developer` message is a SYSTEM instruction, and Anthropic's system
+/// instruction is a top-level field rather than a turn.
+///
+/// This is the class of bug a second protocol exists to expose. `developer`
+/// used to normalize to `Role::User` with its raw spelling in the residue,
+/// which was invisible while only one protocol existed — the spelling was
+/// restored verbatim on the way out. Anthropic may not read that bag, so all
+/// it ever saw was a user turn, and the instruction arrived as an ordinary
+/// message with none of the force the caller asked for.
+#[test]
+fn a_developer_instruction_reaches_claude_as_its_system_prompt() {
+    with_anthropic_key(async {
+        let (sent, _) = exchange(
+            from_json(json!({
+                "model": "anthropic/claude-opus-5",
+                "messages": [
+                    {"role": "developer", "content": "Answer in French."},
+                    {"role": "user", "content": "hi"}
+                ]
+            })),
+            anthropic_message_body(),
+        )
+        .await;
+
+        assert_eq!(sent["system"], "Answer in French.");
+        // And it is NOT also a message, which is the half that would make the
+        // conversation two consecutive user turns.
+        let roles: Vec<&str> = sent["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|m| m["role"].as_str().unwrap())
+            .collect();
+        assert_eq!(roles, vec!["user"]);
+    });
+}
+
+/// `max_completion_tokens` caps a Claude reply, and the roster's ceiling is
+/// only a fallback.
+///
+/// OpenAI's newer families REJECT `max_tokens` and require this spelling, so a
+/// caller moving from `openai/gpt-5-nano` to a Claude model carries it across
+/// unchanged. warpllm does not model it, so it rode `ext["openai_compat"]` —
+/// which the Anthropic renderer may not read. A request asking for 16 tokens
+/// therefore went out asking for 128,000.
+#[test]
+fn the_newer_spelling_of_the_cap_is_honoured() {
+    with_anthropic_key(async {
+        let (sent, _) = exchange(
+            from_json(json!({
+                "model": "anthropic/claude-opus-5",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_completion_tokens": 16
+            })),
+            anthropic_message_body(),
+        )
+        .await;
+        assert_eq!(
+            sent["max_tokens"], 16,
+            "the caller's cap was replaced by the roster's ceiling"
+        );
+
+        // And it outranks the older spelling when a caller sends both, which is
+        // OpenAI's own deprecation order.
+        let (sent, _) = exchange(
+            from_json(json!({
+                "model": "anthropic/claude-opus-5",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 4096,
+                "max_completion_tokens": 16
+            })),
+            anthropic_message_body(),
+        )
+        .await;
+        assert_eq!(sent["max_tokens"], 16);
+    });
+}
+
+/// Anthropic answers an overload with **529**, which is its own status and not
+/// one `classify`'s residual would place. Without the table entry it would
+/// arrive as `Error::Unknown` when it is a retryable server condition.
+#[test]
+fn a_529_is_reported_as_an_overload() {
+    with_anthropic_key(async {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(529).set_body_json(json!({
+                "type": "error",
+                "error": {"type": "overloaded_error", "message": "Overloaded"}
+            })))
+            .mount(&server)
+            .await;
+
+        let err = client_for(&server)
+            .chat_completions(request("anthropic/claude-opus-5"))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, Error::Overloaded(_)), "{err:?}");
+        // And it reaches a non-Rust caller as a 503, not as an unattributed
+        // failure.
+        let wire: Value = serde_json::from_str(&err.to_openai_json()).unwrap();
+        assert_eq!(wire["status"], 503);
+    });
+}
+
+/// A control the caller's protocol can express and the routed one cannot is
+/// REFUSED, not dropped.
+///
+/// warpllm's answer everywhere else is passthrough — forward what the caller
+/// wrote, let the provider judge it — and a translated route quietly loses the
+/// second half of that. `n` rides `ext["openai_compat"]`, which the Anthropic
+/// renderer is forbidden to read, so the provider never receives it and so
+/// cannot reject it. Dropped, `n: 2` comes back as one choice, which is
+/// indistinguishable from a model that ignored the request.
+///
+/// The mock expects ZERO requests: the refusal has to land before the network,
+/// or the caller is billed for an answer to a question they did not ask.
+#[test]
+fn a_control_anthropic_cannot_express_is_refused_not_dropped() {
+    with_anthropic_key(async {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(anthropic_message_body()))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let err = client_for(&server)
+            .chat_completions(from_json(json!({
+                "model": "anthropic/claude-opus-5",
+                "messages": [{"role": "user", "content": "hi"}],
+                "n": 2
+            })))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, Error::InvalidInput(_)), "{err:?}");
+        assert!(format!("{err}").contains("`n`"), "{err}");
+    });
+}
+
+/// The rest of the class, each one a control that changes the ANSWER rather
+/// than the request's shape. Left in `ext["openai_compat"]` every one of these
+/// reaches Claude as if it were never written, and the caller reads a
+/// materially different completion as a normal reply.
+#[test]
+fn every_untranslatable_control_is_refused_before_the_network() {
+    with_anthropic_key(async {
+        for (field, value) in [
+            ("frequency_penalty", json!(2)),
+            ("presence_penalty", json!(-1.5)),
+            ("logprobs", json!(true)),
+            ("top_logprobs", json!(5)),
+            ("logit_bias", json!({"1234": -100})),
+            ("seed", json!(42)),
+        ] {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(anthropic_message_body()))
+                .expect(0)
+                .mount(&server)
+                .await;
+
+            let err = client_for(&server)
+                .chat_completions(from_json(json!({
+                    "model": "anthropic/claude-opus-5",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    field: value
+                })))
+                .await
+                .unwrap_err();
+
+            assert!(matches!(err, Error::InvalidInput(_)), "{field}: {err:?}");
+            assert!(format!("{err}").contains(field), "{field}: {err}");
+        }
+    });
+}
+
+/// The value an SDK fills in when the caller asked for nothing is not a
+/// refusal. Every control above has one, and rejecting on the KEY rather than
+/// on the value would turn away the ordinary requests that carry them —
+/// which is most requests.
+#[test]
+fn the_default_value_of_an_untranslatable_control_still_passes() {
+    with_anthropic_key(async {
+        let (sent, _) = exchange(
+            from_json(json!({
+                "model": "anthropic/claude-opus-5",
+                "messages": [{"role": "user", "content": "hi"}],
+                "n": 1,
+                "frequency_penalty": 0,
+                "presence_penalty": 0.0,
+                "logprobs": false,
+                "logit_bias": {}
+            })),
+            anthropic_message_body(),
+        )
+        .await;
+
+        // And none of them rode along into a body with no field to hold them.
+        for field in ["n", "frequency_penalty", "logprobs", "logit_bias"] {
+            assert!(sent.get(field).is_none(), "{field} reached Claude: {sent}");
+        }
+    });
+}
+
+/// Only what CHANGES the answer is refused. One choice is what Anthropic
+/// returns anyway, so a caller who spelled the default out is not turned away —
+/// a refusal here would reject requests every OpenAI SDK can emit by default.
+#[test]
+fn asking_for_the_one_choice_anthropic_returns_is_not_a_refusal() {
+    with_anthropic_key(async {
+        let (_, got) = exchange(
+            from_json(json!({
+                "model": "anthropic/claude-opus-5",
+                "messages": [{"role": "user", "content": "hi"}],
+                "n": 1
+            })),
+            anthropic_message_body(),
+        )
+        .await;
+
+        assert_eq!(got["choices"].as_array().unwrap().len(), 1, "{got}");
+    });
+}
+
+/// A caller who forbids parallel tool calls is obeyed across the seam.
+///
+/// The two protocols spell it oppositely — `parallel_tool_calls: false` here,
+/// `disable_parallel_tool_use: true` there — and it hangs off `tool_choice`
+/// on Anthropic's side, so this also pins that a choice gets synthesized to
+/// carry it. Dropped, the model is free to open several calls at once for a
+/// caller who explicitly ruled that out.
+#[test]
+fn forbidding_parallel_tool_calls_reaches_claude() {
+    with_anthropic_key(async {
+        let (sent, _) = exchange(
+            from_json(json!({
+                "model": "anthropic/claude-opus-5",
+                "messages": [{"role": "user", "content": "weather?"}],
+                "tools": [{
+                    "type": "function",
+                    "function": {"name": "weather", "parameters": {"type": "object"}}
+                }],
+                "parallel_tool_calls": false
+            })),
+            anthropic_message_body(),
+        )
+        .await;
+
+        assert_eq!(
+            sent["tool_choice"]["disable_parallel_tool_use"],
+            json!(true),
+            "{sent}"
+        );
+        // And the caller's own spelling does not ride along into a body that
+        // has no such field.
+        assert!(sent.get("parallel_tool_calls").is_none(), "{sent}");
+    });
+}
+
+/// The test the neutral tool path was built for, and the one Responses will
+/// copy. An OpenAI-shaped conversation with tools, an assistant `tool_calls`
+/// turn, and TWO consecutive `role: "tool"` results renders to a valid
+/// Anthropic body — and the reply's `tool_use` comes back as `tool_calls`.
+///
+/// The merge is the part with nowhere else to be tested end to end: chat
+/// completions sends one message per result, Anthropic wants them as blocks
+/// inside ONE user turn.
+#[test]
+fn a_tool_conversation_crosses_both_ways() {
+    with_anthropic_key(async {
+        let (sent, got) = exchange(
+            from_json(json!({
+                "model": "anthropic/claude-opus-5",
+                "messages": [
+                    {"role": "system", "content": "Be brief."},
+                    {"role": "user", "content": "weather in both?"},
+                    {"role": "assistant", "content": null, "tool_calls": [
+                        {"id": "call_a", "type": "function",
+                         "function": {"name": "get_weather", "arguments": "{\"city\":\"Oslo\"}"}},
+                        {"id": "call_b", "type": "function",
+                         "function": {"name": "get_weather", "arguments": "{\"city\":\"Lima\"}"}}
+                    ]},
+                    {"role": "tool", "tool_call_id": "call_a", "content": "-3C"},
+                    {"role": "tool", "tool_call_id": "call_b", "content": "24C"}
+                ],
+                "tools": [{
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "current weather",
+                        "parameters": {"type": "object", "properties": {"city": {"type": "string"}}}
+                    }
+                }],
+                "tool_choice": "required"
+            })),
+            json!({
+                "id": "msg_1", "type": "message", "role": "assistant",
+                "model": "claude-opus-5",
+                "content": [
+                    {"type": "text", "text": "checking"},
+                    {"type": "tool_use", "id": "toolu_9", "name": "get_weather",
+                     "input": {"city": "Oslo"}}
+                ],
+                "stop_reason": "tool_use", "stop_sequence": null,
+                "usage": {"input_tokens": 5, "output_tokens": 7}
+            }),
+        )
+        .await;
+
+        // The system turn is HOISTED to the top level, not sent as a message.
+        assert_eq!(sent["system"], "Be brief.");
+        // Tools in Anthropic's spelling: `input_schema`, no function wrapper.
+        assert_eq!(sent["tools"][0]["name"], "get_weather");
+        assert_eq!(sent["tools"][0]["input_schema"]["type"], "object");
+        // "required" is `any` here.
+        assert_eq!(sent["tool_choice"]["type"], "any");
+
+        // THE merge: user, assistant, and ONE user turn holding both results.
+        let roles: Vec<&str> = sent["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|m| m["role"].as_str().unwrap())
+            .collect();
+        assert_eq!(roles, vec!["user", "assistant", "user"]);
+        let results = &sent["messages"][2]["content"];
+        assert_eq!(results.as_array().unwrap().len(), 2);
+        assert_eq!(results[0]["type"], "tool_result");
+        assert_eq!(results[0]["tool_use_id"], "call_a");
+        assert_eq!(results[1]["tool_use_id"], "call_b");
+        // Arguments are TEXT in the IR and an OBJECT here.
+        assert_eq!(sent["messages"][1]["content"][0]["input"]["city"], "Oslo");
+
+        // BACK: a tool call in this protocol's vocabulary, with `function` and
+        // not Anthropic's `tool_use`.
+        let call = &got["choices"][0]["message"]["tool_calls"][0];
+        assert_eq!(call["id"], "toolu_9");
+        assert_eq!(call["type"], "function");
+        assert_eq!(call["function"]["name"], "get_weather");
+        assert_eq!(call["function"]["arguments"], "{\"city\":\"Oslo\"}");
+        assert_eq!(got["choices"][0]["finish_reason"], "tool_calls");
+    });
+}
+
+/// Every chunk of a streamed reply, rendered for the caller.
+async fn stream_of(request: CreateChatCompletionRequest, transcript: &str) -> Vec<Value> {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/messages"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(transcript),
+        )
+        .mount(&server)
+        .await;
+
+    let mut stream = client_for(&server)
+        .chat_completions_stream(request)
+        .await
+        .expect("a 200 opens a stream");
+    let mut chunks = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        chunks.push(serde_json::to_value(chunk.expect("a well-formed transcript")).unwrap());
+    }
+    chunks
+}
+
+/// A transcript that opens with TEXT and then calls a tool, which is the
+/// ordinary shape and the one that exposes the index divergence.
+const TEXT_THEN_TOOL: &str = concat!(
+    r#"data: {"type":"message_start","message":{"id":"msg_1","type":"message","#,
+    r#""role":"assistant","model":"claude-opus-5","content":[],"#,
+    r#""stop_reason":null,"stop_sequence":null,"#,
+    r#""usage":{"input_tokens":4,"output_tokens":0}}}"#,
+    "\n\n",
+    r#"data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#,
+    "\n\n",
+    r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"one sec"}}"#,
+    "\n\n",
+    r#"data: {"type":"content_block_stop","index":0}"#,
+    "\n\n",
+    r#"data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","#,
+    r#""id":"toolu_1","name":"get_weather","input":{}}}"#,
+    "\n\n",
+    r#"data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","#,
+    r#""partial_json":"{\"city\":"}}"#,
+    "\n\n",
+    r#"data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","#,
+    r#""partial_json":"\"Oslo\"}"}}"#,
+    "\n\n",
+    r#"data: {"type":"content_block_stop","index":1}"#,
+    "\n\n",
+    r#"data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":9}}"#,
+    "\n\n",
+    r#"data: {"type":"message_stop"}"#,
+    "\n\n",
+);
+
+/// THE streamed blocker, closed. Anthropic numbers every content block, so a
+/// reply that opens with text puts its first tool call at index 1 — and
+/// `tool_calls[].index` is an index INTO the array an OpenAI client assembles.
+/// openai-python's own streaming accumulator indexes `tool_calls` by that
+/// value, so a 1 with no 0 before it is an out-of-range failure rather than a
+/// cosmetic mismatch.
+///
+/// End to end rather than against the renderer, because the map lives on the
+/// STREAM: a per-chunk renderer cannot hold it, and nothing but an open stream
+/// can prove the fragments of one call agree.
+#[test]
+fn a_streamed_tool_call_is_numbered_for_the_caller_not_for_anthropic() {
+    with_anthropic_key(async {
+        let chunks = stream_of(request("anthropic/claude-opus-5"), TEXT_THEN_TOOL).await;
+
+        let indices: Vec<i64> = chunks
+            .iter()
+            .filter_map(|chunk| chunk["choices"][0]["delta"]["tool_calls"][0]["index"].as_i64())
+            .collect();
+        assert!(
+            !indices.is_empty(),
+            "no tool-call fragment reached the caller"
+        );
+        assert!(
+            indices.iter().all(|&index| index == 0),
+            "Anthropic's block index reached an OpenAI client as an array slot: {indices:?}"
+        );
+
+        // The opener still names the call, and the fragments still carry the
+        // argument text — the remap must not have cost either.
+        let text: String = chunks
+            .iter()
+            .filter_map(|chunk| {
+                chunk["choices"][0]["delta"]["tool_calls"][0]["function"]["arguments"].as_str()
+            })
+            .collect();
+        assert_eq!(text, "{\"city\":\"Oslo\"}");
+        assert!(
+            chunks
+                .iter()
+                .any(|chunk| { chunk["choices"][0]["delta"]["tool_calls"][0]["id"] == "toolu_1" }),
+            "the opener's id was dropped"
+        );
+    });
+}
+
+/// A stream's totals are the caller's to ask for. Anthropic reports them on
+/// every `message_delta` whether or not anyone did, and chat completions
+/// reports them only under `stream_options.include_usage` — on a TRAILING chunk
+/// that carries no choices.
+///
+/// Both sides in one test, because the risk is a gate that is wired to nothing:
+/// a version ignoring the request passes whichever half it was written for.
+#[test]
+fn a_streams_totals_arrive_only_when_the_caller_asked() {
+    with_anthropic_key(async {
+        let unasked = stream_of(request("anthropic/claude-opus-5"), TEXT_THEN_TOOL).await;
+        assert!(
+            unasked.iter().all(|chunk| chunk["usage"].is_null()),
+            "totals nobody asked for reached the caller"
+        );
+
+        let mut asked = request("anthropic/claude-opus-5");
+        asked.stream_options = Some(Some(warpllm::ChatCompletionStreamOptions {
+            include_usage: Some(true),
+            unknown_fields: Default::default(),
+        }));
+        let chunks = stream_of(asked, TEXT_THEN_TOOL).await;
+
+        let last = chunks.last().expect("a stream with chunks");
+        assert_eq!(
+            last["choices"].as_array().map(Vec::len),
+            Some(0),
+            "the totals rode a chunk that also carried content: {last}"
+        );
+        assert_eq!(last["usage"]["completion_tokens"], 9);
+        assert_eq!(last["usage"]["prompt_tokens"], 4);
+        // Exactly one chunk carries them.
+        assert_eq!(
+            chunks
+                .iter()
+                .filter(|chunk| !chunk["usage"].is_null())
+                .count(),
+            1
+        );
+    });
+}
+
+/// A model that serves Anthropic's surface and a model that serves chat
+/// completions go out over DIFFERENT protocols from the same entrypoint, which
+/// is what egress dispatch means.
+///
+/// The path is the tell and it is the whole assertion: `/messages` against
+/// `/chat/completions`. A dispatch that ignored the routed model's surface
+/// would send both to whichever arm it hard-coded, and every other test here
+/// would still pass.
+#[test]
+fn the_routed_models_surface_picks_the_protocol_not_the_entrypoint() {
+    with_anthropic_key(async {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(anthropic_message_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        client_for(&server)
+            .chat_completions(request("anthropic/claude-sonnet-5"))
+            .await
+            .unwrap();
+
+        // And the OpenAI-compatible model on the same client, whose key is
+        // absent here — so it must be REFUSED before a request goes out rather
+        // than sent to `/messages`.
+        let err = client_for(&server)
+            .chat_completions(request("openai/gpt-5.6"))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::MissingApiKey { .. }), "{err:?}");
+        assert_eq!(
+            server.received_requests().await.unwrap().len(),
+            1,
+            "a second request went out"
+        );
+    });
+}

--- a/crates/warpllm/tests/providers/openai/common.rs
+++ b/crates/warpllm/tests/providers/openai/common.rs
@@ -115,3 +115,31 @@ pub const MISTRAL_KEY: &str = "sk-test-mistral";
 pub fn with_mistral_key<F: Future<Output = ()>>(body: F) {
     with_env_key("MISTRAL_API_KEY", MISTRAL_KEY, body);
 }
+
+pub const ANTHROPIC_KEY: &str = "sk-ant-test";
+
+pub fn with_anthropic_key<F: Future<Output = ()>>(body: F) {
+    with_env_key("ANTHROPIC_API_KEY", ANTHROPIC_KEY, body);
+}
+
+/// A whole reply on Anthropic's wire, which is a different SHAPE from
+/// [`openai_completion_body`] rather than a renaming of it: no `created`, no
+/// `choices`, content as a block array, and usage counting the cache
+/// separately.
+pub fn anthropic_message_body() -> Value {
+    json!({
+        "id": "msg_013Zva2CMHLNnXjNJJKqJ2EF",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-opus-5",
+        "content": [{"type": "text", "text": "Hello there!"}],
+        "stop_reason": "end_turn",
+        "stop_sequence": null,
+        "usage": {
+            "input_tokens": 9,
+            "output_tokens": 12,
+            "cache_read_input_tokens": 3,
+            "cache_creation_input_tokens": 2
+        }
+    })
+}

--- a/docs/concepts/model-routing.mdx
+++ b/docs/concepts/model-routing.mdx
@@ -79,14 +79,50 @@ A model name may contain further slashes after the provider prefix —
 `openrouter/anthropic/claude-sonnet-4` is the OpenRouter provider serving the
 `anthropic/claude-sonnet-4` slug.
 
-<Note>
-  OpenRouter is the only route to Claude today. A direct `anthropic/` provider
-  is not yet registered, so `anthropic/claude-sonnet-4` fails the same way any
-  unknown string does. The protocol underneath it — translating your request
-  into Anthropic's `/messages` shape and its reply back — is on `main`;
-  routing to it is tracked in
-  [#23](https://github.com/warpllm/warpllm/issues/23).
-</Note>
+## Claude over Anthropic's own protocol
+
+`anthropic/` models go to `api.anthropic.com` directly, and they are the first
+on the roster reached over a protocol that is not chat completions. Nothing
+changes in your code: you send the same request shape and read the same reply
+shape, and warpllm translates both ways.
+
+```python Python
+# Claude direct — needs ANTHROPIC_API_KEY
+client.chat_completions({"model": "anthropic/claude-opus-5", "messages": messages})
+
+# The same model through OpenRouter — needs OPENROUTER_API_KEY
+client.chat_completions({"model": "openrouter/anthropic/claude-sonnet-4", "messages": messages})
+```
+
+Both routes work. Direct is one hop fewer and bills through Anthropic; the
+OpenRouter entry stays registered and unchanged.
+
+Two differences from a chat-completions provider are worth knowing:
+
+<AccordionGroup>
+  <Accordion title="max_tokens is always sent" icon="ruler">
+    Anthropic requires it and chat completions does not, so warpllm falls back
+    to the model's published output ceiling when you name none. Your own value
+    always wins. A model whose ceiling is undocumented and a request naming no
+    `max_tokens` is refused rather than given an invented default — truncating
+    a reply at a length nobody asked for looks like the model stopping early.
+  </Accordion>
+  <Accordion title="temperature, top_p and top_k are rejected by newer models" icon="triangle-exclamation">
+    Anthropic deprecated all three on Claude Opus 4.7 and later: a non-default
+    value returns a 400. warpllm forwards what you write rather than dropping
+    it, because dropping a parameter would change your request instead of
+    translating it — so the refusal is Anthropic's, with Anthropic's message.
+    Omit them for those models and steer with the prompt.
+  </Accordion>
+  <Accordion title="Extended thinking with tools is not yet complete" icon="brain">
+    Anthropic requires its own signed `thinking` blocks to be echoed back
+    alongside your tool results, and a chat-completions reply has nowhere to
+    carry them — so a *multi-turn* tool conversation with thinking enabled is
+    rejected by Anthropic on the second turn. Single-turn tool calls and
+    thinking-without-tools both work. Tracked in
+    [#23](https://github.com/warpllm/warpllm/issues/23).
+  </Accordion>
+</AccordionGroup>
 
 ## What the registry records
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -60,16 +60,16 @@ honest version of what you can build on.
 | Bringing your own roster file | Released |
 | Weighted load balancing (Rust only) | Released |
 | OpenAI-compatible HTTP gateway | On `main`, unreleased |
-| Anthropic's Messages protocol | On `main`, not yet routable |
-| Claude direct on `api.anthropic.com` | Not yet — [#23](https://github.com/warpllm/warpllm/issues/23) |
+| Claude direct on `api.anthropic.com` | On `main`, unreleased |
 | Failover, retries, caching, metrics | Planned |
 
 <Note>
-  Those two Anthropic rows say different things. warpllm can now translate a
-  chat-completions request into Anthropic's `/messages` shape and read its
-  streamed reply back, but no model string routes there yet — so Claude is
-  still reached through OpenRouter. See
-  [Model routing](/concepts/model-routing).
+  Claude is the first model warpllm reaches over a protocol that is **not**
+  chat completions. You still write an OpenAI-shaped request and read an
+  OpenAI-shaped reply; warpllm translates to Anthropic's `/messages` on the way
+  out and back, streaming included. Two gaps are worth knowing before you
+  route production traffic there — see
+  [Model routing](/concepts/model-routing#claude-over-anthropics-own-protocol).
 </Note>
 
 <Info>

--- a/docs/models/overview.mdx
+++ b/docs/models/overview.mdx
@@ -78,10 +78,14 @@ models Google's own shape. None of those have an `api:` here yet, and
 registering them would hand back a model string that resolves and then fails
 upstream on every request.
 
-`anthropic_messages` is the closest to arriving: the surface is implemented on
-`main` and nothing routes to it, which is the last step of
-[#23](https://github.com/warpllm/warpllm/issues/23). Registering these entries
-is what that step unblocks.
+`anthropic_messages` is now implemented and routable — the `anthropic` provider
+uses it — so Zen's Claude models are a data entry rather than a blocked one.
+What is missing is the endpoint mapping: Zen serves them at `/zen/v1/messages`
+and a provider entry carries ONE `base_url`, so registering them needs a second
+`anthropic`-speaking provider entry pointed at that path. Its GPT, Grok, Muse
+and Gemini models still wait on
+[#41](https://github.com/warpllm/warpllm/issues/41) and
+[#35](https://github.com/warpllm/warpllm/issues/35).
 
 No entry carries `capabilities`: Zen publishes a price per model and no context
 window, output ceiling, or concurrency figure. Every model is re-hosted, so the

--- a/docs/scripts/gen_model_roster.py
+++ b/docs/scripts/gen_model_roster.py
@@ -36,7 +36,17 @@ BANNER = (
     "    run `uv run --with pyyaml docs/scripts/gen_model_roster.py`. */}"
 )
 
-STREAM_API = "openai_compat_chat_completions_stream"
+def streams(apis: set[str]) -> bool:
+    """Whether any surface this model serves is a streaming one.
+
+    A suffix test rather than a named surface. The column asks "can I stream
+    this?", which is a question about the model and not about a protocol — and
+    warpllm now speaks two, so a single hard-coded name answered "No" for every
+    Claude model while the roster listed `anthropic_messages_stream` beside it.
+    The suffix is the naming convention `Api` is checked against in
+    `client::tests::the_admission_lists_are_disjoint_and_correctly_halved`.
+    """
+    return any(api.endswith("_stream") for api in apis)
 
 
 def thousands(value: int | None) -> str:
@@ -87,7 +97,7 @@ def render_model_roster(registry: dict) -> str:
                 f"| `{upstream_name(model_key, model_spec)}` "
                 f"| {thousands(capabilities.get('max_input_tokens'))} "
                 f"| {thousands(capabilities.get('max_output_tokens'))} "
-                f"| {'Yes' if STREAM_API in apis else 'No'} |"
+                f"| {'Yes' if streams(apis) else 'No'} |"
             )
         lines.append("")
     return "\n".join(lines)

--- a/docs/snippets/model-roster.mdx
+++ b/docs/snippets/model-roster.mdx
@@ -2,6 +2,23 @@
     crates/warpllm/src/registry/specs.yaml. Do not edit by hand:
     run `uv run --with pyyaml docs/scripts/gen_model_roster.py`. */}
 
+### anthropic
+
+Base URL `https://api.anthropic.com/v1` &middot; API key `ANTHROPIC_API_KEY`
+
+| Model string | Sent upstream as | Context window | Max output | Streaming |
+| --- | --- | --- | --- | --- |
+| `anthropic/claude-fable-5` | `claude-fable-5` | 1,000,000 | 128,000 | Yes |
+| `anthropic/claude-haiku-4-5` | `claude-haiku-4-5-20251001` | 200,000 | 64,000 | Yes |
+| `anthropic/claude-opus-4-5` | `claude-opus-4-5-20251101` | 200,000 | 64,000 | Yes |
+| `anthropic/claude-opus-4-6` | `claude-opus-4-6` | 1,000,000 | 128,000 | Yes |
+| `anthropic/claude-opus-4-7` | `claude-opus-4-7` | 1,000,000 | 128,000 | Yes |
+| `anthropic/claude-opus-4-8` | `claude-opus-4-8` | 1,000,000 | 128,000 | Yes |
+| `anthropic/claude-opus-5` | `claude-opus-5` | 1,000,000 | 128,000 | Yes |
+| `anthropic/claude-sonnet-4-5` | `claude-sonnet-4-5-20250929` | 200,000 | 64,000 | Yes |
+| `anthropic/claude-sonnet-4-6` | `claude-sonnet-4-6` | 1,000,000 | 128,000 | Yes |
+| `anthropic/claude-sonnet-5` | `claude-sonnet-5` | 1,000,000 | 128,000 | Yes |
+
 ### deepseek
 
 Base URL `https://api.deepseek.com` &middot; API key `DEEPSEEK_API_KEY`

--- a/docs/snippets/provider-keys.mdx
+++ b/docs/snippets/provider-keys.mdx
@@ -4,6 +4,7 @@
 
 | Provider prefix | Environment variable | Base URL |
 | --- | --- | --- |
+| `anthropic/` | `ANTHROPIC_API_KEY` | `https://api.anthropic.com/v1` |
 | `deepseek/` | `DEEPSEEK_API_KEY` | `https://api.deepseek.com` |
 | `kimi/` | `MOONSHOT_API_KEY` | `https://api.moonshot.ai/v1` |
 | `mistral/` | `MISTRAL_API_KEY` | `https://api.mistral.ai/v1` |

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -48,6 +48,14 @@
 # alone, one block per specs.yaml provider — add a block here when specs.yaml
 # adds one.
 
+# The anthropic provider (specs.yaml: `providers.anthropic.env_api_key`).
+# Base URL: https://api.anthropic.com/v1.
+# Required for any request routed to a model under `anthropic/`. This is the one
+# key on the roster that does NOT go out as a bearer token: Anthropic reads
+# `x-api-key` and refuses `Authorization`, so warpllm sends it under that name
+# and sets no other header. Nothing about setting it here differs.
+ANTHROPIC_API_KEY=
+
 # The deepseek provider (specs.yaml: `providers.deepseek.env_api_key`).
 # Base URL: https://api.deepseek.com.
 # Required for any request routed to a model under `deepseek/`.


### PR DESCRIPTION
The step that makes #23 observable. Everything before this was additive and unreachable from `Client`; this adds the two Anthropic surfaces, the provider entry, the credential scheme, and the egress dispatch — so:

```python
client.chat_completions({"model": "anthropic/claude-opus-5", "messages": [...]})
```

reaches `api.anthropic.com` and returns a chat-completions reply.

## Ingress by entrypoint, egress by the routed model's surface

`client.rs` used to say only half of this: *"a second protocol arrives as a second entrypoint"* was right about being **called** and silent about **speaking**. The protocol a request goes out in is a property of the routed model, not of the method the caller used.

Both entrypoints now take a list of admitted surfaces paired with the module that serves each, and `validate_api` returns what matched. Pairing them is what keeps dispatch to two real arms — `Api` has five variants and only two can reach either entrypoint, so a match on `Api` would carry arms for cases the validation just ruled out.

## The tool-call index — blocker 1 of 2, closed

Anthropic numbers every content block, so a reply that opens with text puts its first tool call at index **1**. Chat completions' `tool_calls[].index` is an index *into* the array a client assembles, and openai-python's own streaming accumulator indexes by that value — a 1 with no 0 before it is an out-of-range failure, not a cosmetic mismatch.

The map lives in `openai_compat`'s renderer, beside `render_finish_reason` and `render_tool_call_kind`, and is owned by `ChatCompletionStream` because a per-chunk free function cannot hold it. Scoped per **choice** as well as per stream, since `tool_calls[].index` is numbered within one choice — Anthropic never reaches that, but this renderer also serves `n > 1` on its own protocol. On a same-protocol stream the map is the identity, which is what makes it safe everywhere rather than only on a translated path.

**Blocker 2 — signed thinking with tools — is deliberately not here.** It is a public-surface design question (where a signed block lives in a chat-completions reply) and gets its own PR. The gap is documented on `/concepts/model-routing` rather than left silent.

## Credentials gain a scheme

Anthropic is the roster's first non-bearer provider. `Credentials::scheme` is the table its own comment invited, keyed on the **provider** rather than the protocol — Zen re-hosts Claude behind a bearer header, and Vertex will serve two protocols under one OAuth token, so a scheme filed under a protocol gets both wrong.

Bearer stays the fallback rather than an error, because a caller may bring a roster naming providers this table has never heard of. The limitation that leaves is written where it happens: **a host serving Anthropic's surface under some other name gets a bearer header and a 401**, because the roster has no way to say which scheme it wants. Worth a follow-up.

## The roster

Ten models, every figure verbatim from Anthropic's tables and every lifecycle judgement from its deprecations page (both checked today). **No entry carries a `deprecation_date`**, and that is a reading rather than an oversight: what Anthropic publishes for an active model is *"not sooner than \<date\>"* with *"Deprecated: N/A"* — a floor on when retirement could be announced, not an announcement.

Deliberately not enforced: `temperature`/`top_p`/`top_k` are deprecated on Opus 4.7+ and 400 when set. warpllm forwards them — capabilities describe a model and never reshape a request, and dropping a parameter would change the request rather than translate it. The docs say so where someone would look.

## Two gates caught what reading would not have

- `examples/.env.example` is mirrored against the roster **both ways** by a script CI runs.
- The docs roster generator hard-coded one streaming surface name, so it printed `Streaming: No` for every Claude model while the roster listed `anthropic_messages_stream`. Now a `_stream` suffix test; the regenerated diff being additions-only is the proof it is equivalent for existing rows.

## Staged allows, in the shape the code took

`gateway/mod.rs`'s is gone, and so is `Authenticator::anthropic_api_key`'s. What remains is the **ingress** direction — `ingest_request`, `render_response`, `render_event` — dead until an Anthropic-shaped entrypoint exists, which is out of scope. Three attributes cover what were twenty-eight warnings: an allowed item counts as a live root for reachability, so a helper that goes dead for its *own* reason still warns.

## Testing

Eleven end-to-end wiremock tests watching the body that went out and the body that came back — system turn hoisted, two consecutive tool results merged into one user turn, arguments as text becoming an object, `x-api-key` set and `Authorization` absent, 529 as an overload. The cross-protocol reply is asserted on **serialized JSON**, because serde emits duplicate keys without complaint and a renderer that flattened Anthropic's retained `content` array in beside its own typed `content` string would produce two `content` keys no struct-level check can see.

Four mutations, all caught:

| mutation | caught by |
| --- | --- |
| dispatch always picks openai_compat | 9 e2e tests + 2 unit |
| the index is copied through, not remapped | 4 unit + the e2e streamed test |
| the scheme is always bearer | 5 e2e tests |
| ordinals not scoped per choice | `ordinals_are_numbered_within_a_choice` |

**That last row is the one worth reading.** The test was written vacuous and only mutation testing found it: the sweep used the same correlation key in every choice, so a map ignoring the choice entirely still answered 0 each time — the second lookup found the first entry by key alone. Different keys per choice are what force the scoping to be real. Reading it, it looks like it covers the case. That is the fifth instance in this issue of a test passing while the behaviour it names was broken.

Full gate green, including the live-stream arm (`anthropic/claude-haiku-4-5`, opt-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)