### PR TITLE
Register OpenRouter's Ox Alpha, a cloaked model with a 1M window

### DIFF
--- a/crates/warpllm/src/registry/mod.rs
+++ b/crates/warpllm/src/registry/mod.rs
@@ -414,6 +414,7 @@ mod tests {
                 "openrouter/moonshotai/kimi-k2.7-code",
                 "openrouter/moonshotai/kimi-k3",
                 "openrouter/openai/gpt-5.6",
+                "openrouter/stealth/ox-alpha",
                 "openrouter/~deepseek/deepseek-v4-flash-latest",
             ]
         );

--- a/crates/warpllm/src/registry/specs.yaml
+++ b/crates/warpllm/src/registry/specs.yaml
@@ -793,6 +793,28 @@ providers:
         capabilities:
           max_input_tokens: 1050000
           max_output_tokens: 128000
+      # Checked 2026-08-24: a CLOAKED model — OpenRouter serves it under the
+      # `stealth/` vendor and names no lab behind it, so there is no upstream
+      # model page to check this entry against and the usual second source
+      # does not exist. One endpoint, whose own name is "Stealth": 1,048,576
+      # context and 131,072 max output, and being alone it is trivially the
+      # narrowest. Free while it is cloaked, which is what a cloak is for.
+      #
+      # Expect this one to be REMOVED rather than deprecated. A cloak ends
+      # when the lab announces the weights, and the slug is withdrawn on the
+      # day rather than carrying a date anyone can read ahead of time —
+      # OpenRouter's `expiration_date` for it is the year 2098, a placeholder,
+      # so `deprecation_date` is deliberately absent here. Nothing to do until
+      # it 404s, at which point the remedy is deleting these lines.
+      # <https://openrouter.ai/stealth/ox-alpha>
+      openrouter/stealth/ox-alpha:
+        supported_apis:
+          - {api: openai_compat_chat_completions}
+          - {api: openai_compat_chat_completions_stream}
+        model: stealth/ox-alpha
+        capabilities:
+          max_input_tokens: 1048576
+          max_output_tokens: 131072
       # Checked 2026-08-09: the `~deepseek/…-latest` alias, always the newest
       # DeepSeek V4 Flash revision — 1,048,576 context, which every member of
       # the family shares, so the alias cannot resolve to something narrower.

--- a/crates/warpllm/tests/providers/openrouter/chat_completions/mod.rs
+++ b/crates/warpllm/tests/providers/openrouter/chat_completions/mod.rs
@@ -141,6 +141,34 @@ fn openrouter_errors_name_openrouter() {
     });
 }
 
+/// A cloaked slug routes like any other. `stealth/` is a vendor to OpenRouter
+/// and nothing special to warpllm — the roster's `model:` ships both segments,
+/// and the anonymity is the provider's business, not the gateway's.
+#[test]
+fn openrouter_routes_a_cloaked_slug() {
+    with_openrouter_key(async {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("authorization", format!("Bearer {OPENROUTER_KEY}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(openrouter_completion_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let completion = client_for(&server)
+            .chat_completions(request("openrouter/stealth/ox-alpha"))
+            .await
+            .unwrap();
+
+        assert_eq!(completion.model, "openrouter/stealth/ox-alpha");
+
+        let sent: serde_json::Value =
+            serde_json::from_slice(&server.received_requests().await.unwrap()[0].body).unwrap();
+        assert_eq!(sent["model"], "stealth/ox-alpha");
+    });
+}
+
 /// OpenRouter is an aggregator, so its roster keys carry a vendor prefix that
 /// the direct providers do not. The registry is closed either way: an
 /// unlisted slug is an error before any request, and a bare model name under

--- a/docs/snippets/model-roster.mdx
+++ b/docs/snippets/model-roster.mdx
@@ -95,4 +95,5 @@ Base URL `https://openrouter.ai/api/v1` &middot; API key `OPENROUTER_API_KEY`
 | `openrouter/moonshotai/kimi-k2.7-code` | `moonshotai/kimi-k2.7-code` | 256,000 | — | Yes |
 | `openrouter/moonshotai/kimi-k3` | `moonshotai/kimi-k3` | 974,842 | — | Yes |
 | `openrouter/openai/gpt-5.6` | `openai/gpt-5.6` | 1,050,000 | 128,000 | Yes |
+| `openrouter/stealth/ox-alpha` | `stealth/ox-alpha` | 1,048,576 | 131,072 | Yes |
 | `openrouter/~deepseek/deepseek-v4-flash-latest` | `~deepseek/deepseek-v4-flash-latest` | 1,048,576 | — | Yes |


### PR DESCRIPTION
Closes #81.

Adds one routable model: `openrouter/stealth/ox-alpha` → `stealth/ox-alpha`,
1,048,576 in / 131,072 out, both chat-completions surfaces.

## What was checked, and against what

The `openrouter:` header asks for limits from
`/api/v1/models/<slug>/endpoints`, recording the **narrowest** any endpoint
offers. Checked 2026-08-24, this slug has exactly one endpoint — provider name
`Stealth`, `context_length` 1048576, `max_completion_tokens` 131072 — so the
narrowest is trivially those two numbers. No `max_concurrent_requests`:
OpenRouter publishes per-key account limits, not per-slug ceilings.

The `model:` field is set to the full two-segment slug, as every entry in this
block does. Without it the key's last-segment default would send `ox-alpha`
upstream, which is not a model OpenRouter knows. `openrouter_routes_a_cloaked_slug`
is the test that would fail if that line were dropped.

## Two things this entry does differently, both deliberate

**No upstream model page in the comment.** Every other entry cites the lab's
own page alongside OpenRouter's. A cloaked model has no lab named against it,
so that second source doesn't exist — the comment says this outright rather
than leaving a reader to wonder whether the citation was just forgotten.

**No `deprecation_date`, and the comment explains why rather than staying
silent.** The header is explicit that an absent date "means nothing is
scheduled, never that the model is permanent," and here the distinction earns
its keep: this is the entry most likely to outlive its slug. Cloaks end by
withdrawal on announcement day — the Quasar Alpha / Optimus Alpha pattern — not
on a schedule published in advance. OpenRouter's `expiration_date` for it is
`2098-12-31`, a placeholder, so any date recorded here would be invented rather
than sourced. The comment states the expected end state (removed, not
deprecated) and that the remedy is deleting the lines, so whoever meets the
first 404 spends seconds on it instead of reconstructing why it was ever added.

That is the tradeoff this PR is asking for a decision on, and #81 argues it at
length: `specs.yaml` is `include_str!`'d into the binary, so a withdrawn slug
is a dead route in a shipped release. The failure is one entry returning an
upstream 404 — loud, contained, and not a broken client — against the cost of
a gateway that can't reach the model people are actually reaching for right
now.

## Not touched

`opencode:`. Zen's `GET /zen/v1/models` (64 models, checked 2026-08-24) does
not serve Ox Alpha, so there is nothing to register there.

`examples/.env.example` already carries `OPENROUTER_API_KEY` — this adds a
model to an existing provider, not a provider.

## Verification

```
cargo fmt --all --check                              clean
cargo clippy --workspace --all-targets -- -D warnings clean
cargo test --workspace                               554 passed, 2 ignored
uv run --with pyyaml docs/scripts/gen_model_roster.py --check   clean
```

`docs/snippets/model-roster.mdx` is regenerated, not hand-edited. The roster
list in `registry/mod.rs` and the byte-order lint both cover the new key —
`stealth` sorts after `openai` and before `~deepseek`, which is why it lands
where it does.
