### PR TITLE
Narrow the thinking refusal, document the refused controls, carry Claude's thinking back

### DIFF
--- a/crates/warpllm/src/gateway/anthropic/api/messages/request.rs
+++ b/crates/warpllm/src/gateway/anthropic/api/messages/request.rs
@@ -472,6 +472,36 @@ fn arrived_on_this_protocol(request: &types::ChatRequest) -> bool {
         .is_some_and(|source| source.protocol == Protocol::Anthropic)
 }
 
+/// Whether the conversation already restates an assistant turn that Anthropic
+/// would demand a `thinking` block in front of.
+///
+/// That turn is the one a thinking tool loop actually breaks on. Anthropic
+/// requires the assistant message carrying a `tool_use` to OPEN with its own
+/// signed thinking block, and a caller translated onto this protocol was handed
+/// none to put there — so the request restating that turn cannot be built,
+/// whatever warpllm does with it.
+///
+/// A first request holds no such turn and is not refused: it is an ordinary
+/// single-turn tool call, it goes out whole and comes back whole.
+///
+/// A message that DOES carry reasoning is left alone. Nothing on chat
+/// completions produces one today, but the question this asks is whether the
+/// block is missing, and a caller who somehow has one is not the caller this
+/// refusal is about.
+fn holds_an_unsigned_tool_turn(request: &types::ChatRequest) -> bool {
+    request.messages.iter().any(|message| {
+        message.role == Role::Assistant
+            && message
+                .content
+                .iter()
+                .any(|block| matches!(block, ContentBlock::ToolCall { .. }))
+            && !message
+                .content
+                .iter()
+                .any(|block| matches!(block, ContentBlock::Reasoning { .. }))
+    })
+}
+
 /// Whether this request turns extended thinking ON.
 ///
 /// Asked once so that a refusal cannot disagree with what would actually be
