### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versions follow [semantic versioning](https://semver.org). While the project is
 pre-1.0, a breaking change bumps the MINOR number: `0.1.x` and `0.2.x` are
 incompatible, and `^0.1` will not upgrade you into one.
 
-## [Unreleased]
+## [0.5.0] - 2026-09-02
 
 Point warpllm at your own roster. Self-hosted OpenAI-compatible servers — vLLM,
 TGI, Ollama, llama.cpp — are first-class routable targets, with no fork and no
@@ -86,6 +86,11 @@ pattern would have to claim both on behalf of models nobody enumerated, which is
 the same fails-open claim a bare `{}` entry has always been refused for. If your
 server's model set moves often, generate the file from its own `/v1/models`.
 
+**Also in this release.** Weighted load balancing across a fixed set of models,
+Mistral as a provider, OpenRouter's cloaked `stealth/ox-alpha`, and an explicit
+`null` on `temperature`, `max_tokens` or `top_p` reaching the backend instead of
+being dropped on the way out.
+
 ### Added
 
 - `ClientConfig::specs_path`, `WarpLLM(specs_path=…)` in Python,
@@ -108,6 +113,46 @@ server's model set moves often, generate the file from its own `/v1/models`.
 - `examples/warpllm.yaml` and `examples/self_hosted.{rs,py,ts}`, plus
   `tests/live_self_hosted.rs` — an opt-in test against a real server, since a
   mock cannot prove that a real backend's replies decode.
+- **`BalancedClient`, weighted load balancing across a fixed set of models.**
+  Built from a `&Client` and a list of `(model_str, weight)` pairs; its
+  `chat_completions` and `chat_completions_stream` pick a candidate, write it
+  onto the request, and hand it to the inner client — so the same four gates
+  that validate an ordinary request validate a balanced one, and a candidate
+  that is not on that client's roster fails when the balancer is built rather
+  than at the request that happened to land on it.
+
+  ```rust
+  let balanced = BalancedClient::new(&client, &[
+      ("openai/gpt-5.6", 3),
+      ("deepseek/deepseek-v4-pro", 1),
+  ])?;
+  ```
+
+  Selection is Nginx's smooth weighted round-robin: exact distribution over each
+  cycle, with one candidate's turns spread through the cycle rather than
+  arriving in a run. The whole of the state is one `AtomicI32` per candidate and
+  the candidate set is fixed at construction, so nothing here grows at runtime.
+  Two threads racing may select the same candidate — one extra request to a
+  provider that was due one anyway — and the cycle's distribution still holds.
+
+  **Rust only.** Neither binding exposes it yet.
+- **Mistral**, a new `mistral` provider at `api.mistral.ai/v1` with
+  `MISTRAL_API_KEY`, serving four models: `codestral-2501`, `ministral-8b-2410`,
+  `mistral-large-2411` and `pixtral-large-2411`. Dated versions rather than the
+  floating `-latest` aliases, so a model string on the roster keeps naming the
+  weights it was checked against.
+
+  No `max_output_tokens` on any of the four: Mistral documents no fixed ceiling,
+  only a shared `prompt_tokens + max_tokens <= context_window` budget, and a
+  number invented for the field would be a promise the provider never made.
+- `openrouter/stealth/ox-alpha`, a cloaked model with a 1M window — 1,048,576
+  in, 131,072 out, served by the single `Stealth` endpoint. No lab is named
+  behind it, so the upstream model page a roster entry is normally checked
+  against does not exist for this one; the endpoint list is what can be checked,
+  and it is what the entry records. It carries no `deprecation_date` on purpose:
+  a cloak ends by withdrawal on announcement day rather than on a published
+  schedule, and OpenRouter's own `expiration_date` for it is the year 2098, a
+  placeholder. When the slug 404s, the remedy is deleting the entry.
 
 ### Fixed
 
