### PR TITLE
ci: report mutants findings instead of failing the weekly job

### DIFF
--- a/.github/workflows/cron-weekly-cargo-mutants.yml
+++ b/.github/workflows/cron-weekly-cargo-mutants.yml
@@ -4,8 +4,11 @@
 # Mutates the core warpllm crate only — binding crates (Python/Node) are
 # thin FFI wrappers where mutations produce meaningless survivors.
 #
-# When survived mutants are found, a GitHub issue is created listing the
-# first 10. If no mutants survived, the job stays silent (no issue filed).
+# When mutants survive or time out, they are reported onto a single standing
+# "New Mutants Found" issue, edited in place each week. A comment — the part
+# that pages everyone watching — is added only when the findings themselves
+# change. If the run is clean, the job stays silent (no issue filed).
+# Findings do not fail the job; only a broken tool or a failing baseline does.
 # Full results are uploaded as an artifact for deep investigation.
 name: Weekly cargo-mutants
 on:
@@ -45,7 +48,30 @@ jobs:
       #   RNG even when the code and tests haven't changed.
       # -p warpllm: scope to the core crate only. Binding crates are
       #   thin FFI shells where mutations produce false survivors.
-      - run: cargo mutants --in-place --no-shuffle -p warpllm
+      #
+      # cargo-mutants exit codes: 0 all caught, 1 usage error, 2 mutants
+      # survived, 3 a mutant timed out, 4 the unmutated baseline already
+      # fails, 5+ internal error. 2 and 3 are findings, not breakage — the
+      # report step below files them as an issue, so they must not turn the
+      # job red. A weekly cron that is permanently red carries no signal:
+      # it cannot distinguish "same survivors as last week" from "the tool
+      # or the baseline is broken", which is what the other codes mean.
+      - name: Run cargo-mutants
+        run: |
+          status=0
+          cargo mutants --in-place --no-shuffle -p warpllm || status=$?
+          case "$status" in
+            0)
+              echo "All mutants caught"
+              ;;
+            2 | 3)
+              echo "cargo-mutants exited $status; the report step files the findings"
+              ;;
+            *)
+              echo "::error::cargo-mutants failed with exit code $status"
+              exit "$status"
+              ;;
+          esac
 
       # Upload the full mutants.out directory (missed.txt, caught.txt,
       # timeout.txt, unviable.txt). if: always() ensures the artifact is
@@ -58,28 +84,75 @@ jobs:
           name: mutants.out
           path: mutants.out
 
-      # Gate on missed.txt: -s checks file exists AND is non-empty.
-      # When no mutants survived, the job completes silently — no issue
-      # filed, no noise in the tracker.
-      - name: Check for new mutants
-        if: always()
-        run: |
-          if [ -s mutants.out/missed.txt ]; then
-            echo "New missed mutants found"
-            MUTANTS_VERSION=$(cargo mutants --version)
-            gh issue create \
-              --title "New Mutants Found" \
-              --body "$(cat <<EOF
-          Displaying up to the first 10 mutants:
-          \`\`\`
-          $(head -n 10 mutants.out/missed.txt)
-          \`\`\`
-          Running cargo mutants version: ${MUTANTS_VERSION}
-          For the complete list, please check the [mutants.out artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
-          EOF
-          )"
-          else
-            echo "No new mutants found"
-          fi
+      # Gate on missed.txt and timeout.txt: -s checks the file exists AND
+      # is non-empty. When nothing survived and nothing hung, the job
+      # completes silently — no issue filed, no noise in the tracker.
+      # A timeout is a finding too: it means the mutant ran until the limit,
+      # usually an infinite loop no test asserted its way out of.
+      #
+      # !cancelled() rather than always(): reporting on a failed run is the
+      # point, but cargo-mutants writes missed.txt as it goes, so a cancelled
+      # run holds a partial list that would be posted as if it were the total.
+      - name: Report surviving mutants
+        if: ${{ !cancelled() }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TITLE: New Mutants Found
+        run: |
+          if [ ! -s mutants.out/missed.txt ] && [ ! -s mutants.out/timeout.txt ]; then
+            echo "No surviving or timed-out mutants found"
+            exit 0
+          fi
+
+          # The findings alone, kept apart from the run-specific provenance
+          # below so that a digest of them is stable across identical weeks.
+          findings="$RUNNER_TEMP/findings.md"
+          body="$RUNNER_TEMP/body.md"
+          {
+            if [ -s mutants.out/missed.txt ]; then
+              echo "Surviving mutants ($(wc -l < mutants.out/missed.txt | tr -d " ") total), showing up to 10:"
+              echo '```'
+              head -n 10 mutants.out/missed.txt
+              echo '```'
+            fi
+            if [ -s mutants.out/timeout.txt ]; then
+              echo "Timed-out mutants ($(wc -l < mutants.out/timeout.txt | tr -d " ") total), showing up to 10 — usually an infinite loop:"
+              echo '```'
+              head -n 10 mutants.out/timeout.txt
+              echo '```'
+            fi
+          } > "$findings"
+
+          digest=$(sha256sum "$findings" | cut -d " " -f 1)
+          {
+            cat "$findings"
+            echo "Running $(cargo mutants --version). For the complete list, see the [mutants.out artifact]($RUN_URL)."
+            echo "<!-- findings-digest: $digest -->"
+          } > "$body"
+
+          # One standing tracking issue, edited in place, rather than a
+          # near-duplicate every Sunday. --search scopes the lookup by title
+          # so finding it does not depend on how many issues are open; the
+          # select is the exact match, since search is fuzzy.
+          existing=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number,title \
+            --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
+          if [ -z "$existing" ]; then
+            gh issue create --title "$TITLE" --body-file "$body"
+            exit 0
+          fi
+
+          previous=$(gh issue view "$existing" --json body --jq ".body" \
+            | sed -n "s/.*findings-digest: \([0-9a-f]*\).*/\1/p")
+          gh issue edit "$existing" --body-file "$body"
+
+          # Editing is silent, so a week that finds the same blind spots
+          # refreshes the issue without paging everyone watching it. Comment
+          # only when the findings themselves moved, which is the event
+          # worth interrupting someone for.
+          if [ "$digest" != "$previous" ]; then
+            gh issue comment "$existing" \
+              --body "The mutants list changed in [this run]($RUN_URL); the issue body above is up to date."
+          else
+            echo "Findings unchanged since the last report; issue #$existing refreshed silently"
+          fi