@@ -517,27 +547,34 @@ fn ensure_renderable(request: &types::ChatRequest) -> Result<()> {
     // correctly denies it the `anthropic` bag the signature was retained in, so
     // nothing a caller can echo ever reaches them.
     //
-    // Which means the conversation cannot COMPLETE. The first exchange looks
-    // fine and answers with tool calls; the request carrying the results back
-    // has no thinking block to put before them and Anthropic rejects it. So the
-    // refusal is here, at the first request, rather than at the second: a
-    // caller told now loses only a turn they could not have used, and a caller
-    // told later has already built the loop around it.
+    // So the SECOND request of a tool loop cannot be built. Anthropic answers
+    // the first with thinking and a tool_use, the caller reads tool_calls and
+    // sends the results back, and that request has to restate the assistant
+    // turn -- now a tool_use with no thinking in front of it.
+    //
+    // Refused there and not before, because the first request is not broken:
+    // it goes out whole, it comes back whole, and a single-turn tool call is a
+    // real thing to want. Refusing it too would take away a case that works to
+    // make the failure of a different case arrive sooner.
     //
     // The counterpart comment in `openai_compat::…::response` records the other
     // half of this and says dropping silently is the one option not available.
-    // This is that promise being kept. Carrying the blocks in a caller-visible,
-    // round-trippable form is the larger fix that would lift the refusal.
+    // This is that promise being kept: the caller is told, in the request that
+    // is actually unbuildable, instead of reading Anthropic's 400 for it.
+    // Carrying the blocks in a caller-visible, round-trippable form is the
+    // larger fix that would lift the refusal entirely.
     //
     // And ONLY for a caller who cannot carry them. A request that ARRIVED on
     // this protocol keeps its signed blocks in the retained residue and hands
     // them straight back untouched, so the loop was never broken for them —
     // refusing it would turn away the one caller this all works for.
-    if !arrived_on_this_protocol(request) && !request.tools.is_empty() && thinks(request) {
+    if !arrived_on_this_protocol(request) && thinks(request) && holds_an_unsigned_tool_turn(request)
+    {
         return Err(Error::NotImplemented(
-            "extended thinking with tools on the anthropic renderer: Anthropic \
-             wants its signed thinking blocks back alongside the tool results \
-             and chat completions has no field to carry them",
+            "extended thinking with a tool result on the anthropic renderer: \
+             Anthropic wants the assistant turn holding a tool call to open \
+             with its own signed thinking block, and chat completions has no \
+             field to carry one back",
         ));
     }
     // Anthropic's base64 source REQUIRES a media type — `application/pdf`,
@@ -1358,18 +1395,18 @@ mod tests {
         );
     }
 
-    /// Thinking and tools cannot round trip on this route, so the pair is
-    /// refused rather than sent.
+    /// The request that CARRIES TOOL RESULTS BACK cannot be built, so it is
+    /// refused rather than sent to collect Anthropic's 400.
     ///
-    /// Anthropic wants the assistant turn holding a `tool_use` to START with
-    /// its own signed `thinking` block, and a chat-completions caller is never
+    /// Anthropic wants the assistant turn holding a `tool_use` to OPEN with its
+    /// own signed `thinking` block, and a chat-completions caller is never
     /// given one to return — the reply renderer drops it and `may_read` denies
-    /// it the bag the signature was kept in. Sent anyway, the FIRST exchange
-    /// succeeds and the second is rejected upstream, which is the shape this
-    /// fixture used to have: it asked for `reasoning_effort` alongside tools
-    /// and asserted the result was a valid Anthropic body. It was not.
+    /// it the bag the signature was kept in. `openai_tool_conversation` is
+    /// exactly that second request: an assistant `tool_calls` turn and the
+    /// results answering it. The fixture used to ask for `reasoning_effort`
+    /// here and assert the render was a valid Anthropic body. It was not.
     #[test]
-    fn thinking_with_tools_is_refused_rather_than_sent_to_be_rejected() {
+    fn a_thinking_tool_result_turn_is_refused_rather_than_sent_to_be_rejected() {
         let mut request = openai_tool_conversation();
         request.reasoning = Some(types::ReasoningConfig {
             effort: Some("medium".into()),
@@ -1392,9 +1429,36 @@ mod tests {
         ));
     }
 
-    /// The refusal is about the PAIR. Tools without thinking is the ordinary
-    /// tool call this whole path exists to serve, and thinking without tools
-    /// has no blocks to hand back, so neither is turned away.
+    /// A FIRST tool request with thinking is not refused, and that is the
+    /// point of scoping the refusal to the turn rather than to the pair.
+    ///
+    /// It holds no assistant turn yet, so there is no `tool_use` missing a
+    /// thinking block in front of it: the request goes out whole and comes
+    /// back whole. A refusal keyed on "tools and thinking together" turned this
+    /// away too, which took a working single-turn tool call off the table to
+    /// make a different request's failure arrive one turn sooner.
+    #[test]
+    fn a_first_tool_request_with_thinking_still_renders() {
+        let mut request = openai_tool_conversation();
+        // Keep the tools and the thinking; drop back to the opening turn.
+        request
+            .messages
+            .retain(|message| message.role == Role::User);
+        request.messages.truncate(1);
+        request.reasoning = Some(types::ReasoningConfig {
+            effort: Some("medium".into()),
+            ..Default::default()
+        });
+
+        let body = rendered(&request);
+        assert_eq!(body["output_config"]["effort"], json!("medium"), "{body}");
+        assert!(body["tools"].is_array(), "{body}");
+    }
+
+    /// The refusal is about the TURN, not about thinking or tools as such.
+    /// Tools without thinking is the ordinary tool call this whole path exists
+    /// to serve, and thinking without tools has no blocks to hand back, so
+    /// neither is turned away.
     #[test]
     fn thinking_and_tools_are_each_fine_alone() {
         assert!(render_request(&openai_tool_conversation(), "anthropic", None).is_ok());
@@ -1402,11 +1466,38 @@ mod tests {
         let mut thinking_only = openai_tool_conversation();
         thinking_only.tools.clear();
         thinking_only.tool_choice = None;
+        // The TURN has to go too, not just the tool declarations. An assistant
+        // turn restating a `tool_use` is what Anthropic wants a thinking block
+        // in front of, and it wants that whether or not this request happens to
+        // declare the tools that produced it.
+        thinking_only
+            .messages
+            .retain(|message| message.role == Role::User);
+        thinking_only.messages.truncate(1);
         thinking_only.reasoning = Some(types::ReasoningConfig {
             effort: Some("medium".into()),
             ..Default::default()
         });
         assert!(render_request(&thinking_only, "anthropic", None).is_ok());
+    }
+
+    /// Clearing `tools` does NOT lift the refusal, which is the same claim from
+    /// the other side. The unbuildable request is the one restating an
+    /// unsigned `tool_use` turn; whether it also re-declares the tools that
+    /// produced that turn is not what Anthropic is checking.
+    #[test]
+    fn dropping_the_tool_declarations_does_not_make_the_turn_buildable() {
+        let mut request = openai_tool_conversation();
+        request.tools.clear();
+        request.tool_choice = None;
+        request.reasoning = Some(types::ReasoningConfig {
+            effort: Some("medium".into()),
+            ..Default::default()
+        });
+        assert!(matches!(
+            render_request(&request, "anthropic", None),
+            Err(Error::NotImplemented(_))
+        ));
     }
 
     /// The refusal is for callers who were TRANSLATED onto this protocol. One

--- a/crates/warpllm/src/gateway/openai_compat/api/chat_completions/response.rs
+++ b/crates/warpllm/src/gateway/openai_compat/api/chat_completions/response.rs
@@ -178,6 +178,27 @@ fn reasoning_block(fields: &UnknownFields) -> Option<ContentBlock> {
     })
 }
 
+/// The part of a reasoning block a caller on this protocol can read.
+///
+/// `reasoning_content` is a string of chain-of-thought, so only the kinds that
+/// ARE that are rendered. An encrypted payload is deliberately not: it is
+/// opaque bytes meant to be replayed to the provider that issued them, and
+/// putting base64 in a field callers print would show them noise and claim it
+/// was the model's thinking. It stays retained for a renderer that can replay
+/// it and reaches this protocol as nothing, which is what it is worth here.
+///
+/// The signature is dropped for a different reason — this protocol has no
+/// field for it — and that drop is what
+/// `anthropic::…::request::ensure_renderable` refuses the tool-result turn
+/// over.
+fn visible_reasoning(detail: &ReasoningDetail) -> Option<&str> {
+    match detail {
+        ReasoningDetail::Text { text, .. } => Some(text.as_str()),
+        ReasoningDetail::Summary { summary } => Some(summary.as_str()),
+        ReasoningDetail::Encrypted { .. } => None,
+    }
+}
+
 /// A plain function call becomes a typed block; anything else — custom
 /// tool calls, or calls carrying unknown fields at either level — passes
 /// through as an `Unknown` block, re-emitted verbatim in array order.
@@ -327,10 +348,12 @@ fn render_message(message: &types::Message, provider: &str) -> ChatCompletionRes
         _ => role_to_wire(message.role).to_string(),
     };
     let mut texts = Vec::new();
+    let mut reasoning = Vec::new();
     let mut tool_calls = Vec::new();
     for block in &message.content {
         match block {
             ContentBlock::Text { text, .. } => texts.push(text.as_str()),
+            ContentBlock::Reasoning { detail, .. } => reasoning.extend(visible_reasoning(detail)),
             ContentBlock::ToolCall {
                 id,
                 name,
@@ -375,16 +398,33 @@ fn render_message(message: &types::Message, provider: &str) -> ChatCompletionRes
             // that restates an unsigned `tool_use` turn — the one carrying tool
             // results back, which is the request this drop makes unbuildable.
             // Not the first request of the loop, which goes out whole and comes
-            // back whole. Dropping silently was the option that was not
-            // available, and it is not what happens. Carrying the blocks in a
-            // caller-visible form that round trips with the signature intact is
-            // still the larger fix, and it is what would lift that refusal.
+            // back whole. Carrying the blocks in a caller-visible form that
+            // round trips WITH THE SIGNATURE intact is still the larger fix,
+            // and it is what would lift that refusal — the reasoning TEXT now
+            // reaches the caller (see `reasoning_content` below), but a
+            // signature has no field on this protocol to survive in.
             _ => {}
         }
     }
     if !tool_calls.is_empty() {
         // Typed tool calls are authoritative over any stashed empty array.
         unknown_fields.remove("tool_calls");
+    }
+    // A caller on this protocol reads reasoning under `reasoning_content`, and
+    // a Claude reply used to arrive with none: the block was dropped here and
+    // `Protocol::may_read` denies this renderer the `anthropic` bag it was
+    // retained in, so thinking a caller paid for was invisible. DeepSeek's
+    // reasoning has always reached them, and nothing about Claude's is
+    // different from where a caller sits.
+    //
+    // What ARRIVED still wins, which keeps the same-protocol path untouched:
+    // this block came out of `reasoning_content`, that field is still in the
+    // residue, and rewriting it from the block would drop a provider's exact
+    // spelling in favour of a reconstruction.
+    if !reasoning.is_empty() {
+        unknown_fields
+            .entry("reasoning_content".to_string())
+            .or_insert_with(|| Value::String(reasoning.join("\n")));
     }
     ChatCompletionResponseMessage {
         // Same-protocol messages carry at most one text block, so the join

--- a/crates/warpllm/src/gateway/openai_compat/api/chat_completions/response.rs
+++ b/crates/warpllm/src/gateway/openai_compat/api/chat_completions/response.rs
@@ -371,12 +371,14 @@ fn render_message(message: &types::Message, provider: &str) -> ChatCompletionRes
             // rejects.
             //
             // Of the two ways out that comment named, the SECOND is taken:
-            // `anthropic::…::request::ensure_renderable` refuses thinking
-            // paired with tools, at the first request rather than the second.
-            // Dropping silently was the option that was not available, and it
-            // is not what happens. Carrying the blocks in a caller-visible form
-            // that round trips with the signature intact is still the larger
-            // fix, and it is what would lift that refusal.
+            // `anthropic::…::request::ensure_renderable` refuses the request
+            // that restates an unsigned `tool_use` turn — the one carrying tool
+            // results back, which is the request this drop makes unbuildable.
+            // Not the first request of the loop, which goes out whole and comes
+            // back whole. Dropping silently was the option that was not
+            // available, and it is not what happens. Carrying the blocks in a
+            // caller-visible form that round trips with the signature intact is
+            // still the larger fix, and it is what would lift that refusal.
             _ => {}
         }
     }

--- a/crates/warpllm/src/gateway/openai_compat/api/chat_completions/stream.rs
+++ b/crates/warpllm/src/gateway/openai_compat/api/chat_completions/stream.rs
@@ -167,9 +167,10 @@ fn ingest_delta(delta: ChatCompletionStreamResponseDelta) -> types::MessageDelta
 ///
 /// PROMOTE BUT RETAIN, exactly as [`super::response`] does it for a whole
 /// reply: the caller leaves `unknown_fields` intact, so the field still rides
-/// `ext["openai_compat"]` and the renderer replays it verbatim. Nothing could
-/// rebuild it from the delta — `render_delta` drops Reasoning, because the
-/// protocol has no field to render it into.
+/// `ext["openai_compat"]` and the renderer replays that copy verbatim, which is
+/// what keeps a same-protocol stream byte-identical. `render_delta` renders the
+/// delta itself only when no such copy exists — a fragment that arrived on
+/// ANOTHER protocol, where this one's bag is unreadable.
 ///
 /// The emptiness rule differs from the whole-reply one deliberately. There, an
 /// empty string means "the provider sent no thinking" and is not promoted.
@@ -398,6 +399,7 @@ fn render_delta(
         _ => delta.role.map(|role| role_to_wire(role).to_string()),
     };
     let mut content = None;
+    let mut reasoning = Vec::new();
     let mut tool_calls = Vec::new();
     for fragment in &delta.content {
         match fragment {
@@ -442,11 +444,19 @@ fn render_delta(
                     tool_calls.push(call);
                 }
             }
-            // A Reasoning fragment was lifted out of `reasoning_content`,
-            // which is still sitting in ext and about to be emitted verbatim —
-            // PROMOTE BUT RETAIN, read from the other end, so dropping it
-            // loses nothing.
-            ContentDelta::Reasoning { .. } => {}
+            // On a same-protocol stream this fragment was lifted OUT of
+            // `reasoning_content`, which is still sitting in ext and about to
+            // be emitted verbatim — PROMOTE BUT RETAIN, read from the other
+            // end, so dropping it there loses nothing. Cross-protocol there is
+            // no such copy: Anthropic's `thinking_delta` retains into the
+            // `anthropic` bag, which `Protocol::may_read` denies this renderer,
+            // and a streamed Claude reply reached callers with its thinking
+            // silently gone while the same reply unstreamed now carries it.
+            //
+            // So it is rendered, and what ARRIVED still wins below — the
+            // same rule `render_message` follows for a whole reply, and what
+            // keeps the same-protocol stream byte-identical.
+            ContentDelta::Reasoning { text, .. } => reasoning.push(text.as_str()),
         }
     }
     // A stashed null only stands in for content nothing else claimed.