@@ -140,6 +185,20 @@ server's model set moves often, generate the file from its own `/v1/models`.
   No other provider reclassifies: nothing on the roster mapped a `type` of its
   own, so every existing failure resolves exactly as before. `ErrorMapper` is
   internal, so no package's API changes.
+
+- **An explicit `null` on `temperature`, `max_tokens` or `top_p` was dropped.**
+  A caller sending `{"temperature": null}` had it forwarded as `{}`, on every
+  OpenAI-compatible backend that reads a null differently from an absence.
+  OpenAI documents all three as nullable, so the distinction was the caller's
+  to make and warpllm was erasing it.
+
+  The three read as three states now — absent, null, a value — the way `stop`,
+  `stream_options` and `reasoning_effort` already did, and the arrived value is
+  retained under `ext["openai_compat"]` so a same-protocol round trip renders
+  the null back out. The gateway IR stays a plain `Option<T>`: to a renderer for
+  another protocol a null and an absence are the same thing, and only the
+  same-protocol residue carries the difference, which is what it is for.
+  Fixes #51.
 
 - A provider taking no credential was **unreachable**, not merely unsupported.
   `env_api_key` has always been optional, but such a provider was skipped when
@@ -568,6 +627,8 @@ environment is not supported. The OpenAI-compatible HTTP gateway
 Early SDK releases serving OpenAI chat completions only, before the provider
 registry existed. See the [release tags](https://github.com/warpllm/warpllm/tags).
 
+[0.5.0]: https://github.com/warpllm/warpllm/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/warpllm/warpllm/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/warpllm/warpllm/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/warpllm/warpllm/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/warpllm/warpllm/compare/v0.1.4...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2050,7 +2050,7 @@ dependencies = [
 
 [[package]]
 name = "warpllm"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "proptest",
@@ -2071,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "warpllm-codegen"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "schemars",
  "serde_json",
@@ -2081,7 +2081,7 @@ dependencies = [
 
 [[package]]
 name = "warpllm-node"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "warpllm-python"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "warpllm-server"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.85"

--- a/README.md
+++ b/README.md
@@ -214,28 +214,32 @@ This project is to lay out the most resilient open source productionization laye
 ## Status
 
 > [!IMPORTANT]
-> The published packages are **0.4.0**, which adds the OpenCode Zen provider
-> and lets a client declare the providers it serves. It is **source-breaking
-> for Rust only**: `ClientConfig` gained a field, so an exhaustive struct
-> literal no longer compiles — add `providers: None`, or switch to
-> `..Default::default()`. Python and TypeScript are purely additive. See the
-> [changelog](CHANGELOG.md) before upgrading from `0.3.x`.
+> The published packages are **0.5.0**, which lets a client bring its own
+> roster file — so a self-hosted OpenAI-compatible server is a routable target
+> without forking the crate — and adds weighted load balancing (Rust only) and
+> Mistral. It is **source-breaking for Rust only**: `ClientConfig` gained a
+> field, so an exhaustive struct literal no longer compiles — add
+> `specs_path: None`, or switch to `..Default::default()`. Python and
+> TypeScript are purely additive. See the [changelog](CHANGELOG.md) before
+> upgrading from `0.4.x`.
 >
 > The OpenAI-compatible HTTP gateway has landed on `main` but is **not
 > released yet**.
 
-| | Released (0.4.0) | On `main` |
+| | Released (0.5.0) | On `main` |
 | --- | --- | --- |
 | OpenAI chat completions, non-streaming | Yes | Yes |
 | `provider/model` routing strings | Provider registry | Provider registry |
 | DeepSeek, OpenRouter | Yes | Yes |
 | Kimi | Yes | Yes |
+| Mistral | Yes | Yes |
 | OpenCode Zen | Yes | Yes |
 | Declaring the providers a client serves | Yes | Yes |
-| Self-hosted models via your own roster file | — | Unreleased |
+| Self-hosted models via your own roster file | Yes | Yes |
 | OpenAI-compatible HTTP gateway | — | Unreleased |
 | Streaming | Yes | Yes |
-| Failover, load balancing, caching, metrics | — | — |
+| Weighted load balancing | Rust only | Rust only |
+| Failover, caching, metrics | — | — |
 
 Unlisted models are rejected rather than guessed at, so routing a name warpllm
 doesn't know is an error, not a surprise upstream bill.

--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-android-arm64')
         const bindingPackageVersion = require('@warpllm/warpllm-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-android-arm-eabi')
         const bindingPackageVersion = require('@warpllm/warpllm-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-win32-x64-gnu')
         const bindingPackageVersion = require('@warpllm/warpllm-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-win32-x64-msvc')
         const bindingPackageVersion = require('@warpllm/warpllm-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-win32-ia32-msvc')
         const bindingPackageVersion = require('@warpllm/warpllm-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-win32-arm64-msvc')
         const bindingPackageVersion = require('@warpllm/warpllm-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@warpllm/warpllm-darwin-universal')
       const bindingPackageVersion = require('@warpllm/warpllm-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-darwin-x64')
         const bindingPackageVersion = require('@warpllm/warpllm-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-darwin-arm64')
         const bindingPackageVersion = require('@warpllm/warpllm-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-freebsd-x64')
         const bindingPackageVersion = require('@warpllm/warpllm-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-freebsd-arm64')
         const bindingPackageVersion = require('@warpllm/warpllm-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-x64-musl')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-x64-gnu')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-arm64-musl')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-arm64-gnu')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-arm-musleabihf')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-loong64-musl')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-loong64-gnu')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-riscv64-musl')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@warpllm/warpllm-linux-riscv64-gnu')
           const bindingPackageVersion = require('@warpllm/warpllm-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-linux-ppc64-gnu')
         const bindingPackageVersion = require('@warpllm/warpllm-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-linux-s390x-gnu')
         const bindingPackageVersion = require('@warpllm/warpllm-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-openharmony-arm64')
         const bindingPackageVersion = require('@warpllm/warpllm-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-openharmony-x64')
         const bindingPackageVersion = require('@warpllm/warpllm-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@warpllm/warpllm-openharmony-arm')
         const bindingPackageVersion = require('@warpllm/warpllm-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@warpllm/warpllm",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@warpllm/warpllm",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.7",

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@warpllm/warpllm",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A warp-speed, robust AI gateway",
   "license": "Apache-2.0",
   "repository": {

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "warpllm gateway",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "The OpenAI-compatible HTTP surface of a self-hosted warpllm gateway. Model strings are `provider/model`; the prefix is required. The gateway authenticates upstream with its own provider keys from the environment and ignores the caller's Authorization header.",
     "license": {
       "name": "Apache-2.0",
@@ -164,7 +164,7 @@
                     "version": {
                       "type": "string",
                       "description": "The warpllm version this gateway was built from.",
-                      "examples": ["0.4.0"]
+                      "examples": ["0.5.0"]
                     }
                   }
                 }

--- a/docs/concepts/requests-and-responses.mdx
+++ b/docs/concepts/requests-and-responses.mdx
@@ -159,8 +159,9 @@ await client.chatCompletions({
   ```
 
   <Note>
-    `temperature`, `max_tokens`, and `top_p` gained the nested shape after
-    0.4.0. On 0.4.0 they are plain `Option<_>` — write `Some(0.2)` there.
+    `temperature`, `max_tokens`, and `top_p` gained the nested shape in
+    0.5.0. On 0.4.0 and earlier they are plain `Option<_>` — write `Some(0.2)`
+    there.
     Python and TypeScript are unaffected either way.
   </Note>
 </Tip>

--- a/docs/gateway/run.mdx
+++ b/docs/gateway/run.mdx
@@ -43,7 +43,7 @@ non-root user.
     ```
 
     ```json
-    { "status": "ok", "version": "0.4.0" }
+    { "status": "ok", "version": "0.5.0" }
     ```
   </Step>
 </Steps>

--- a/docs/get-started/installation.mdx
+++ b/docs/get-started/installation.mdx
@@ -20,7 +20,7 @@ are building from source.
 | Node | `@warpllm/warpllm` | [npm](https://www.npmjs.com/package/@warpllm/warpllm) | Node 20 |
 | Rust | `warpllm` | [crates.io](https://crates.io/crates/warpllm) | Rust 1.85 (edition 2024) |
 
-The published version of all three is **0.4.0**.
+The published version of all three is **0.5.0**.
 
 ## Platform support
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -46,7 +46,7 @@ of it.
 
 ## What ships today
 
-The published packages are **0.4.0**. warpllm is early, and this table is the
+The published packages are **0.5.0**. warpllm is early, and this table is the
 honest version of what you can build on.
 
 | Capability | Status |
@@ -54,12 +54,12 @@ honest version of what you can build on.
 | Chat completions, non-streaming | Released |
 | Chat completions, streaming | Released |
 | `provider/model` routing strings | Released |
-| OpenAI, DeepSeek, Kimi, OpenRouter, OpenCode Zen | Released |
+| OpenAI, DeepSeek, Kimi, OpenRouter, OpenCode Zen, Mistral | Released |
 | Declaring the providers a client serves | Released |
 | Normalized error taxonomy | Released |
-| Mistral | On `main`, unreleased |
+| Bringing your own roster file | Released |
+| Weighted load balancing (Rust only) | Released |
 | OpenAI-compatible HTTP gateway | On `main`, unreleased |
-| Weighted load balancing (Rust only) | On `main`, unreleased |
 | Anthropic's Messages protocol | On `main`, not yet routable |
 | Claude direct on `api.anthropic.com` | Not yet — [#23](https://github.com/warpllm/warpllm/issues/23) |
 | Failover, retries, caching, metrics | Planned |
@@ -73,12 +73,12 @@ honest version of what you can build on.
 </Note>
 
 <Info>
-  0.4.0 is **source-breaking for Rust only**: `ClientConfig` gained a
-  `providers` field, so an exhaustive struct literal no longer compiles — add
-  `providers: None`, or switch to `..Default::default()`. Python and TypeScript
-  are purely additive. Read the
+  0.5.0 is **source-breaking for Rust only**: `ClientConfig` gained a
+  `specs_path` field, so an exhaustive struct literal no longer compiles — add
+  `specs_path: None`, or switch to `..Default::default()`. Python and
+  TypeScript are purely additive. Read the
   [changelog](https://github.com/warpllm/warpllm/blob/main/CHANGELOG.md) before
-  upgrading from `0.3.x`.
+  upgrading from `0.4.x`.
 </Info>
 
 ## Design decisions worth knowing up front

--- a/docs/sdk/reference.mdx
+++ b/docs/sdk/reference.mdx
@@ -58,11 +58,13 @@ not reimplementations — so behaviour cannot drift between them.
         timeout=None,              # seconds; total deadline. Default 600
         stream_read_timeout=None,  # seconds; longest silence on a stream
         providers=None,            # narrow this client to named providers
+        specs_path=None,           # a roster file of your own, merged over the
+                                   # built-in one; also WARPLLM_SPECS
     )
     ```
 
-    All four parameters are keyword-only and optional. `AsyncWarpLLM` takes the
-    same four.
+    All five parameters are keyword-only and optional. `AsyncWarpLLM` takes the
+    same five.
   </Tab>
 
   <Tab title="TypeScript">
@@ -74,6 +76,8 @@ not reimplementations — so behaviour cannot drift between them.
       timeout: undefined,           // SECONDS; total deadline. Default 600
       streamReadTimeout: undefined, // SECONDS; longest silence on a stream
       providers: undefined,         // narrow this client to named providers
+      specsPath: undefined,         // a roster file of your own, merged over
+                                    // the built-in one; also WARPLLM_SPECS
     })
     ```
 
@@ -94,6 +98,7 @@ not reimplementations — so behaviour cannot drift between them.
     ```rust
     pub struct ClientConfig {
         pub base_url: Option<String>,
+        pub specs_path: Option<PathBuf>,
         pub timeout_secs: Option<u64>,
         pub stream_read_timeout_secs: Option<u64>,
         pub providers: Option<BTreeMap<String, ProviderConfig>>,
@@ -101,9 +106,10 @@ not reimplementations — so behaviour cannot drift between them.
     ```
 
     <Note>
-      `ClientConfig` is `Default`, and it gained `providers` in 0.4.0 — an
-      exhaustive struct literal from 0.3.x no longer compiles. Add
-      `providers: None`, or use `..Default::default()`.
+      `ClientConfig` is `Default`, and it has gained a field in each of the
+      last two releases — `providers` in 0.4.0, `specs_path` in 0.5.0 — so an
+      exhaustive struct literal from either no longer compiles. Add the missing
+      field as `None`, or use `..Default::default()` and stop having to.
     </Note>
   </Tab>
 </Tabs>
@@ -707,7 +713,7 @@ provider omitted from one it sent as `null`.
     ```python
     import warpllm
 
-    warpllm.__version__   # "0.4.0"
+    warpllm.__version__   # "0.5.0"
     warpllm.version()     # the same string, from the native binary
     ```
   </Tab>
@@ -716,13 +722,13 @@ provider omitted from one it sent as `null`.
     ```ts
     import { version } from '@warpllm/warpllm'
 
-    console.log(version()) // "0.4.0"
+    console.log(version()) // "0.5.0"
     ```
   </Tab>
 
   <Tab title="Rust">
     ```rust
-    println!("{}", warpllm::version()); // "0.4.0"
+    println!("{}", warpllm::version()); // "0.5.0"
     ```
 
     warpllm emits through [`tracing`](https://docs.rs/tracing) and installs no


### PR DESCRIPTION
Cuts **0.5.0** — the version-lockstep gate in all three release workflows is satisfied (`Cargo.toml` = `bindings/node/package.json` = `0.5.0`), so a `v0.5.0` tag on the merge commit will publish to crates.io, PyPI, and npm.

## Why MINOR

`ClientConfig` gained `specs_path` and carries no `#[non_exhaustive]`, so a downstream exhaustive struct literal stops compiling. Rust-only, one line to fix. Pre-1.0 this project bumps MINOR for a break.

## The changelog was two-eighths complete

`[Unreleased]` covered the roster file (#70) and Zen's credit exhaustion (#75). Four merged, user-facing changes had no entry and are written up here rather than shipped silently:

- **`BalancedClient`** — smooth weighted round-robin (#71). Rust only; the bindings PR (#79) is still open.
- **Mistral** — new provider, four dated models (#59).
- **`openrouter/stealth/ox-alpha`** — cloaked 1M-context model (#82).
- **Explicit `null` on `temperature` / `max_tokens` / `top_p`** was dropped on the way out (#73, fixes #51).

Deliberately not written up: the Anthropic stream reader (#68, #77) and the OAuth `TokenProvider` (#72, #83). Nothing dispatches to either yet — both are `#[allow(dead_code)]` or unreachable from `Client`.

This overlaps #80, which drafted the load-balancing entry and never landed. #80 can be closed in favour of this.

## Docs

README and the docs site carried version claims this release makes wrong, so they move with it. The `ClientConfig` listings in `docs/sdk/reference.mdx` had also never been told about `specs_path` — fixed in all three language tabs.

**Known gap, not closed here:** the docs site still has no page for the roster file itself — no `WARPLLM_SPECS`, no `auth: none`, no `--specs`, no self-hosting guide. That is the headline feature of this release going out with a changelog entry and nothing else.

## Verification

`./scripts/test-all.sh` passes — fmt, clippy `-D warnings`, the Rust workspace, the Node suite, 35 Python tests, and the generated-types staleness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jm6wXL866CjyaxL18r9hPG