### PR DESCRIPTION
Fixes the first scheduled run of the weekly mutation job, [run 33286709564](https://github.com/warpllm/warpllm/actions/runs/33286709564), which went red.

## What actually failed

The job failed at `cargo mutants` with **exit code 3**. In cargo-mutants that code is `Timeout`, not "mutants survived" — 9 mutants hung, all of them in the SSE buffering loops (`SseFrames::next_payload`, `SseFrames::take_line`, `EventStream::buffer_more`, `ChunkStream::buffer_more`, and the `delete !` mutants in both `post_stream`s). Mutating a `buffer_more` to `Ok(true)` is an infinite loop by construction, so those will time out on every run.

Fixing the timeouts would not have made the job green either. `LabOutcome::exit_code()` ranks `BaselineFailed(4) > Timeout(3) > FoundProblems(2)`, so the 69 survivors would still have exited 2.

So the job is red on every weekly run, permanently — which is the same as having no signal, because a red run cannot be told apart from a run where the tool broke or the baseline stopped compiling. The reporting the workflow was built for worked correctly: #89 was filed as designed.

## What this changes

**Dispatch on the exit code.** 0, 2 and 3 are outcomes the report step handles; 1 (usage), 4 (baseline already failing) and 5+ (internal error) still fail the job loudly with a `::error::` annotation. Those are the codes that mean something is broken rather than found.

**Report timeouts too.** Exit 3 was the actual cause of this failure and `timeout.txt` was surfaced nowhere — not in the issue, only in the artifact. A timeout is a finding: the mutant ran to the limit and no test asserted its way out.

**One standing issue, edited in place.** The step was named "Check for new mutants" but compared against nothing, so it would have filed an identical near-duplicate every Sunday — the tracker flooding #86 explicitly wanted to avoid. It now looks up the open `New Mutants Found` issue by title and edits the body. Editing is silent, so an unchanged week refreshes the issue without paging watchers; a comment is posted only when a digest of the findings themselves changes, which is the event worth interrupting someone for.

**`!cancelled()` instead of `always()` on the report step.** cargo-mutants writes `missed.txt` incrementally and the job has no `timeout-minutes`, so a cancelled or 6-hour-capped run holds a partial list. Under `always()` that partial list gets posted as if it were the week's total, with a wrong count and a wrong top-10. Reporting on the failure path — the useful half of `always()` — is kept.

## Verification

The two shell steps were extracted from the YAML and exercised against the real `mutants.out` from run 33286709564:

- exit dispatch: 0 → green "All mutants caught"; 2 and 3 → green, report runs; 1, 4, 101 → step exits with that code
- report step: no standing issue → `issue create`; standing issue with changed findings → `issue edit` + `issue comment`; standing issue with identical findings → `issue edit` only; clean run (both files empty) → silent, rc 0; `gh` failing → step goes red rather than swallowing it
- digest extraction is tolerant of the CRLF line endings GitHub returns in issue bodies
- `wc -l` output is stripped, so the count renders as `(69 total)` rather than padded

`cargo test --workspace` is green (553 passed, 2 ignored); no Rust changed.

## Not in this PR

The 69 survivors and 9 timeouts are real test blind spots, and they stay tracked in #89 rather than being fixed here — this PR is about the reporting channel working. The timeouts in particular are a known cargo-mutants pattern and are probably best handled with `#[mutants::skip]` on the stream-buffering loops, since no timeout increase makes an infinite loop terminate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jm6wXL866CjyaxL18r9hPG