@@ -457,6 +467,11 @@ fn render_delta(
     if !tool_calls.is_empty() {
         // Typed fragments are authoritative over any stashed empty array.
         unknown_fields.remove("tool_calls");
+    }
+    if !reasoning.is_empty() {
+        unknown_fields
+            .entry("reasoning_content".to_string())
+            .or_insert_with(|| Value::String(reasoning.concat()));
     }
     ChatCompletionStreamResponseDelta {
         content,

--- a/crates/warpllm/tests/providers/anthropic/messages/mod.rs
+++ b/crates/warpllm/tests/providers/anthropic/messages/mod.rs
@@ -410,6 +410,66 @@ fn forbidding_parallel_tool_calls_reaches_claude() {
     });
 }
 
+/// A first tool request with thinking reaches Claude; the request carrying the
+/// results BACK is refused before the network.
+///
+/// Both halves in one test, because each is what makes the other meaningful. A
+/// refusal keyed on "thinking and tools together" passes the second assertion
+/// and silently takes away the first — a single-turn tool call with thinking,
+/// which works and which the docs promise. Anthropic wants the assistant turn
+/// holding a `tool_use` to open with its own signed `thinking` block, and a
+/// chat-completions caller is handed none, so it is only the turn RESTATING
+/// that tool call that cannot be built.
+#[test]
+fn thinking_survives_the_first_tool_turn_and_stops_at_the_results() {
+    with_anthropic_key(async {
+        let tools = json!([{
+            "type": "function",
+            "function": {"name": "weather", "parameters": {"type": "object"}}
+        }]);
+
+        let (sent, _) = exchange(
+            from_json(json!({
+                "model": "anthropic/claude-opus-5",
+                "messages": [{"role": "user", "content": "weather in SF?"}],
+                "tools": tools,
+                "reasoning_effort": "medium"
+            })),
+            anthropic_message_body(),
+        )
+        .await;
+        assert_eq!(sent["output_config"]["effort"], json!("medium"), "{sent}");
+        assert!(sent["tools"].is_array(), "{sent}");
+
+        // The same conversation one turn on, and now unbuildable.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(anthropic_message_body()))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let err = client_for(&server)
+            .chat_completions(from_json(json!({
+                "model": "anthropic/claude-opus-5",
+                "messages": [
+                    {"role": "user", "content": "weather in SF?"},
+                    {"role": "assistant", "content": null, "tool_calls": [
+                        {"id": "call_a", "type": "function",
+                         "function": {"name": "weather", "arguments": "{}"}}
+                    ]},
+                    {"role": "tool", "tool_call_id": "call_a", "content": "18C"}
+                ],
+                "tools": tools,
+                "reasoning_effort": "medium"
+            })))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, Error::NotImplemented(_)), "{err:?}");
+    });
+}
+
 /// The test the neutral tool path was built for, and the one Responses will
 /// copy. An OpenAI-shaped conversation with tools, an assistant `tool_calls`
 /// turn, and TWO consecutive `role: "tool"` results renders to a valid

