### PR TITLE
Write down why a balanced client's candidates are the caller's

### DIFF
--- a/crates/warpllm/src/balanced.rs
+++ b/crates/warpllm/src/balanced.rs
@@ -4,6 +4,27 @@
 //! round-robin selection via [`Balancer`](crate::balancer::Balancer). The
 //! candidate set is fixed at construction; each call picks one candidate and
 //! delegates to the inner client's normal 4-gate validation.
+//!
+//! # The candidate list is the caller's, not the roster's
+//!
+//! An earlier draft put a `balance:` key in `specs.yaml`. It was refused: the
+//! roster ships with the crate, so such a key would state to every consumer
+//! that one model may be billed to another provider, and it would contradict
+//! [`ClientConfig::providers`](crate::ClientConfig), which exists so a client
+//! can withhold a vendor deliberately. Which models are interchangeable is an
+//! application judgement, so it lives where the application is.
+//!
+//! # Boundaries
+//!
+//! - **This is not failover.** One candidate is selected per request, and if
+//!   that provider fails the caller sees the failure. Retrying the next
+//!   candidate is issue #27, and the two are meant to compose — selection picks
+//!   the head of the chain — rather than to reorder candidates independently.
+//! - **State is per process.** Two warpllm instances balance independently, and
+//!   their combined split is only as even as the traffic split between them.
+//!   Anything better needs state shared across instances.
+//! - **No metrics yet.** The realized distribution is not observable from
+//!   outside, which is issue #29.
 
 use crate::balancer::Balancer;
 use crate::client::{ChatCompletionStream, Client};
@@ -56,7 +77,8 @@ impl<'a> BalancedClient<'a> {
     ///
     /// * `client` — The underlying client used for every request.
     /// * `candidates` — Non-empty list of `(model_str, weight)` pairs. Each
-    ///   `model_str` must exist in the registry. Weight determines the relative
+    ///   `model_str` must exist in the roster this client loaded, which may be a
+    ///   roster file of the caller's own. Weight determines the relative
     ///   proportion of requests routed to that candidate.
     ///
     /// # Errors


### PR DESCRIPTION
Follow-up to #80, which this replaces.

`BalancedClient`'s design reasoning lived only in a review thread on #71. 0.5.0's
release notes (#91) say what the client *does*; they do not say why a `balance:`
key in `specs.yaml` was refused, and they omit three of the boundaries the design
deliberately leaves open.

#80 tried to fix that in the changelog. That is the wrong home twice over: the
`[Unreleased]` section it targeted is now `## [0.5.0] - 2026-09-02`, so it would
be editing shipped release notes, and "why can't I declare this in my roster?" is
a question asked at the API rather than in a release section. So it goes in the
module's rustdoc instead.

**Added to `balanced.rs` module docs:**

- **The candidate list is the caller's, not the roster's.** The roster ships with
  the crate, so a `balance:` key would state to every consumer that one model may
  be billed to another provider, and it would contradict
  `ClientConfig::providers`, which exists so a client can withhold a vendor
  deliberately. Which models are interchangeable is an application judgement.
- **Boundaries** — this is not failover (#27, and the two are meant to compose:
  selection picks the head of the chain), state is per process, and the realized
  distribution is not yet observable (#29).

**Also:** `BalancedClient::new`'s own doc said a candidate must exist in "the
registry". Since #70 it is resolved against the roster the wrapped client loaded,
which may be a file of the caller's own.

"Rust only" is deliberately not carried over — it is in the 0.5.0 notes already,
and #79 would falsify it in the core crate's docs once it lands.

Docs only; no behaviour change. `scripts/test-all.sh` passes end to end, and
`cargo doc` introduces no new warnings.