--- a/crates/warpllm/tests/providers/anthropic/messages/mod.rs
+++ b/crates/warpllm/tests/providers/anthropic/messages/mod.rs
@@ -410,6 +410,56 @@ fn forbidding_parallel_tool_calls_reaches_claude() {
     });
 }
 
+/// REPRODUCTION: what a caller actually receives when Claude thinks.
+#[test]
+fn claude_thinking_reaches_the_caller_as_reasoning_content() {
+    with_anthropic_key(async {
+        let mut reply = anthropic_message_body();
+        reply["content"] = json!([
+            {"type": "thinking", "thinking": "Counting the letters.", "signature": "sig_abc"},
+            {"type": "text", "text": "Hello there!"}
+        ]);
+
+        let (_, got) = exchange(request("anthropic/claude-opus-5"), reply).await;
+        let message = &got["choices"][0]["message"];
+
+        assert_eq!(message["content"], "Hello there!", "{message}");
+        assert_eq!(
+            message["reasoning_content"], "Counting the letters.",
+            "Claude's thinking never reached the caller: {message}"
+        );
+    });
+}
+
+/// A redacted block is NOT rendered as reasoning.
+///
+/// `redacted_thinking` is an encrypted payload meant to be replayed to the
+/// provider that issued it, not read. Putting its base64 in the field callers
+/// print would show them noise and label it the model's thinking — so it
+/// reaches this protocol as nothing, which is what it is worth here.
+#[test]
+fn a_redacted_thinking_block_is_not_shown_to_the_caller() {
+    with_anthropic_key(async {
+        let mut reply = anthropic_message_body();
+        reply["content"] = json!([
+            {"type": "redacted_thinking", "data": "EncryptedBase64=="},
+            {"type": "text", "text": "Hello there!"}
+        ]);
+
+        let (_, got) = exchange(request("anthropic/claude-opus-5"), reply).await;
+        let message = &got["choices"][0]["message"];
+
+        assert_eq!(message["content"], "Hello there!", "{message}");
+        assert!(message.get("reasoning_content").is_none(), "{message}");
+        assert!(
+            !serde_json::to_string(&got)
+                .unwrap()
+                .contains("EncryptedBase64"),
+            "an opaque payload reached the caller: {got}"
+        );
+    });
+}
+
 /// A first tool request with thinking reaches Claude; the request carrying the
 /// results BACK is refused before the network.
 ///
@@ -609,6 +659,59 @@ const TEXT_THEN_TOOL: &str = concat!(
     r#"data: {"type":"message_stop"}"#,
     "\n\n",
 );
+
+/// A streamed reply that THINKS before it answers.
+const THINKING_THEN_TEXT: &str = concat!(
+    r#"data: {"type":"message_start","message":{"id":"msg_1","type":"message","#,
+    r#""role":"assistant","model":"claude-opus-5","content":[],"#,
+    r#""stop_reason":null,"stop_sequence":null,"#,
+    r#""usage":{"input_tokens":4,"output_tokens":0}}}"#,
+    "\n\n",
+    r#"data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}"#,
+    "\n\n",
+    r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"counting"}}"#,
+    "\n\n",
+    r#"data: {"type":"content_block_stop","index":0}"#,
+    "\n\n",
+    r#"data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}"#,
+    "\n\n",
+    r#"data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"three"}}"#,
+    "\n\n",
+    r#"data: {"type":"content_block_stop","index":1}"#,
+    "\n\n",
+    r#"data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":9}}"#,
+    "\n\n",
+    r#"data: {"type":"message_stop"}"#,
+    "\n\n",
+);
+
+/// A STREAMED Claude reply carries its thinking to the caller too.
+///
+/// The same drop as the whole-reply path and worth its own test, because the
+/// two renderers are separate code: fixing one and not the other would leave a
+/// caller reading reasoning when they ask for a whole reply and none when they
+/// stream the identical request.
+#[test]
+fn streamed_claude_thinking_reaches_the_caller() {
+    with_anthropic_key(async {
+        let chunks = stream_of(request("anthropic/claude-opus-5"), THINKING_THEN_TEXT).await;
+
+        let thinking: String = chunks
+            .iter()
+            .filter_map(|chunk| chunk["choices"][0]["delta"]["reasoning_content"].as_str())
+            .collect();
+        assert_eq!(
+            thinking, "counting",
+            "streamed thinking never reached the caller: {chunks:?}"
+        );
+
+        let answer: String = chunks
+            .iter()
+            .filter_map(|chunk| chunk["choices"][0]["delta"]["content"].as_str())
+            .collect();
+        assert_eq!(answer, "three", "{chunks:?}");
+    });
+}
 
 /// THE streamed blocker, closed. Anthropic numbers every content block, so a
 /// reply that opens with text puts its first tool call at index 1 — and

--- a/docs/concepts/model-routing.mdx
+++ b/docs/concepts/model-routing.mdx
@@ -114,6 +114,31 @@ Two differences from a chat-completions provider are worth knowing:
     translating it — so the refusal is Anthropic's, with Anthropic's message.
     Omit them for those models and steer with the prompt.
   </Accordion>
+  <Accordion title="Controls Anthropic cannot express are refused, not dropped" icon="ban">
+    Everywhere else warpllm forwards what you write and lets the provider judge
+    it. On a translated route the provider never receives the field, so it
+    cannot judge it — and a silent drop would answer a different request than
+    the one you sent. `n: 2` would come back as a single choice, which looks
+    exactly like a model that ignored you.
+
+    So these are refused with an `InvalidInput` error naming the field:
+
+    | Field | Refused when |
+    | --- | --- |
+    | `n` | greater than 1 |
+    | `frequency_penalty`, `presence_penalty` | non-zero |
+    | `logprobs` | `true` |
+    | `top_logprobs` | greater than 0 |
+    | `logit_bias` | non-empty |
+    | `seed` | any value |
+
+    The value your SDK fills in when you asked for nothing — `n: 1`, zero
+    penalties, `logprobs: false`, an empty bias map — is not refused, so an
+    ordinary request carrying them still routes.
+
+    `top_k` and `parallel_tool_calls` are NOT on this list: Anthropic has an
+    equivalent for each, so warpllm translates them instead of refusing them.
+  </Accordion>
   <Accordion title="Extended thinking cannot be combined with tool results" icon="brain">
     Anthropic requires the assistant turn holding a tool call to open with its
     own signed `thinking` block, and a chat-completions reply has nowhere to

--- a/docs/concepts/model-routing.mdx
+++ b/docs/concepts/model-routing.mdx
@@ -151,6 +151,11 @@ Two differences from a chat-completions provider are worth knowing:
     thinking off for a tool loop, or run the loop on a chat-completions
     provider. Tracked in
     [#23](https://github.com/warpllm/warpllm/issues/23).
+
+    The thinking itself does reach you, streamed or whole, under
+    `reasoning_content` — the same field DeepSeek and vLLM use. Its signature
+    does not, because chat completions has no field for one, and that missing
+    signature is exactly what the tool-result turn would need.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/concepts/model-routing.mdx
+++ b/docs/concepts/model-routing.mdx
@@ -114,12 +114,17 @@ Two differences from a chat-completions provider are worth knowing:
     translating it — so the refusal is Anthropic's, with Anthropic's message.
     Omit them for those models and steer with the prompt.
   </Accordion>
-  <Accordion title="Extended thinking with tools is not yet complete" icon="brain">
-    Anthropic requires its own signed `thinking` blocks to be echoed back
-    alongside your tool results, and a chat-completions reply has nowhere to
-    carry them — so a *multi-turn* tool conversation with thinking enabled is
-    rejected by Anthropic on the second turn. Single-turn tool calls and
-    thinking-without-tools both work. Tracked in
+  <Accordion title="Extended thinking cannot be combined with tool results" icon="brain">
+    Anthropic requires the assistant turn holding a tool call to open with its
+    own signed `thinking` block, and a chat-completions reply has nowhere to
+    carry one — so the request that sends your tool results back cannot be
+    built. warpllm refuses it with a `NotImplemented` error rather than letting
+    Anthropic answer it with a 400.
+
+    A single-turn tool call with thinking works, and so does
+    thinking-without-tools; it is sending the results back that stops. Turn
+    thinking off for a tool loop, or run the loop on a chat-completions
+    provider. Tracked in
     [#23](https://github.com/warpllm/warpllm/issues/23).
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
Three follow-ups from the codex review of #78, one per commit. The first is a
behavior regression that shipped in #78; the other two are gaps that shipped
with it.

### Refuse the tool-result turn, not the tool call that works

#78 keyed the thinking refusal on the PAIR — tools together with thinking —
which was wider than the thing it protected against. A single-turn tool call
with `reasoning_effort` goes out whole and comes back whole; refusing it took a
working case off the table to make a different case fail one turn sooner. It
also contradicted the docs shipped in the same PR, which promised that exact
case works.

What cannot be built is the request restating an assistant `tool_use` turn with
no thinking in front of it. That one is refused now, and only that one. Keyed on
the turn rather than on `request.tools`, because Anthropic checks the turn — a
caller who stops re-declaring their tools would otherwise slip through, and
there is a test for that.

### Document the controls Anthropic routes refuse

`reject_untranslatable` turned six fields from silent drops into errors in #78
with nothing written down about it. The accordion states the rule rather than
just the list, names why the "no opinion" values still pass, and says that
`top_k` and `parallel_tool_calls` are deliberately NOT on the list.

### Carry Claude's thinking to the caller

A caller who asked Claude to think got no thinking back — both renderers
dropped the block, and `may_read` denies them the bag it was retained in. The
reply was literally `{"content":"Hello there!","refusal":null,"role":"assistant"}`.
DeepSeek's reasoning has always reached callers through `reasoning_content`;
Claude's now does too, streamed and whole, each half tested failing-first.

Encrypted `redacted_thinking` is deliberately not rendered — opaque bytes meant
for replay, not for a field callers print. The signature is still dropped
because this protocol has no field for one, which is exactly what the
tool-result turn needs and why it stays refused.

### Still open

A model that thinks BY DEFAULT with no `reasoning_effort` set is not covered:
`thinks()` keys on what the caller asked for, so those still reach Anthropic's
raw 400. Closing it needs either a roster capability naming which models think
by default — the roster has no thinking data at all today — or a mapping of
Anthropic's specific error. Both need facts I could not verify, so neither is
guessed at here.

Gate: `cargo fmt --check`, `clippy --workspace --all-targets` (silent), and
`cargo test --workspace` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fk4LXaSuvsMenRbYbCpTMF
